### PR TITLE
fix: content-processorをESMビルド・適切なexportsに修正（Vite/SvelteKit解決不可対策）

### DIFF
--- a/packages/content-processor/package.json
+++ b/packages/content-processor/package.json
@@ -5,11 +5,14 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    ".": "./dist/index.js"
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
   },
   "files": ["dist"],
   "scripts": {
-    "build": "tsup src/index.ts --dts",
+    "build": "tsup src/index.ts --dts --format esm",
     "test": "vitest"
   },
   "dependencies": {


### PR DESCRIPTION
## 概要
Vite/SvelteKitで @estrivault/content-processor をimportした際に解決できない問題を修正しました。

- tsup出力をESM形式（.js）に統一
- package.jsonのmain/exports/typesを dist/index.js, dist/index.d.ts に揃え
- buildスクリプトも --format esm へ修正

Closes #（該当Issue番号を後で追記してください）

---
ご確認よろしくお願いいたします。