### PR TITLE
fix: content schemaにpublishフィールドを追加

### DIFF
--- a/apps/astro-blog/src/content.config.ts
+++ b/apps/astro-blog/src/content.config.ts
@@ -12,6 +12,7 @@ const blog = defineCollection({
 		pubDate: z.coerce.date(),
 		updatedDate: z.coerce.date().optional(),
 		heroImage: z.string().optional(),
+		publish: z.boolean().default(true),
 	}),
 });
 


### PR DESCRIPTION
contentコレクションのschemaに`publish`フィールド（boolean, default: true）を追加しました。
これにより、トップページや/blogで記事一覧が正しく表示されます。