### PR TITLE
M2: Implement Markdown collection

### DIFF
--- a/apps/astro-blog/astro.config.mjs
+++ b/apps/astro-blog/astro.config.mjs
@@ -2,10 +2,21 @@
 import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
+import { defineCollection, z } from 'astro:content';
+
+export const collections = {
+  blog: defineCollection({
+    schema: z.object({
+      title: z.string(),
+      publish: z.boolean().default(true),
+      date: z.date(),
+    }),
+  }),
+};
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://{preview_domain}',
-	output: 'static',
-	integrations: [mdx(), sitemap()],
+  site: 'https://{preview_domain}',
+  output: 'static',
+  integrations: [mdx(), sitemap()],
 });

--- a/apps/astro-blog/src/content.config.ts
+++ b/apps/astro-blog/src/content.config.ts
@@ -2,17 +2,19 @@ import { glob } from 'astro/loaders';
 import { defineCollection, z } from 'astro:content';
 
 const blog = defineCollection({
-	// Load Markdown and MDX files in the `src/content/blog/` directory.
-	loader: glob({ base: './src/content/blog', pattern: '**/*.{md,mdx}' }),
-	// Type-check frontmatter using a schema
-	schema: z.object({
-		title: z.string(),
-		description: z.string(),
-		// Transform string to Date object
-		pubDate: z.coerce.date(),
-		updatedDate: z.coerce.date().optional(),
-		heroImage: z.string().optional(),
-	}),
+  // Load Markdown and MDX files in the `src/content/blog/` directory.
+  loader: glob({ base: './src/content/blog', pattern: '**/*.{md,mdx}' }),
+  // Type-check frontmatter using a schema
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    /** Publish flag: only show when true */
+    publish: z.boolean().default(true),
+    // Transform string to Date object
+    pubDate: z.coerce.date(),
+    updatedDate: z.coerce.date().optional(),
+    heroImage: z.string().optional(),
+  }),
 });
 
 export const collections = { blog };


### PR DESCRIPTION
This PR adds the Markdown collection configuration for blog posts in `astro.config.mjs`, defining the `blog` collection schema with title, publish flag, and date fields.

Next steps:
- Filter `getCollection("blog")` to only include published posts in `src/pages/index.astro`.
- Implement layouts and styling (M3).
