### PR TITLE
fix: TypeScriptエラーとCloudflareルーティング制限を解決

### DIFF
--- a/apps/svelte-blog/static/_routes.json
+++ b/apps/svelte-blog/static/_routes.json
@@ -2,11 +2,5 @@
   "version": 1,
   "description": "Cloudflare Pages routing configuration for optimal static/dynamic separation",
   "include": ["/api/*", "/category/*/*", "/tag/*/*"],
-  "exclude": [
-    "/post/*",
-    "/*.[js|css|svg|png|jpg|jpeg|webp|ico|txt|xml]",
-    "/category/*/1",
-    "/tag/*/1",
-    "/"
-  ]
+  "exclude": ["/post/*", "/category/*/1", "/tag/*/1", "/"]
 }

--- a/apps/svelte-blog/vite.config.ts
+++ b/apps/svelte-blog/vite.config.ts
@@ -56,6 +56,9 @@ export default defineConfig({
             }
             return 'vendor';
           }
+
+          // デフォルト: undefined を返す（自動チャンキング）
+          return undefined;
         },
       },
     },


### PR DESCRIPTION
- vite.config.tsのmanualChunks関数で未定義戻り値エラーを修正
- _routes.jsonから静的アセット除外ルールを削除して制限回避
- 448個の余分なexcludeルールによる警告を解決
- TypeScriptチェックが正常に通るように修正

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **その他**
  * ルーティング設定の除外パターンから静的アセットファイルの拡張子が削除されました。
  * Viteの設定で、チャンク分割処理のデフォルト動作が明示的に記述されました（動作に変更はありません）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->