### PR TITLE
fix: configure TS paths to resolve cloudinary-utils in remark plugin

### DIFF
--- a/packages/remark-cloudinary-images/tsconfig.json
+++ b/packages/remark-cloudinary-images/tsconfig.json
@@ -5,7 +5,11 @@
     "target": "ES2020",
     "moduleResolution": "node",
     "declaration": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "baseUrl": ".",
+    "paths": {
+      "@estrivault/cloudinary-utils": ["../cloudinary-utils/dist"]
+    }
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Issue
`remark-cloudinary-images` plugin is importing `@estrivault/cloudinary-utils` but TS can't resolve it in plugin source.

## Changes
- Added `baseUrl` and `paths` in `packages/remark-cloudinary-images/tsconfig.json` to map `@estrivault/cloudinary-utils` to its build output.
