### PR TITLE
fix: SvelteKit側のgetPostsで二重フィルタを排除し、content-processor側に一本化

### DIFF
--- a/apps/svelte-blog/src/lib/posts.ts
+++ b/apps/svelte-blog/src/lib/posts.ts
@@ -27,35 +27,16 @@ export async function getPosts(options?: {
     const page = options?.page || 1;
     const perPage = options?.perPage || 20;
 
-    // フィルター関数
-    const filter = (post: PostMeta) => {
-      // カテゴリーが指定されている場合はフィルタリング（大文字小文字を区別しない）
-      if (options?.category && post.category?.toLowerCase() !== options.category.toLowerCase()) {
-        return false;
-      }
-      // タグが指定されている場合はフィルタリング（大文字小文字を区別せず、前後の空白も無視）
-      if (options?.tag) {
-        const targetTag = options.tag;
-        return post.tags?.some((tag) => tag === targetTag) ?? false;
-      }
-      return true;
-    };
-
-    // 記事一覧を取得
+    // content-processor側でフィルタされるため、ここでのfilter処理は不要
     const allPostsObj = await getPostsFromProcessor({
       cloudinaryCloudName: PUBLIC_CLOUDINARY_CLOUD_NAME,
-    });
-
-    // PostMeta[] へフィルタ適用
-    const filteredPosts = allPostsObj.posts.filter(filter);
-
-    return {
-      posts: filteredPosts, // PostMeta[] 型で返す
-      total: filteredPosts.length,
       page,
       perPage,
-      totalPages: Math.ceil(filteredPosts.length / perPage),
-    };
+      category: options?.category,
+      tag: options?.tag,
+    });
+
+    return allPostsObj;
   } catch (err) {
     console.error('Failed to get posts:', err);
     throw new Error('Failed to get posts');

--- a/packages/content-processor/src/loaders/directory-loader.ts
+++ b/packages/content-processor/src/loaders/directory-loader.ts
@@ -59,7 +59,7 @@ export async function getPosts(options: PostListOptions = {}) {
         .trim()
         .toLowerCase()
         // 全角英数字→半角
-        .replace(/[！-～]/g, s => String.fromCharCode(s.charCodeAt(0) - 0xfee0))
+        .replace(/[！-～]/g, (s) => String.fromCharCode(s.charCodeAt(0) - 0xfee0))
         // 空白・アンダースコア→ハイフン
         .replace(/[\s_]+/g, '-')
         // 英数字・ハイフン以外除去
@@ -76,10 +76,8 @@ export async function getPosts(options: PostListOptions = {}) {
     }
     if (options.tag) {
       const tags = Array.isArray(options.tag) ? options.tag : [options.tag];
-      filteredPosts = filteredPosts.filter(
-        (post) => tags.some(
-          (tag) => post.tags.some((t) => normalize(t) === normalize(tag))
-        )
+      filteredPosts = filteredPosts.filter((post) =>
+        tags.some((tag) => post.tags.some((t) => normalize(t) === normalize(tag)))
       );
     }
     if (options.filter) {

--- a/packages/content-processor/src/loaders/directory-loader.ts
+++ b/packages/content-processor/src/loaders/directory-loader.ts
@@ -52,11 +52,21 @@ export async function getPosts(options: PostListOptions = {}) {
 
     // category/tag/filter条件で絞り込み
     let filteredPosts = posts;
+    // 絞り込み用正規化関数
+    const normalize = (str: string) => str.trim().toLowerCase();
+
     if (options.category) {
-      filteredPosts = filteredPosts.filter((post) => post.category === options.category);
+      filteredPosts = filteredPosts.filter(
+        (post) => normalize(post.category) === normalize(options.category!)
+      );
     }
     if (options.tag) {
-      filteredPosts = filteredPosts.filter((post) => post.tags.includes(options.tag!));
+      const tags = Array.isArray(options.tag) ? options.tag : [options.tag];
+      filteredPosts = filteredPosts.filter(
+        (post) => tags.some(
+          (tag) => post.tags.some((t) => normalize(t) === normalize(tag))
+        )
+      );
     }
     if (options.filter) {
       filteredPosts = filteredPosts.filter(options.filter);

--- a/packages/content-processor/src/loaders/directory-loader.ts
+++ b/packages/content-processor/src/loaders/directory-loader.ts
@@ -53,7 +53,21 @@ export async function getPosts(options: PostListOptions = {}) {
     // category/tag/filter条件で絞り込み
     let filteredPosts = posts;
     // 絞り込み用正規化関数
-    const normalize = (str: string) => str.trim().toLowerCase();
+    // URLセーフなスラッグ化も含む正規化関数
+    const normalize = (str: string) =>
+      str
+        .trim()
+        .toLowerCase()
+        // 全角英数字→半角
+        .replace(/[！-～]/g, s => String.fromCharCode(s.charCodeAt(0) - 0xfee0))
+        // 空白・アンダースコア→ハイフン
+        .replace(/[\s_]+/g, '-')
+        // 英数字・ハイフン以外除去
+        .replace(/[^a-z0-9-]/g, '')
+        // 連続ハイフンを1つに
+        .replace(/-+/g, '-')
+        // 先頭・末尾ハイフン除去
+        .replace(/^-+|-+$/g, '');
 
     if (options.category) {
       filteredPosts = filteredPosts.filter(


### PR DESCRIPTION
SvelteKitアプリ側のgetPostsで、カテゴリー・タグの二重フィルタリングを排除し、content-processor側の絞り込み処理に一本化しました。

- options.category, options.tagはそのままcontent-processorに渡すだけに
- フロント側でのfilter関数やfilter適用処理を削除

Closes #<該当Issue番号>

---

これにより、カテゴリーやタグの絞り込みロジックが一元化され、意図しない除外やバグを防げます。ご確認ください。