### PR TITLE
fix: cloudinary-utils参照エラーの解消とREADMEの最新化

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # estrivault-blog-app
 
+## セットアップ・依存関係の解決
+
+本リポジトリはpnpm workspaceを利用しています。新しい依存パッケージを追加した場合や、パッケージ間の参照エラーが発生した場合は、必ず以下を実行してください。
+
+```bash
+pnpm install
+```
+
+## パッケージのビルド
+
+TypeScriptで記述されたパッケージ（例: `@estrivault/cloudinary-utils`）を利用する場合、利用前にビルドが必要です。
+
+```bash
+pnpm --filter @estrivault/cloudinary-utils run build
+```
+
 ## ブログの起動
 
 ルートディレクトリで以下のコマンドを実行し、`apps/astro-blog` の開発サーバを起動します:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@astrojs/sitemap':
         specifier: ^3.3.0
         version: 3.3.0
+      '@estrivault/cloudinary-utils':
+        specifier: workspace:*
+        version: link:../../packages/cloudinary-utils
       '@estrivault/remark-cloudinary-images':
         specifier: workspace:*
         version: link:../../packages/remark-cloudinary-images


### PR DESCRIPTION
pnpmワークスペース依存解決・cloudinary-utils参照エラーの解消手順をREADMEに追記し、参照エラーが発生しないよう運用手順を明確化しました。

- pnpm installの実行手順をREADMEに明記
- @estrivault/cloudinary-utilsのビルド手順をREADMEに明記
- 依存解決・ビルド後にastro-blogが正常起動することを確認

ご確認をお願いいたします。