### PR TITLE
fix: 404

### DIFF
--- a/apps/svelte-blog/src/routes/llms-full.txt/+server.ts
+++ b/apps/svelte-blog/src/routes/llms-full.txt/+server.ts
@@ -1,6 +1,8 @@
 import { getPosts } from '$lib/posts';
 import { SITE_URL, SOCIAL_LINK_X, SOCIAL_LINK_GITHUB } from '$constants';
 
+export const prerender = true;
+
 export async function GET() {
   const { posts } = await getPosts({ perPage: 1000 });
   

--- a/apps/svelte-blog/src/routes/llms.txt/+server.ts
+++ b/apps/svelte-blog/src/routes/llms.txt/+server.ts
@@ -1,6 +1,8 @@
 import { getPosts } from '$lib/posts';
 import { SITE_URL, SOCIAL_LINK_X, SOCIAL_LINK_GITHUB } from '$constants';
 
+export const prerender = true;
+
 export async function GET() {
   const { posts } = await getPosts({ perPage: 1000 });
   

--- a/apps/svelte-blog/src/routes/sitemap.xml/+server.ts
+++ b/apps/svelte-blog/src/routes/sitemap.xml/+server.ts
@@ -1,8 +1,48 @@
 import { getPosts } from '$lib/posts';
 import { SITE_URL } from '$constants';
+import { POSTS_PER_PAGE } from '$constants';
+import type { PostMeta } from '@estrivault/content-processor';
+
+export const prerender = true;
 
 export async function GET() {
   const { posts } = await getPosts({ perPage: 1000 });
+  
+  // Generate category URLs (lowercase for consistency)
+  const categories = [...new Set(posts.map(post => post.category))];
+  const categoryUrls = [];
+  for (const category of categories) {
+    const categoryPosts = await getPosts({ category });
+    const totalPages = Math.ceil(categoryPosts.total / POSTS_PER_PAGE);
+    
+    for (let page = 1; page <= totalPages; page++) {
+      categoryUrls.push(`<url>
+    <loc>${SITE_URL.replace(/\/$/, '')}/category/${category.toLowerCase()}/${page}</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>`);
+    }
+  }
+  
+  // Generate tag URLs (lowercase for consistency)
+  const tags = new Set<string>();
+  posts.forEach((post: PostMeta) => {
+    post.tags?.forEach((tag: string) => tags.add(tag));
+  });
+  
+  const tagUrls = [];
+  for (const tag of tags) {
+    const tagPosts = await getPosts({ tag });
+    const totalPages = Math.ceil(tagPosts.total / POSTS_PER_PAGE);
+    
+    for (let page = 1; page <= totalPages; page++) {
+      tagUrls.push(`<url>
+    <loc>${SITE_URL.replace(/\/$/, '')}/tag/${tag.toLowerCase()}/${page}</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>`);
+    }
+  }
   
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
@@ -27,6 +67,8 @@ export async function GET() {
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>`).join('')}
+  ${categoryUrls.join('')}
+  ${tagUrls.join('')}
 </urlset>`.trim();
 
   return new Response(sitemap, {

--- a/apps/svelte-blog/src/routes/tag/[tag]/[page]/+page.server.ts
+++ b/apps/svelte-blog/src/routes/tag/[tag]/[page]/+page.server.ts
@@ -7,12 +7,32 @@ export const load = (async ({ params }) => {
   const { tag, page: pageParam } = params;
   const currentPage = pageParam ? parseInt(pageParam, 10) : 1;
 
-  // getPostsのオプションでタグフィルタリングとページネーションを実行
-  const result = await getPosts({
+  // First try exact match, then try case-insensitive match
+  let result = await getPosts({
     tag,
     page: currentPage,
     perPage: POSTS_PER_PAGE,
   });
+
+  // If no results with exact match, try finding the correct case
+  if (result.posts.length === 0) {
+    const allPosts = await getPosts();
+    const allTags = new Set<string>();
+    
+    allPosts.posts.forEach((post) => {
+      post.tags?.forEach((t: string) => allTags.add(t));
+    });
+    
+    const correctTag = Array.from(allTags).find(t => t.toLowerCase() === tag.toLowerCase());
+    
+    if (correctTag) {
+      result = await getPosts({
+        tag: correctTag,
+        page: currentPage,
+        perPage: POSTS_PER_PAGE,
+      });
+    }
+  }
 
   return {
     posts: result.posts,

--- a/apps/svelte-blog/svelte.config.js
+++ b/apps/svelte-blog/svelte.config.js
@@ -4,9 +4,7 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 const config = {
   preprocess: vitePreprocess(),
   kit: {
-    adapter: adapter({
-      fallback: 'index.html',
-    }),
+    adapter: adapter(),
     alias: {
       $components: './src/components',
       $lib: './src/lib',


### PR DESCRIPTION
 1. /llms.txtの404エラー
    - svelte.config.jsからfallback: 'index.html'を削除
    - llms.txt/+server.tsとllms-full.txt/+server.tsにprerender = trueを追加
  2. /category/stocks/1の404エラー
    - URL生成を小文字に統一（category.toLowerCase()）
    - 大文字小文字を区別しないルーティング処理を追加
  3. sitemap.xmlの改善
    - カテゴリ・タグページのURLを追加
    - prerender = trueを追加
    - 小文字URLで統一
  4. タグページの堅牢性向上
    - 大文字小文字を区別しない検索ロジックを追加