### PR TITLE
fix: import buildUrl from package in CldImage.astro

### DIFF
--- a/apps/astro-blog/src/components/CldImage.astro
+++ b/apps/astro-blog/src/components/CldImage.astro
@@ -1,5 +1,5 @@
 ---
-import { buildUrl } from "../../../../packages/cloudinary-utils/index.ts";
+import { buildUrl } from "@estrivault/cloudinary-utils";
 // cloudNameを環境変数から取得してbuildUrlに渡す
 const cloudName = import.meta.env.PUBLIC_CLOUDINARY_CLOUD_NAME;
 if (!cloudName) {


### PR DESCRIPTION
`CldImage.astro` の `buildUrl` インポートをパッケージ `@estrivault/cloudinary-utils` から行うよう修正しました。