### PR TITLE
Feat/directive info

### DIFF
--- a/apps/svelte-blog/src/components/Post/PostBody.svelte
+++ b/apps/svelte-blog/src/components/Post/PostBody.svelte
@@ -4,6 +4,7 @@
   import postStyles from './style/post.module.scss';
   import twitterEmbedStyles from './style/twitter-embed.module.scss';
   import syntaxHighlightStyles from './style/syntax-highlight.module.scss';
+  import directiveBoxesStyles from './style/directive-boxes.module.scss';
   import ImageLightbox from './ImageLightbox.svelte';
   import { onMount } from 'svelte';
 
@@ -15,11 +16,13 @@
   // コードブロックがある場合のみシンタックスハイライトスタイルを適用
   // Twitterの埋め込みがある場合のみTwitterスタイルを適用
   // Amazonの埋め込みがある場合のみAmazonスタイルを適用
+  // ディレクティブボックスがある場合のみディレクティブボックススタイルを適用
   $: proseClasses = [
     postStyles.prose,
     post.hasTwitterEmbeds ? twitterEmbedStyles.prose : '',
     post.hasAmazonEmbeds ? amazonCardStyles.prose : '',
     post.hasCodeBlocks ? syntaxHighlightStyles.prose : '',
+    post.hasDirectiveBoxes ? directiveBoxesStyles.prose : '',
     'prose max-w-none',
   ]
     .filter(Boolean)

--- a/apps/svelte-blog/src/components/Post/style/directive-boxes.module.scss
+++ b/apps/svelte-blog/src/components/Post/style/directive-boxes.module.scss
@@ -1,0 +1,56 @@
+// 非常にシンプルなディレクティブボックススタイル
+.prose {
+  :global(.directive-box) {
+    margin: 1rem 0;
+    padding: 1rem 1rem 1rem 3rem;
+    border-radius: 0.25rem;
+    background-color: var(--directive-bg);
+    position: relative;
+
+    // 左上にアイコンを配置（本文と上部余白を合わせる）
+    &::before {
+      position: absolute;
+      left: 1rem;
+      top: 1.5rem;
+      font-size: 1.1rem;
+      opacity: 0.6;
+      line-height: 1;
+    }
+
+    // タイトルとコンテンツのマージン調整（上下に余白）
+    p:first-child {
+      margin-top: 0.25rem;
+    }
+
+    p:last-child {
+      margin-bottom: 0.25rem;
+    }
+  }
+
+  // Info directive - 薄い緑背景
+  :global(.directive-info) {
+    --directive-bg: #f0fdf4;
+
+    &::before {
+      content: 'ⓘ';
+    }
+  }
+
+  // Alert directive - 薄い赤背景
+  :global(.directive-alert) {
+    --directive-bg: #fef2f2;
+
+    &::before {
+      content: '×';
+    }
+  }
+
+  // Warn directive - 薄い黄色背景
+  :global(.directive-warn) {
+    --directive-bg: #fefce8;
+
+    &::before {
+      content: '⚠';
+    }
+  }
+}

--- a/content/blog/tech/2025-07-08-ClaudeCodeにHooksを導入.md
+++ b/content/blog/tech/2025-07-08-ClaudeCodeにHooksを導入.md
@@ -12,7 +12,7 @@ AnthropicはClaude Codeに**Hooks**という機能拡張を行っています。
 
 https://docs.anthropic.com/en/docs/claude-code/hooks
 
-:::note alert
+:::warn
 便利な機能ではありますが、常に特定のシェルコマンドを実行するということはユーザー自身が内容を分かっていないHooksを設定することは非常に危険ということでもあります。Hooksに設定するコマンドは自分自身で意図を理解した内容に留めましょう。
 :::
 

--- a/packages/content-processor/src/pipeline.ts
+++ b/packages/content-processor/src/pipeline.ts
@@ -15,6 +15,7 @@ import { remarkTwitterEmbed } from './plugins/embeds/twitter-embed';
 import { remarkCommonLinkEmbed } from './plugins/embeds/common-link-embed';
 import { remarkGithubEmbed } from './plugins/embeds/github-embed';
 import { remarkAmazonEmbed } from './plugins/embeds/amazon-embed';
+import { remarkDirectiveBoxes } from './plugins/embeds/directive-boxes';
 import type { ProcessorOptions } from './types';
 
 /**
@@ -41,6 +42,7 @@ function createBasePipeline(
     .use(remarkCommonLinkEmbed)
     .use(remarkGithubEmbed)
     .use(remarkAmazonEmbed)
+    .use(remarkDirectiveBoxes)
 
     // HTML 変換
     .use(remarkRehype, { allowDangerousHtml: true })

--- a/packages/content-processor/src/plugins/embeds/directive-boxes.ts
+++ b/packages/content-processor/src/plugins/embeds/directive-boxes.ts
@@ -1,0 +1,68 @@
+import { visit } from 'unist-util-visit';
+import type { Plugin } from 'unified';
+import type { Root } from 'mdast';
+
+/**
+ * :::info, :::alert, :::warn ディレクティブを HTML 要素に変換する remark プラグイン
+ */
+export const remarkDirectiveBoxes: Plugin<[], Root, Root> = () => {
+  return (tree) => {
+    visit(tree, function (node) {
+      if (node.type !== 'containerDirective') return;
+
+      const directiveType = node.name;
+      if (!['info', 'alert', 'warn'].includes(directiveType)) return;
+
+      const data = node.data || (node.data = {});
+      const attributes = node.attributes || {};
+      const title = attributes.title;
+
+      // ベースクラス名を設定
+      const baseClass = `directive-box directive-${directiveType}`;
+
+      const displayTitle = title;
+
+      // HTML 要素として変換
+      data.hName = 'div';
+      data.hProperties = {
+        className: [baseClass],
+        'data-directive-type': directiveType,
+      };
+
+      // 子要素を再構築
+      const originalChildren = node.children || [];
+      const newChildren: typeof originalChildren = [];
+
+      // カスタムタイトルがある場合のみタイトルを追加
+      if (displayTitle) {
+        newChildren.push({
+          type: 'paragraph',
+          children: [
+            {
+              type: 'strong',
+              children: [
+                {
+                  type: 'text',
+                  value: displayTitle,
+                },
+              ],
+            },
+          ],
+          data: {
+            hProperties: {
+              className: ['directive-title'],
+            },
+          },
+        });
+      }
+
+      // 元のコンテンツをそのまま追加
+      newChildren.push(...originalChildren);
+
+      // アイコンはCSSの::before疑似要素で表示
+
+      // 新しい子要素を設定
+      node.children = newChildren;
+    });
+  };
+};

--- a/packages/content-processor/src/processor.ts
+++ b/packages/content-processor/src/processor.ts
@@ -5,6 +5,7 @@ import { createPipeline } from './pipeline';
 import { hasCodeBlocks } from './utils/code-detector';
 import { hasTwitterEmbeds } from './utils/twitter-detector';
 import { hasAmazonEmbeds } from './utils/amazon-detector';
+import { hasDirectiveBoxes } from './utils/directive-boxes-detector';
 import { unified } from 'unified';
 import remarkParse from 'remark-parse';
 import remarkDirective from 'remark-directive';
@@ -81,6 +82,7 @@ export async function processMarkdown(
     const enableSyntaxHighlight = hasCodeBlocks(parseResult);
     const enableTwitterEmbeds = hasTwitterEmbeds(parseResult);
     const enableAmazonEmbeds = hasAmazonEmbeds(parseResult);
+    const enableDirectiveBoxes = hasDirectiveBoxes(parseResult);
 
     // パイプラインでHTMLに変換
     const pipeline = createPipeline(options, enableSyntaxHighlight);
@@ -162,6 +164,7 @@ export async function processMarkdown(
       hasCodeBlocks: enableSyntaxHighlight,
       hasTwitterEmbeds: enableTwitterEmbeds,
       hasAmazonEmbeds: enableAmazonEmbeds,
+      hasDirectiveBoxes: enableDirectiveBoxes,
     };
   } catch (error) {
     if (error instanceof FrontMatterError || error instanceof MarkdownParseError) {

--- a/packages/content-processor/src/types.ts
+++ b/packages/content-processor/src/types.ts
@@ -42,4 +42,5 @@ export interface PostHTML {
   hasCodeBlocks?: boolean;
   hasTwitterEmbeds?: boolean;
   hasAmazonEmbeds?: boolean;
+  hasDirectiveBoxes?: boolean;
 }

--- a/packages/content-processor/src/utils/directive-boxes-detector.ts
+++ b/packages/content-processor/src/utils/directive-boxes-detector.ts
@@ -1,0 +1,25 @@
+import { visit, EXIT } from 'unist-util-visit';
+import type { Root } from 'mdast';
+
+/**
+ * Markdownの構文木にディレクティブボックス（info, alert, warn）が含まれているかを検出する
+ * @param tree Markdownの構文木
+ * @returns ディレクティブボックスが含まれている場合はtrue
+ */
+export function hasDirectiveBoxes(tree: Root): boolean {
+  let hasDirectives = false;
+
+  visit(tree, ['containerDirective', 'leafDirective', 'textDirective'], (node) => {
+    if (
+      'name' in node &&
+      typeof node.name === 'string' &&
+      ['info', 'alert', 'warn'].includes(node.name)
+    ) {
+      hasDirectives = true;
+      return EXIT; // ASTのトラバーサルを中断
+    }
+    return undefined;
+  });
+
+  return hasDirectives;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Markdown記事内で「info」「alert」「warn」タイプのディレクティブボックス（情報・警告・注意ボックス）の表示に対応しました。各ボックスは専用のアイコンと背景色で強調されます。
* **スタイル**
  * ディレクティブボックス用の新しいスタイルが追加され、記事内で一貫したデザインで表示されるようになりました。
* **ドキュメント**
  * 記事内の注意書きの一部がより強調される「warn」スタイルに変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->