### PR TITLE
fix: Post型とアプリ全体をthumbnailからcoverImageに統一

### DIFF
--- a/apps/svelte-blog/src/components/PostCard/PostCard.svelte
+++ b/apps/svelte-blog/src/components/PostCard/PostCard.svelte
@@ -15,7 +15,7 @@
 	<!-- サムネイル -->
 	<div class="relative w-full overflow-hidden pt-[56.25%]">
 		<img
-			src={post.thumbnail}
+			src={post.coverImage}
 			alt={post.title}
 			class="absolute inset-0 h-full w-full object-cover"
 		/>

--- a/apps/svelte-blog/src/lib/posts.ts
+++ b/apps/svelte-blog/src/lib/posts.ts
@@ -48,9 +48,7 @@ export async function getPosts(options?: {
 
     // Postインターフェースに変換
     const posts = allPosts.map((post) => ({
-      ...post,
-      // coverImageをthumbnailとしてマッピング
-      thumbnail: post.coverImage || ''
+      ...post
     }));
 
     return {
@@ -128,9 +126,7 @@ export async function getPostsByCategory(
 
     // Postインターフェースに変換
     const posts = allPosts.map((post) => ({
-      ...post,
-      // coverImageをthumbnailとしてマッピング
-      thumbnail: post.coverImage || ''
+      ...post
     }));
 
     return {

--- a/apps/svelte-blog/src/lib/types.ts
+++ b/apps/svelte-blog/src/lib/types.ts
@@ -3,7 +3,7 @@ export interface Post {
     slug: string;
     date: string;
     description: string;
-    thumbnail: string;
+    coverImage?: string;
     category: string;
     tags: string[];
 }

--- a/apps/svelte-blog/src/routes/category/[category]/[page]/+page.svelte
+++ b/apps/svelte-blog/src/routes/category/[category]/[page]/+page.svelte
@@ -8,7 +8,7 @@
 			date: '2025-04-21',
 			description:
 				'主要テック企業の好決算を受けてS&P500とNasdaqが上昇。FOMCを前に投資家心理も改善。',
-			thumbnail: 'https://res.cloudinary.com/damonge/image/upload/Hero/kotohira-konpirasan',
+			coverImage: 'https://res.cloudinary.com/damonge/image/upload/Hero/kotohira-konpirasan',
 			category: 'Stocks',
 			tags: ['NASDAQ', 'Tech', 'FOMC']
 		},
@@ -18,7 +18,7 @@
 			date: '2025-04-21',
 			description:
 				'主要テック企業の好決算を受けてS&P500とNasdaqが上昇。FOMCを前に投資家心理も改善。',
-			thumbnail: 'https://res.cloudinary.com/damonge/image/upload/Hero/kotohira-konpirasan',
+			coverImage: 'https://res.cloudinary.com/damonge/image/upload/Hero/kotohira-konpirasan',
 			category: 'Stocks',
 			tags: ['NASDAQ', 'Tech', 'FOMC']
 		},
@@ -28,7 +28,7 @@
 			date: '2025-04-21',
 			description:
 				'主要テック企業の好決算を受けてS&P500とNasdaqが上昇。FOMCを前に投資家心理も改善。',
-			thumbnail: 'https://res.cloudinary.com/damonge/image/upload/Hero/kotohira-konpirasan',
+			coverImage: 'https://res.cloudinary.com/damonge/image/upload/Hero/kotohira-konpirasan',
 			category: 'Stocks',
 			tags: ['NASDAQ', 'Tech', 'FOMC']
 		},
@@ -38,7 +38,7 @@
 			date: '2025-04-21',
 			description:
 				'主要テック企業の好決算を受けてS&P500とNasdaqが上昇。FOMCを前に投資家心理も改善。',
-			thumbnail: 'https://res.cloudinary.com/damonge/image/upload/Hero/kotohira-konpirasan',
+			coverImage: 'https://res.cloudinary.com/damonge/image/upload/Hero/kotohira-konpirasan',
 			category: 'Stocks',
 			tags: ['NASDAQ', 'Tech', 'FOMC']
 		},
@@ -48,7 +48,7 @@
 			date: '2025-04-21',
 			description:
 				'主要テック企業の好決算を受けてS&P500とNasdaqが上昇。FOMCを前に投資家心理も改善。',
-			thumbnail: 'https://res.cloudinary.com/damonge/image/upload/Hero/kotohira-konpirasan',
+			coverImage: 'https://res.cloudinary.com/damonge/image/upload/Hero/kotohira-konpirasan',
 			category: 'Stocks',
 			tags: ['NASDAQ', 'Tech', 'FOMC']
 		},
@@ -58,7 +58,7 @@
 			date: '2025-04-21',
 			description:
 				'主要テック企業の好決算を受けてS&P500とNasdaqが上昇。FOMCを前に投資家心理も改善。',
-			thumbnail: 'https://res.cloudinary.com/damonge/image/upload/Hero/kotohira-konpirasan',
+			coverImage: 'https://res.cloudinary.com/damonge/image/upload/Hero/kotohira-konpirasan',
 			category: 'Stocks',
 			tags: ['NASDAQ', 'Tech', 'FOMC']
 		},
@@ -68,7 +68,7 @@
 			date: '2025-04-21',
 			description:
 				'主要テック企業の好決算を受けてS&P500とNasdaqが上昇。FOMCを前に投資家心理も改善。',
-			thumbnail: 'https://res.cloudinary.com/damonge/image/upload/Hero/kotohira-konpirasan',
+			coverImage: 'https://res.cloudinary.com/damonge/image/upload/Hero/kotohira-konpirasan',
 			category: 'Stocks',
 			tags: ['NASDAQ', 'Tech', 'FOMC']
 		},
@@ -78,7 +78,7 @@
 			date: '2025-04-21',
 			description:
 				'主要テック企業の好決算を受けてS&P500とNasdaqが上昇。FOMCを前に投資家心理も改善。',
-			thumbnail: 'https://res.cloudinary.com/damonge/image/upload/Hero/kotohira-konpirasan',
+			coverImage: 'https://res.cloudinary.com/damonge/image/upload/Hero/kotohira-konpirasan',
 			category: 'Stocks',
 			tags: ['NASDAQ', 'Tech', 'FOMC']
 		}


### PR DESCRIPTION
## 概要

Post型およびアプリケーション全体で画像プロパティ名を`thumbnail`から`coverImage`に統一しました。

### 主な対応内容
- Post型の`thumbnail`プロパティを`coverImage`にリネーム
- PostCardコンポーネント等、`thumbnail`を参照していた箇所を`coverImage`に修正
- getPosts/getPostsByCategory等での`thumbnail`マッピング処理を削除し、冗長性排除
- ダミーデータも`coverImage`に修正

これにより、content-processor側のAPI設計とアプリ側の型が一致し、冗長な変換処理が不要になりました。

Closes #（該当Issue番号を記載してください）