### PR TITLE
feat: content-processor API関数の実装（Closes #41）

### DIFF
--- a/packages/content-processor/src/index.ts
+++ b/packages/content-processor/src/index.ts
@@ -1,3 +1,80 @@
 // content-processor public API エントリポイント
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { markdownToHtmlPipeline } from './pipeline';
+import { PostMeta, PostHTML, ProcessorOptions, ListOptions } from './types';
 
-export {};
+/**
+ * Markdown文字列を解析してPostHTMLを返す
+ */
+export async function loadFromString(
+  markdown: string,
+  options?: ProcessorOptions
+): Promise<PostHTML> {
+  return markdownToHtmlPipeline(markdown, options);
+}
+
+/**
+ * ファイルパスからMarkdownを読み込み、PostHTMLを返す
+ */
+export async function loadFromFile(
+  filePath: string,
+  options?: ProcessorOptions
+): Promise<PostHTML> {
+  const markdown = await fs.readFile(filePath, 'utf-8');
+  return markdownToHtmlPipeline(markdown, options);
+}
+
+/**
+ * ディレクトリ内の全記事のPostMeta配列を返す
+ */
+export async function getAllPosts(
+  dir: string,
+  options?: ListOptions & ProcessorOptions
+): Promise<PostMeta[]> {
+  const files = await fs.readdir(dir);
+  const mdFiles = files.filter(f => f.endsWith('.md'));
+  const posts: PostMeta[] = [];
+  for (const file of mdFiles) {
+    const fullPath = path.join(dir, file);
+    try {
+      const { meta } = await loadFromFile(fullPath, options);
+      if (!meta.draft) posts.push(meta);
+    } catch (e) {
+      // 読み込み失敗はスキップ
+    }
+  }
+  // ソート
+  if (options?.sort === 'title') {
+    posts.sort((a, b) => a.title.localeCompare(b.title));
+  } else {
+    posts.sort((a, b) => (b.date || '').localeCompare(a.date || ''));
+  }
+  // ページネーション
+  const page = options?.page || 1;
+  const perPage = options?.perPage || 20;
+  return posts.slice((page - 1) * perPage, page * perPage);
+}
+
+/**
+ * slug指定で記事を取得
+ */
+export async function getPostBySlug(
+  dir: string,
+  slug: string,
+  options?: ProcessorOptions
+): Promise<PostHTML | null> {
+  const filePath = path.join(dir, slug + '.md');
+  try {
+    return await loadFromFile(filePath, options);
+  } catch {
+    return null;
+  }
+}
+
+export {
+  PostMeta,
+  PostHTML,
+  ProcessorOptions,
+  ListOptions,
+};

--- a/packages/content-processor/src/pipeline.ts
+++ b/packages/content-processor/src/pipeline.ts
@@ -1,3 +1,51 @@
-// Markdown→HTML変換パイプライン実装予定
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkFrontmatter from 'remark-frontmatter';
+import remarkRehype from 'remark-rehype';
+import rehypeStringify from 'rehype-stringify';
+import rehypeSanitize from 'rehype-sanitize';
+import matter from 'gray-matter';
+import { PostMeta, PostHTML, ProcessorOptions } from './types';
 
-export {};
+/**
+ * Markdown→HTML変換パイプライン
+ * @param markdown Markdownテキスト
+ * @param options 追加オプション
+ * @returns HTML・meta情報
+ */
+export async function markdownToHtmlPipeline(
+  markdown: string,
+  options?: ProcessorOptions
+): Promise<PostHTML> {
+  // Front-matter抽出
+  const { content, data } = matter(markdown);
+
+  // unifiedパイプライン構築
+  const file = await unified()
+    .use(remarkParse)
+    .use(remarkFrontmatter, ['yaml', 'toml'])
+    .use(remarkRehype)
+    .use(rehypeSanitize, options?.sanitizeSchema)
+    .use(rehypeStringify)
+    .process(content);
+
+  // meta生成（PostMeta型に合わせて必要な項目を抽出・補完）
+  const meta: PostMeta = {
+    slug: data.slug || '',
+    title: data.title || '',
+    description: data.description || '',
+    date: data.date || '',
+    publishedAt: data.publishedAt || '',
+    category: data.category || '',
+    tags: data.tags || [],
+    coverImage: data.coverImage,
+    draft: data.draft,
+    readingTime: Math.ceil(content.split(/\s+/).length / 400), // 400wpm想定
+  };
+
+  return {
+    meta,
+    html: String(file),
+  };
+}
+


### PR DESCRIPTION
content-processorのpublic API関数（loadFromString/loadFromFile/getAllPosts/getPostBySlug）を実装しました。
- pipeline.tsにMarkdown→HTML変換パイプラインを実装
- index.tsにAPI関数4種を実装
- PostMeta, PostHTML型に準拠
- I/O・エラー処理・オプション対応

Closes #41