### PR TITLE
fix: dateプロパティを廃止しpublishedAtに統一・型エラー解消

### DIFF
--- a/apps/svelte-blog/src/components/PostCard/PostCard.svelte
+++ b/apps/svelte-blog/src/components/PostCard/PostCard.svelte
@@ -28,7 +28,7 @@
 			<h2 class="text-lg font-semibold text-gray-900 transition-colors group-hover:text-blue-600">
 				{post.title}
 			</h2>
-			<p class="text-sm text-gray-500">{post.date}</p>
+			<p class="text-sm text-gray-500">{post.publishedAt}</p>
 			<p class="line-clamp-3 text-sm text-gray-700">{post.description}</p>
 		</div>
 

--- a/apps/svelte-blog/src/lib/index.ts
+++ b/apps/svelte-blog/src/lib/index.ts
@@ -1,1 +1,3 @@
 // place files you want to import through the `$lib` alias in this folder.
+export * from './types';
+export * from './posts';

--- a/apps/svelte-blog/src/lib/posts.ts
+++ b/apps/svelte-blog/src/lib/posts.ts
@@ -10,7 +10,7 @@ const CONTENT_DIR = path.resolve(process.cwd(), '../../content/blog');
 export async function getPosts(options?: {
   page?: number;
   perPage?: number;
-  sort?: 'date' | 'title';
+  sort?: 'publishedAt' | 'title';
   includeDrafts?: boolean;
 }): Promise<{
   posts: PostMeta[];
@@ -85,6 +85,7 @@ export async function getPostsByCategory(
   options?: {
     page?: number;
     perPage?: number;
+    sort?: 'publishedAt' | 'title';
     includeDrafts?: boolean;
   }
 ): Promise<{
@@ -120,7 +121,7 @@ export async function getPostsByCategory(
     ], {
       page,
       perPage,
-      sort: 'date',
+      sort: 'publishedAt',
       filter
     });
 

--- a/apps/svelte-blog/src/lib/types.ts
+++ b/apps/svelte-blog/src/lib/types.ts
@@ -1,9 +1,9 @@
 export interface Post {
     title: string;
     slug: string;
-    date: string;
     description: string;
     coverImage?: string;
     category: string;
     tags: string[];
+    publishedAt: string;
 }

--- a/apps/svelte-blog/src/routes/+page.server.ts
+++ b/apps/svelte-blog/src/routes/+page.server.ts
@@ -1,4 +1,4 @@
-import { getPosts } from '$lib/posts';
+import { getPosts } from '$lib';
 import type { PageServerLoad } from './$types';
 import { POSTS_PER_PAGE } from '../constants';
 
@@ -11,7 +11,7 @@ export const load = (async ({ url }) => {
   const { posts, total, totalPages } = await getPosts({
     page,
     perPage,
-    sort: 'date',
+    sort: 'publishedAt',
     includeDrafts: false
   });
 

--- a/apps/svelte-blog/src/routes/+page.svelte
+++ b/apps/svelte-blog/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import PostCard from '../components/PostCard/PostCard.svelte';
-	import type { PageData } from './$types';
 	import Pagination from '../components/Pagination/Pagination.svelte';
+	import type { PageData } from './$types';
 
 	export let data: PageData;
 	const { posts, pagination } = data;

--- a/apps/svelte-blog/src/routes/category/[category]/[page]/+page.svelte
+++ b/apps/svelte-blog/src/routes/category/[category]/[page]/+page.svelte
@@ -5,7 +5,7 @@
 		{
 			title: '米国株式市場、テック主導で続伸',
 			slug: 'us-market-tech-rally',
-			date: '2025-04-21',
+			publishedAt: '2025-04-21',
 			description:
 				'主要テック企業の好決算を受けてS&P500とNasdaqが上昇。FOMCを前に投資家心理も改善。',
 			coverImage: 'https://res.cloudinary.com/damonge/image/upload/Hero/kotohira-konpirasan',
@@ -15,7 +15,7 @@
 		{
 			title: '米国株式市場、テック主導で続伸',
 			slug: 'us-market-tech-rally',
-			date: '2025-04-21',
+			publishedAt: '2025-04-21',
 			description:
 				'主要テック企業の好決算を受けてS&P500とNasdaqが上昇。FOMCを前に投資家心理も改善。',
 			coverImage: 'https://res.cloudinary.com/damonge/image/upload/Hero/kotohira-konpirasan',
@@ -25,7 +25,7 @@
 		{
 			title: '米国株式市場、テック主導で続伸',
 			slug: 'us-market-tech-rally',
-			date: '2025-04-21',
+			publishedAt: '2025-04-21',
 			description:
 				'主要テック企業の好決算を受けてS&P500とNasdaqが上昇。FOMCを前に投資家心理も改善。',
 			coverImage: 'https://res.cloudinary.com/damonge/image/upload/Hero/kotohira-konpirasan',
@@ -35,7 +35,7 @@
 		{
 			title: '米国株式市場、テック主導で続伸',
 			slug: 'us-market-tech-rally',
-			date: '2025-04-21',
+			publishedAt: '2025-04-21',
 			description:
 				'主要テック企業の好決算を受けてS&P500とNasdaqが上昇。FOMCを前に投資家心理も改善。',
 			coverImage: 'https://res.cloudinary.com/damonge/image/upload/Hero/kotohira-konpirasan',
@@ -45,7 +45,7 @@
 		{
 			title: '米国株式市場、テック主導で続伸',
 			slug: 'us-market-tech-rally',
-			date: '2025-04-21',
+			publishedAt: '2025-04-21',
 			description:
 				'主要テック企業の好決算を受けてS&P500とNasdaqが上昇。FOMCを前に投資家心理も改善。',
 			coverImage: 'https://res.cloudinary.com/damonge/image/upload/Hero/kotohira-konpirasan',
@@ -55,7 +55,7 @@
 		{
 			title: '米国株式市場、テック主導で続伸',
 			slug: 'us-market-tech-rally',
-			date: '2025-04-21',
+			publishedAt: '2025-04-21',
 			description:
 				'主要テック企業の好決算を受けてS&P500とNasdaqが上昇。FOMCを前に投資家心理も改善。',
 			coverImage: 'https://res.cloudinary.com/damonge/image/upload/Hero/kotohira-konpirasan',
@@ -65,7 +65,7 @@
 		{
 			title: '米国株式市場、テック主導で続伸',
 			slug: 'us-market-tech-rally',
-			date: '2025-04-21',
+			publishedAt: '2025-04-21',
 			description:
 				'主要テック企業の好決算を受けてS&P500とNasdaqが上昇。FOMCを前に投資家心理も改善。',
 			coverImage: 'https://res.cloudinary.com/damonge/image/upload/Hero/kotohira-konpirasan',
@@ -75,7 +75,7 @@
 		{
 			title: '米国株式市場、テック主導で続伸',
 			slug: 'us-market-tech-rally',
-			date: '2025-04-21',
+			publishedAt: '2025-04-21',
 			description:
 				'主要テック企業の好決算を受けてS&P500とNasdaqが上昇。FOMCを前に投資家心理も改善。',
 			coverImage: 'https://res.cloudinary.com/damonge/image/upload/Hero/kotohira-konpirasan',

--- a/apps/svelte-blog/src/routes/post/[slug]/+page.server.ts
+++ b/apps/svelte-blog/src/routes/post/[slug]/+page.server.ts
@@ -1,9 +1,9 @@
-import { getPost } from '$lib/posts';
+import { getPost } from '$lib';
 import type { PageServerLoad } from './$types';
 
 export const load = (async ({ params }) => {
   const { slug } = params;
-  
+
   if (!slug) {
     throw new Error('Post not found');
   }
@@ -11,7 +11,7 @@ export const load = (async ({ params }) => {
   try {
     // 記事データを取得
     const post = await getPost(slug);
-    
+
     return {
       post
     };

--- a/apps/svelte-blog/src/routes/post/[slug]/+page.svelte
+++ b/apps/svelte-blog/src/routes/post/[slug]/+page.svelte
@@ -21,7 +21,7 @@
 	<!-- 記事ヘッダー -->
 	<header class="mb-8">
 		<div class="flex items-center gap-2 text-sm text-gray-600 mb-2">
-			<span>{formatDate(meta.date)}</span>
+			<span>{formatDate(meta.publishedAt)}</span>
 			<span>•</span>
 			<span>{meta.readingTime} min read</span>
 		</div>

--- a/packages/content-processor/src/index.ts
+++ b/packages/content-processor/src/index.ts
@@ -32,8 +32,8 @@ export async function loadFromString(
     if (!data.title) {
       throw new FrontMatterError('Front-matterにtitleが含まれていません');
     }
-    if (!data.date) {
-      throw new FrontMatterError('Front-matterにdateが含まれていません');
+    if (!data.publishedAt) {
+      throw new FrontMatterError('Front-matterにpublishedAtが含まれていません');
     }
 
     // 読了時間の計算
@@ -48,7 +48,6 @@ export async function loadFromString(
       slug: data.slug || '',
       title: data.title,
       description: data.description || '',
-      date: data.date,
       publishedAt: data.publishedAt || data.date,
       category: data.category || '',
       tags: data.tags || [],
@@ -139,7 +138,7 @@ export async function getAllPosts(
   const { 
     page = 1, 
     perPage = 20, 
-    sort = 'date',
+    sort = 'publishedAt',
     filter = () => true
   } = opts;
   
@@ -178,8 +177,8 @@ export async function getAllPosts(
   
   // ソート
   const sortedPosts = [...validPosts].sort((a, b) => {
-    if (sort === 'date') {
-      return new Date(b.date).getTime() - new Date(a.date).getTime();
+    if (sort === 'publishedAt') {
+      return new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime();
     } else if (sort === 'title') {
       return a.title.localeCompare(b.title);
     }

--- a/packages/content-processor/src/types.ts
+++ b/packages/content-processor/src/types.ts
@@ -7,8 +7,6 @@ export interface PostMeta {
   title: string;
   /** 記事説明 */
   description: string;
-  /** ISO 8601 日付文字列 */
-  date: string;
   /** 公開日時（ISO8601）*/
   publishedAt: string;
   /** カテゴリ名 */
@@ -45,7 +43,7 @@ export interface ProcessorOptions {
 export interface ListOptions {
   page?: number; // ページ番号（1起点）
   perPage?: number; // デフォルト20
-  sort?: "date" | "title"; // ソートキー
+  sort?: "publishedAt" | "title"; // ソートキー
   filter?: (post: PostMeta) => boolean; // フィルタ関数
 }
 


### PR DESCRIPTION
## 概要

- frontmatter, 型定義, データ取得処理等でdateプロパティを廃止し、publishedAtプロパティに統一しました。
- これにより、frontmatterにdateがなくてもエラーにならず、publishedAtのみで運用できます。
- 型定義・sort指定・UI表示もすべてpublishedAtに統一し、関連する型エラーも解消済みです。

### 主な対応内容
- Post, PostMeta型からdateを削除しpublishedAtのみに
- content-processor, svelte-blog両方のデータ取得・ソート・UI表示をpublishedAtに統一
- ダミーデータやサンプルもpublishedAtに修正
- 型エラー・lintエラーも解消

Closes #（該当Issue番号を記載してください）

---
ローカルで動作確認済みです。レビュー・マージをお願いします。