### PR TITLE
fix: カテゴリー・タグ絞り込みの正規化＆複数タグ対応

### DIFF
--- a/packages/content-processor/src/loaders/directory-loader.ts
+++ b/packages/content-processor/src/loaders/directory-loader.ts
@@ -52,11 +52,21 @@ export async function getPosts(options: PostListOptions = {}) {
 
     // category/tag/filter条件で絞り込み
     let filteredPosts = posts;
+    // 絞り込み用正規化関数
+    const normalize = (str: string) => str.trim().toLowerCase();
+
     if (options.category) {
-      filteredPosts = filteredPosts.filter((post) => post.category === options.category);
+      filteredPosts = filteredPosts.filter(
+        (post) => normalize(post.category) === normalize(options.category!)
+      );
     }
     if (options.tag) {
-      filteredPosts = filteredPosts.filter((post) => post.tags.includes(options.tag!));
+      const tags = Array.isArray(options.tag) ? options.tag : [options.tag];
+      filteredPosts = filteredPosts.filter(
+        (post) => tags.some(
+          (tag) => post.tags.some((t) => normalize(t) === normalize(tag))
+        )
+      );
     }
     if (options.filter) {
       filteredPosts = filteredPosts.filter(options.filter);


### PR DESCRIPTION
カテゴリー・タグによる記事絞り込み時に、表記揺れ（大文字小文字・空白など）を吸収する正規化処理を追加し、タグは複数指定（配列）にも対応しました。

- normalize関数で比較時にtrim/toLowerCaseを適用
- タグは単一・複数どちらも対応

Closes #<該当Issue番号>

---

この修正により、カテゴリーやタグの指定がより柔軟かつ正確になります。ご確認ください。