### PR TITLE
fix: getAllPostsのglobパターンを配列渡しに修正（.md/.mdx両対応）

### DIFF
--- a/apps/svelte-blog/src/lib/posts.ts
+++ b/apps/svelte-blog/src/lib/posts.ts
@@ -36,7 +36,10 @@ export async function getPosts(options?: {
     };
 
     // 記事一覧を取得
-    const allPosts = await getAllPosts(CONTENT_DIR, {
+    const allPosts = await getAllPosts([
+      `${CONTENT_DIR}/*.md`,
+      `${CONTENT_DIR}/*.mdx`
+    ], {
       page,
       perPage,
       sort,
@@ -44,7 +47,7 @@ export async function getPosts(options?: {
     });
 
     // Postインターフェースに変換
-    const posts = allPosts.posts.map((post) => ({
+    const posts = allPosts.map((post) => ({
       ...post,
       // coverImageをthumbnailとしてマッピング
       thumbnail: post.coverImage || ''
@@ -52,10 +55,10 @@ export async function getPosts(options?: {
 
     return {
       posts,
-      total: allPosts.total,
-      page: allPosts.page,
-      perPage: allPosts.perPage,
-      totalPages: allPosts.totalPages
+      total: posts.length,
+      page,
+      perPage,
+      totalPages: Math.ceil(posts.length / perPage)
     };
   } catch (err) {
     console.error('Failed to get posts:', err);
@@ -113,7 +116,10 @@ export async function getPostsByCategory(
     };
 
     // 記事一覧を取得
-    const allPosts = await getAllPosts(CONTENT_DIR, {
+    const allPosts = await getAllPosts([
+      `${CONTENT_DIR}/*.md`,
+      `${CONTENT_DIR}/*.mdx`
+    ], {
       page,
       perPage,
       sort: 'date',
@@ -121,7 +127,7 @@ export async function getPostsByCategory(
     });
 
     // Postインターフェースに変換
-    const posts = allPosts.posts.map((post) => ({
+    const posts = allPosts.map((post) => ({
       ...post,
       // coverImageをthumbnailとしてマッピング
       thumbnail: post.coverImage || ''
@@ -129,10 +135,10 @@ export async function getPostsByCategory(
 
     return {
       posts,
-      total: allPosts.total,
-      page: allPosts.page,
-      perPage: allPosts.perPage,
-      totalPages: allPosts.totalPages
+      total: posts.length,
+      page,
+      perPage,
+      totalPages: Math.ceil(posts.length / perPage)
     };
   } catch (err) {
     console.error(`Failed to get posts for category ${category}:`, err);


### PR DESCRIPTION
## 概要

- 記事が表示されない問題の根本原因だった、`getAllPosts` のglobパターン指定を修正しました。
- これまで文字列で渡していたものを、配列（['${CONTENT_DIR}/*.md', '${CONTENT_DIR}/*.mdx']）で渡すよう統一。
- これにより、.md/.mdx両方の記事が正しく取得・表示されます。

## 関連Issue
Closes #

## 詳細
- getPosts, getPostsByCategory 両方修正。
- 動作確認済み（記事一覧・カテゴリページともに正しく表示）。

ご確認よろしくお願いします。