### PR TITLE
fix: use buildUrl from cloudinary-utils in remark-cloudinary-images

### DIFF
--- a/packages/remark-cloudinary-images/src/index.ts
+++ b/packages/remark-cloudinary-images/src/index.ts
@@ -1,21 +1,9 @@
 import { visit } from "unist-util-visit";
+import { buildUrl } from "@estrivault/cloudinary-utils";
 
 const widths = [480, 768, 1024, 1200];
 const aspectRatio = 16 / 9; // 必要に応じて別途指定可能
 const mode = "fill"; // or "fit"
-
-function buildUrl(cloudName: string, publicId: string, options: { w?: number; h?: number; mode?: string }) {
-  const { w, h, mode } = options;
-  const transform = [
-    mode === "fit" ? "c_fit" : "c_fill",
-    w ? `w_${w}` : null,
-    h ? `h_${h}` : null,
-    "f_auto",
-    "q_auto",
-  ].filter(Boolean).join(",");
-
-  return `https://res.cloudinary.com/${cloudName}/image/upload/${transform}/${publicId}`;
-}
 
 function buildSrcSet(cloudName: string, publicId: string) {
   return widths
@@ -61,7 +49,6 @@ export default function remarkCloudinaryImages() {
           />
         `.trim(),
       };
-      console.log("✅ Replaced:", replacement.value);
 
       parent.children[i] = replacement;
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,13 +39,23 @@ importers:
       '@cloudinary/url-gen':
         specifier: ^1.21.0
         version: 1.21.0
+    devDependencies:
+      tsup:
+        specifier: ^8.0.0
+        version: 8.4.0(postcss@8.5.3)(typescript@5.8.3)
 
   packages/remark-cloudinary-images:
     dependencies:
+      '@estrivault/cloudinary-utils':
+        specifier: workspace:*
+        version: link:../cloudinary-utils
       unist-util-visit:
         specifier: ^5.0.0
         version: 5.0.0
     devDependencies:
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/node':
         specifier: ^22.14.1
         version: 22.14.1


### PR DESCRIPTION
`remark-cloudinary-images` で独自実装していた `buildUrl` を `@estrivault/cloudinary-utils` のものに置き換えました。🚀