### PR TITLE
fix: use post.data.slug for post links

### DIFF
--- a/apps/astro-blog/src/pages/category/[category].astro
+++ b/apps/astro-blog/src/pages/category/[category].astro
@@ -1,0 +1,54 @@
+import BaseHead from "../../components/BaseHead.astro";
+import Header from "../../components/Header.astro";
+import Footer from "../../components/Footer.astro";
+import { SITE_TITLE, SITE_DESCRIPTION } from "../../consts";
+import { getCollection } from "astro:content";
+import FormattedDate from "../../components/FormattedDate.astro";
+
+// 動的にカテゴリーページを生成
+export async function getStaticPaths() {
+  const posts = await getCollection("blog");
+  const categories = Array.from(new Set(posts.map((post) => post.data.category)));
+  return categories.map((category) => ({ params: { category } }));
+}
+
+const { category } = Astro.params;
+const posts = (await getCollection("blog"))
+  .filter((post) => !post.data.draft)
+  .filter((post) => post.data.category === category)
+  .sort((a, b) => b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf());
+---
+
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <BaseHead title={`${SITE_TITLE} - ${category}`} description={SITE_DESCRIPTION} />
+    <style>
+      main { width: 960px; margin: auto; }
+      ul { display: flex; flex-wrap: wrap; gap: 2rem; list-style: none; margin: 0; padding: 0; }
+      ul li { width: calc(50% - 1rem); }
+      ul li * { margin: 0; }
+    </style>
+  </head>
+  <body>
+    <Header />
+    <main>
+      <h1>カテゴリ: {category}</h1>
+      {posts.length === 0 ? (
+        <p>該当する記事がありません。</p>
+      ) : (
+        <ul>
+          {posts.map((post) => (
+            <li>
+              <a href={`/post/${post.data.slug}/`}>
+                <h2>{post.data.title}</h2>
+              </a>
+              <FormattedDate date={post.data.publishedAt} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+    <Footer />
+  </body>
+</html>


### PR DESCRIPTION
Fixed incorrect slug reference. Use `post.data.slug` instead of `post.slug` in category listing to resolve TypeScript error.