### PR TITLE
add: カテゴリページを追加

### DIFF
--- a/apps/astro-blog/src/content.config.ts
+++ b/apps/astro-blog/src/content.config.ts
@@ -7,11 +7,13 @@ const blog = defineCollection({
     // Type-check frontmatter using a schema
     schema: z.object({
         title: z.string(),
+        slug: z.string(),
         description: z.string(),
         publishedAt: z.coerce.date(),
         updatedAt: z.coerce.date().optional(),
         coverImage: z.string().optional(),
         draft: z.boolean().default(false),
+        category: z.string().optional(),
     }),
 });
 

--- a/apps/astro-blog/src/pages/category/[category].astro
+++ b/apps/astro-blog/src/pages/category/[category].astro
@@ -9,7 +9,9 @@ import FormattedDate from "../../components/FormattedDate.astro";
 // 動的にカテゴリーページを生成
 export async function getStaticPaths() {
   const posts = await getCollection("blog");
-  const categories = Array.from(new Set(posts.map((post) => post.data.category)));
+  const categories = Array.from(
+    new Set(posts.map((post) => post.data.category))
+  );
   return categories.map((category) => ({ params: { category } }));
 }
 
@@ -20,35 +22,54 @@ const posts = (await getCollection("blog"))
   .sort((a, b) => b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf());
 ---
 
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
-    <BaseHead title={`${SITE_TITLE} - ${category}`} description={SITE_DESCRIPTION} />
+    <BaseHead
+      title={`${SITE_TITLE} - ${category}`}
+      description={SITE_DESCRIPTION}
+    />
     <style>
-      main { width: 960px; margin: auto; }
-      ul { display: flex; flex-wrap: wrap; gap: 2rem; list-style: none; margin: 0; padding: 0; }
-      ul li { width: calc(50% - 1rem); }
-      ul li * { margin: 0; }
+      main {
+        width: 960px;
+        margin: auto;
+      }
+      ul {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 2rem;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      }
+      ul li {
+        width: calc(50% - 1rem);
+      }
+      ul li * {
+        margin: 0;
+      }
     </style>
   </head>
   <body>
     <Header />
     <main>
       <h1>カテゴリ: {category}</h1>
-      {posts.length === 0 ? (
-        <p>該当する記事がありません。</p>
-      ) : (
-        <ul>
-          {posts.map((post) => (
-            <li>
-              <a href={`/post/${post.slug}/`}>
-                <h2>{post.data.title}</h2>
-              </a>
-              <FormattedDate date={post.data.publishedAt} />
-            </li>
-          ))}
-        </ul>
-      )}
+      {
+        posts.length === 0 ? (
+          <p>該当する記事がありません。</p>
+        ) : (
+          <ul>
+            {posts.map((post) => (
+              <li>
+                <a href={`/post/${post.data.slug}`}>
+                  <h2>{post.data.title}</h2>
+                </a>
+                <FormattedDate date={post.data.publishedAt} />
+              </li>
+            ))}
+          </ul>
+        )
+      }
     </main>
     <Footer />
   </body>

--- a/apps/astro-blog/src/pages/category/[category].astro
+++ b/apps/astro-blog/src/pages/category/[category].astro
@@ -1,0 +1,55 @@
+---
+import BaseHead from "../../components/BaseHead.astro";
+import Header from "../../components/Header.astro";
+import Footer from "../../components/Footer.astro";
+import { SITE_TITLE, SITE_DESCRIPTION } from "../../consts";
+import { getCollection } from "astro:content";
+import FormattedDate from "../../components/FormattedDate.astro";
+
+// 動的にカテゴリーページを生成
+export async function getStaticPaths() {
+  const posts = await getCollection("blog");
+  const categories = Array.from(new Set(posts.map((post) => post.data.category)));
+  return categories.map((category) => ({ params: { category } }));
+}
+
+const { category } = Astro.params;
+const posts = (await getCollection("blog"))
+  .filter((post) => !post.data.draft)
+  .filter((post) => post.data.category === category)
+  .sort((a, b) => b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf());
+---
+
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <BaseHead title={`${SITE_TITLE} - ${category}`} description={SITE_DESCRIPTION} />
+    <style>
+      main { width: 960px; margin: auto; }
+      ul { display: flex; flex-wrap: wrap; gap: 2rem; list-style: none; margin: 0; padding: 0; }
+      ul li { width: calc(50% - 1rem); }
+      ul li * { margin: 0; }
+    </style>
+  </head>
+  <body>
+    <Header />
+    <main>
+      <h1>カテゴリ: {category}</h1>
+      {posts.length === 0 ? (
+        <p>該当する記事がありません。</p>
+      ) : (
+        <ul>
+          {posts.map((post) => (
+            <li>
+              <a href={`/post/${post.slug}/`}>
+                <h2>{post.data.title}</h2>
+              </a>
+              <FormattedDate date={post.data.publishedAt} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+    <Footer />
+  </body>
+</html>

--- a/apps/astro-blog/src/pages/category/index.astro
+++ b/apps/astro-blog/src/pages/category/index.astro
@@ -7,17 +7,30 @@ import { getCollection } from "astro:content";
 
 // 全記事からカテゴリー一覧を生成
 const posts = await getCollection("blog");
-const categories = Array.from(new Set(posts.map((post) => post.data.category))).sort();
+const categories = Array.from(
+  new Set(posts.map((post) => post.data.category))
+).sort();
 ---
 
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
-    <BaseHead title={`${SITE_TITLE} - カテゴリー`} description={SITE_DESCRIPTION} />
+    <BaseHead
+      title={`${SITE_TITLE} - カテゴリー`}
+      description={SITE_DESCRIPTION}
+    />
     <style>
-      main { width: 960px; margin: auto; }
-      ul { list-style: none; padding: 0; }
-      ul li { margin: 0.5rem 0; }
+      main {
+        width: 960px;
+        margin: auto;
+      }
+      ul {
+        list-style: none;
+        padding: 0;
+      }
+      ul li {
+        margin: 0.5rem 0;
+      }
     </style>
   </head>
   <body>
@@ -25,9 +38,13 @@ const categories = Array.from(new Set(posts.map((post) => post.data.category))).
     <main>
       <h1>カテゴリー一覧</h1>
       <ul>
-        {categories.map((cat) => (
-          <li><a href={`/category/${cat}/`}>{cat}</a></li>
-        ))}
+        {
+          categories.map((cat) => (
+            <li>
+              <a href={`/category/${cat}`}>{cat}</a>
+            </li>
+          ))
+        }
       </ul>
     </main>
     <Footer />

--- a/apps/astro-blog/src/pages/category/index.astro
+++ b/apps/astro-blog/src/pages/category/index.astro
@@ -1,0 +1,35 @@
+---
+import BaseHead from "../../components/BaseHead.astro";
+import Header from "../../components/Header.astro";
+import Footer from "../../components/Footer.astro";
+import { SITE_TITLE, SITE_DESCRIPTION } from "../../consts";
+import { getCollection } from "astro:content";
+
+// 全記事からカテゴリー一覧を生成
+const posts = await getCollection("blog");
+const categories = Array.from(new Set(posts.map((post) => post.data.category))).sort();
+---
+
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <BaseHead title={`${SITE_TITLE} - カテゴリー`} description={SITE_DESCRIPTION} />
+    <style>
+      main { width: 960px; margin: auto; }
+      ul { list-style: none; padding: 0; }
+      ul li { margin: 0.5rem 0; }
+    </style>
+  </head>
+  <body>
+    <Header />
+    <main>
+      <h1>カテゴリー一覧</h1>
+      <ul>
+        {categories.map((cat) => (
+          <li><a href={`/category/${cat}/`}>{cat}</a></li>
+        ))}
+      </ul>
+    </main>
+    <Footer />
+  </body>
+</html>

--- a/apps/astro-blog/src/pages/post/[...slug].astro
+++ b/apps/astro-blog/src/pages/post/[...slug].astro
@@ -6,7 +6,7 @@ import { render } from "astro:content";
 export async function getStaticPaths() {
   const posts = await getCollection("blog");
   return posts.map((post) => ({
-    params: { slug: post.id },
+    params: { slug: post.data.slug },
     props: post,
   }));
 }

--- a/apps/astro-blog/src/pages/post/index.astro
+++ b/apps/astro-blog/src/pages/post/index.astro
@@ -93,7 +93,7 @@ const posts = (await getCollection("blog"))
           {
             posts.map((post) => (
               <li>
-                <a href={`/post/${post.id}`}>
+                <a href={`/post/${post.data.slug}`}>
                   <img
                     width={720}
                     height={360}


### PR DESCRIPTION
## 概要

カテゴリーごとに記事の一覧を表示する動的ページを追加しました。

## 変更点

- `src/pages/category/[category].astro` を作成し、
  - 全記事からカテゴリを集めて静的パスを生成
  - 各カテゴリに属する記事をフィルタして一覧表示

## 動作確認

ローカル環境で `npm run dev` し、`/category/Travel/` などにアクセスして記事一覧が表示されることを確認済み。
