### PR TITLE
fix: Svelte template syntax for Schema.org JSON-LD script tag

### DIFF
--- a/apps/svelte-blog/src/routes/post/[slug]/+page.svelte
+++ b/apps/svelte-blog/src/routes/post/[slug]/+page.svelte
@@ -134,7 +134,7 @@
 
   <!-- Schema.org JSON-LD -->
   <script type="application/ld+json">
-    {JSON.stringify(schemaData)}
+{@html JSON.stringify(schemaData)}
   </script>
 
   <!-- Google AdSense -->


### PR DESCRIPTION
Invalid JSON template literal was causing parsing errors. Changed from incorrect `{JSON.stringify(schemaData)}` syntax to proper Svelte `@html` directive to output valid JSON-LD structured data.

🤖 Generated with [Claude Code](https://claude.ai/code)