### PR TITLE
fix: add cloudinary-utils to workspace dependencies for astro-blog

### DIFF
--- a/apps/astro-blog/package.json
+++ b/apps/astro-blog/package.json
@@ -15,6 +15,7 @@
     "@astrojs/rss": "^4.0.11",
     "@astrojs/sitemap": "^3.3.0",
     "astro": "^5.7.4",
-    "@estrivault/remark-cloudinary-images": "workspace:*"
+    "@estrivault/remark-cloudinary-images": "workspace:*",
+    "@estrivault/cloudinary-utils": "workspace:*"
   }
 }


### PR DESCRIPTION
## Changes

- Added `@estrivault/cloudinary-utils` as a workspace dependency in `apps/astro-blog/package.json` to resolve module not found error.