### PR TITLE
Refresh blog landing and article design

### DIFF
--- a/apps/astro-blog/src/app.css
+++ b/apps/astro-blog/src/app.css
@@ -1,64 +1,849 @@
 @import 'tailwindcss';
 @plugin '@tailwindcss/typography';
 
+:root {
+  --bg: #e8e1d7;
+  --surface: rgba(248, 244, 237, 0.88);
+  --surface-strong: #f6f2ea;
+  --text: #17191b;
+  --text-soft: #474a4e;
+  --text-muted: #6d7278;
+  --line: rgba(23, 25, 27, 0.12);
+  --line-strong: rgba(23, 25, 27, 0.28);
+  --accent: #c6ff3b;
+  --accent-strong: #9fd11c;
+  --accent-warm: #ff8e3c;
+  --shadow-soft: 0 18px 48px rgba(24, 27, 33, 0.08);
+  --radius-panel: 30px 12px 30px 12px;
+  --radius-card: 24px 10px 24px 10px;
+}
+
 html {
   scrollbar-gutter: stable;
   overflow-y: scroll;
+  background: var(--bg);
+}
+
+body {
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top left, rgba(198, 255, 59, 0.2), transparent 28%),
+    radial-gradient(circle at 100% 15%, rgba(255, 142, 60, 0.12), transparent 18%),
+    linear-gradient(180deg, #f5efe6 0%, #ece4d9 48%, #e3dbd1 100%);
+  color: var(--text);
+  font-family: 'Noto Sans JP', 'Hiragino Sans', 'Yu Gothic', 'Meiryo', sans-serif;
+  line-height: 1.65;
+}
+
+a {
+  transition:
+    color 180ms ease,
+    border-color 180ms ease,
+    background-color 180ms ease,
+    opacity 180ms ease,
+    transform 180ms ease;
+}
+
+img {
+  display: block;
+}
+
+::selection {
+  background: rgba(198, 255, 59, 0.38);
+  color: var(--text);
 }
 
 ::-webkit-scrollbar {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
 }
 
 ::-webkit-scrollbar-track {
-  background: #f1f1f1;
+  background: rgba(255, 255, 255, 0.45);
 }
 
 ::-webkit-scrollbar-thumb {
-  background-color: #c1c1c1;
-  border-radius: 8px;
-  border: 4px solid transparent;
+  border: 3px solid transparent;
+  border-radius: 999px;
+  background: rgba(23, 25, 27, 0.18);
   background-clip: content-box;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background-color: #a8a8a8;
+  background: rgba(23, 25, 27, 0.28);
+  background-clip: content-box;
+}
+
+.site-shell {
+  position: relative;
+}
+
+.site-frame {
+  position: relative;
+  z-index: 1;
+}
+
+.site-chrome {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.site-chrome__grid,
+.site-chrome__beam,
+.site-chrome__grain {
+  position: absolute;
+  inset: 0;
+}
+
+.site-chrome__grid {
+  background-image:
+    linear-gradient(rgba(17, 19, 22, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(17, 19, 22, 0.035) 1px, transparent 1px);
+  background-size: 28px 28px;
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.68), transparent 88%);
+}
+
+.site-chrome__beam--one {
+  background: linear-gradient(
+    135deg,
+    transparent 24%,
+    rgba(255, 255, 255, 0.45) 24.3%,
+    transparent 24.8%
+  );
+  transform: translate(-24%, -18%) scale(1.2);
+  opacity: 0.5;
+}
+
+.site-chrome__beam--two {
+  inset: auto -20% -20% auto;
+  width: 70vw;
+  height: 70vw;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(198, 255, 59, 0.14), transparent 62%);
+}
+
+.site-chrome__grain {
+  opacity: 0.1;
+  background-image:
+    radial-gradient(rgba(17, 19, 22, 0.8) 0.6px, transparent 0.6px),
+    radial-gradient(rgba(255, 255, 255, 0.8) 0.6px, transparent 0.6px);
+  background-position:
+    0 0,
+    10px 10px;
+  background-size: 20px 20px;
+}
+
+.site-main {
+  margin: 0 auto;
+  width: min(1240px, calc(100% - 1.5rem));
+  padding: 0 0 3rem;
+}
+
+.section-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-family: 'Space Grotesk', 'Noto Sans JP', sans-serif;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.section-label::before {
+  content: '';
+  width: 2.1rem;
+  height: 1px;
+  background: var(--line-strong);
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  padding: 1rem 0 0;
+}
+
+.site-header__inner,
+.site-footer__inner,
+.home-hero,
+.home-overview__panel,
+.article-header__panel,
+.article-header__figure,
+.toc-panel,
+.article-body__inner,
+.article-endcap,
+.list-page__header,
+.empty-state {
+  border: 1px solid var(--line);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.7), var(--surface));
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(14px);
+}
+
+.site-header__inner {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem 1.2rem;
+  border-radius: var(--radius-panel);
+}
+
+.site-brand {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  color: var(--text);
+  text-decoration: none;
+}
+
+.site-brand__eyebrow {
+  font-family: 'Space Grotesk', 'Noto Sans JP', sans-serif;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.site-brand__title {
+  font-family: 'Space Grotesk', 'Noto Sans JP', sans-serif;
+  font-size: clamp(1.5rem, 2vw, 1.85rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+}
+
+.site-brand__note {
+  font-size: 0.92rem;
+  color: var(--text-soft);
+}
+
+.site-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.site-nav__link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.85rem;
+  padding: 0.78rem 1rem;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  color: var(--text-soft);
+  text-decoration: none;
+}
+
+.site-nav__link:hover,
+.site-nav__link.is-active {
+  border-color: var(--line);
+  background: rgba(255, 255, 255, 0.58);
+  color: var(--text);
+}
+
+.site-nav__link.is-active::before {
+  content: '';
+  width: 0.58rem;
+  height: 0.58rem;
+  margin-right: 0.55rem;
+  border-radius: 999px;
+  background: var(--accent);
+  box-shadow: 0 0 0 4px rgba(198, 255, 59, 0.22);
+}
+
+.site-footer {
+  padding: 1.25rem 0 2.5rem;
+}
+
+.site-footer__inner {
+  display: grid;
+  gap: 1.25rem;
+  padding: 1.5rem;
+  border-radius: var(--radius-panel);
+}
+
+.site-footer__title {
+  margin-top: 0.65rem;
+  font-family: 'Space Grotesk', 'Noto Sans JP', sans-serif;
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.site-footer__copy {
+  max-width: 42rem;
+  margin-top: 0.5rem;
+  color: var(--text-soft);
+}
+
+.site-footer__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.site-footer__links a {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.7rem 1rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--text);
+  text-decoration: none;
+}
+
+.site-footer__links a:hover {
+  border-color: var(--line-strong);
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.site-footer__meta {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.home-page {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.home-hero {
+  display: grid;
+  gap: 1.4rem;
+  padding: 1.4rem;
+  border-radius: var(--radius-panel);
+}
+
+.home-hero__copy {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.home-hero__title {
+  font-family: 'Space Grotesk', 'Noto Sans JP', sans-serif;
+  font-size: clamp(2.6rem, 6vw, 4.9rem);
+  font-weight: 700;
+  line-height: 0.95;
+  letter-spacing: -0.06em;
+  text-wrap: balance;
+}
+
+.home-hero__lede {
+  max-width: 44rem;
+  font-size: 1.02rem;
+  color: var(--text-soft);
+}
+
+.home-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.hero-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 3rem;
+  padding: 0.85rem 1.2rem;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  color: var(--text);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.hero-action:hover {
+  transform: translateY(-1px);
+}
+
+.hero-action--primary {
+  border-color: rgba(159, 209, 28, 0.55);
+  background: var(--accent);
+}
+
+.hero-action--secondary {
+  background: rgba(255, 255, 255, 0.54);
+}
+
+.home-hero__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+}
+
+.home-hero__stats div,
+.article-header__stats div {
+  padding: 0.95rem 1rem;
+  border: 1px solid var(--line);
+  border-radius: 20px 8px 20px 8px;
+  background: rgba(255, 255, 255, 0.52);
+}
+
+.home-hero__stats dt,
+.article-header__stats dt,
+.list-page__eyebrow {
+  font-family: 'Space Grotesk', 'Noto Sans JP', sans-serif;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.home-hero__stats dd,
+.article-header__stats dd {
+  margin-top: 0.35rem;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.home-hero__feature {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.home-hero__feature-note {
+  color: var(--text-muted);
+  font-size: 0.92rem;
+}
+
+.home-overview {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.home-overview__panel {
+  padding: 1.35rem;
+  border-radius: var(--radius-panel);
+}
+
+.home-overview__title,
+.home-section__title,
+.list-page__title,
+.toc-panel__title {
+  margin-top: 0.85rem;
+  font-family: 'Space Grotesk', 'Noto Sans JP', sans-serif;
+  font-size: clamp(1.9rem, 3vw, 2.5rem);
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+.home-overview__copy,
+.home-section__copy,
+.list-page__description,
+.article-endcap__copy {
+  margin-top: 0.65rem;
+  max-width: 40rem;
+  color: var(--text-soft);
+}
+
+.home-overview__links {
+  display: grid;
+  gap: 0.8rem;
+  margin-top: 1rem;
+}
+
+.home-overview__links a {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.95rem 1rem;
+  border: 1px solid var(--line);
+  border-radius: 18px 8px 18px 8px;
+  background: rgba(255, 255, 255, 0.56);
+  color: var(--text);
+  text-decoration: none;
+}
+
+.home-overview__links a:hover {
+  border-color: var(--line-strong);
+  background: rgba(255, 255, 255, 0.76);
+}
+
+.home-overview__links span:last-child {
+  font-family: 'Space Grotesk', 'Noto Sans JP', sans-serif;
+  font-weight: 700;
+}
+
+.home-overview__spotlights {
+  display: grid;
+  gap: 1rem;
+}
+
+.home-section {
+  display: grid;
+  gap: 1rem;
+}
+
+.post-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.post-card-link {
+  display: block;
+  height: 100%;
+  text-decoration: none;
+}
+
+.post-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-card);
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.84), rgba(244, 239, 230, 0.9));
+  box-shadow: var(--shadow-soft);
+}
+
+.post-card::after {
+  content: '';
+  position: absolute;
+  right: 1rem;
+  bottom: 1rem;
+  width: 2.8rem;
+  height: 2.8rem;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  opacity: 0.65;
+}
+
+.post-card-link:hover .post-card {
+  transform: translateY(-3px);
+  border-color: var(--line-strong);
+}
+
+.post-card__media {
+  position: relative;
+  overflow: hidden;
+  border-bottom: 1px solid var(--line);
+}
+
+.post-card--default .post-card__media {
+  aspect-ratio: 16 / 10;
+}
+
+.post-card--featured .post-card__media {
+  min-height: 240px;
+}
+
+.post-card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.post-card__body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding: 1.1rem;
+}
+
+.post-card__eyebrow {
+  font-family: 'Space Grotesk', 'Noto Sans JP', sans-serif;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.post-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem 1rem;
+  color: var(--text-muted);
+  font-size: 0.84rem;
+}
+
+.post-card__title,
+.article-header__title {
+  font-family: 'Space Grotesk', 'Noto Sans JP', sans-serif;
+  font-weight: 700;
+  line-height: 0.95;
+  letter-spacing: -0.05em;
+  text-wrap: balance;
+}
+
+.post-card__title {
+  font-size: clamp(1.35rem, 2.2vw, 1.95rem);
+}
+
+.post-card--default .post-card__title {
+  font-size: 1.4rem;
+}
+
+.post-card__description,
+.article-header__description {
+  color: var(--text-soft);
+}
+
+.post-card__footer,
+.article-header__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  margin-top: auto;
+}
+
+.post-card__tag,
+.article-header__tag {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2rem;
+  padding: 0.35rem 0.8rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.55);
+  color: var(--text-soft);
+  font-size: 0.82rem;
+}
+
+.post-card__read {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2rem;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(23, 25, 27, 0.07);
+  color: var(--text);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.list-page {
+  display: grid;
+  gap: 1.2rem;
+  padding-top: 0.6rem;
+}
+
+.list-page__header {
+  padding: 1.3rem;
+  border-radius: var(--radius-panel);
+}
+
+.list-page__title {
+  font-size: clamp(2rem, 4vw, 3.3rem);
+}
+
+.pagination {
+  display: flex;
+  justify-content: center;
+}
+
+.pagination__list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.45rem;
+}
+
+.pagination__item {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+  padding: 0.55rem 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.62);
+  color: var(--text);
+  text-decoration: none;
+}
+
+.pagination__item:hover {
+  border-color: var(--line-strong);
+}
+
+.pagination__item.is-current {
+  border-color: rgba(159, 209, 28, 0.65);
+  background: var(--accent);
+  font-weight: 700;
+}
+
+.pagination__item.is-disabled {
+  opacity: 0.42;
+}
+
+.article-page {
+  display: grid;
+  gap: 1.3rem;
+  padding-top: 0.7rem;
+}
+
+.article-page__layout,
+.article-page__main,
+.article-header,
+.article-body {
+  display: grid;
+  gap: 1rem;
+}
+
+.article-header__panel,
+.article-header__figure,
+.article-body__inner,
+.article-endcap {
+  padding: 1.25rem;
+  border-radius: var(--radius-panel);
+}
+
+.article-header__topline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.article-header__category,
+.article-body__backlink a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.35rem;
+  padding: 0.5rem 0.95rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--text);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.article-header__category:hover,
+.article-header__tag:hover,
+.article-body__backlink a:hover {
+  border-color: var(--line-strong);
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.article-header__title {
+  margin-top: 1rem;
+  font-size: clamp(2.5rem, 6vw, 4.7rem);
+}
+
+.article-header__stats {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
+.article-header__figure img {
+  width: 100%;
+  max-height: 28rem;
+  object-fit: cover;
+  border-radius: 20px 10px 20px 10px;
+}
+
+.toc-panel {
+  padding: 1rem 1rem 1.1rem;
+  border-radius: 24px 10px 24px 10px;
+}
+
+.toc-panel__list {
+  display: grid;
+  gap: 0.45rem;
+  margin-top: 0.8rem;
+}
+
+.toc-panel__item--level-3 {
+  padding-left: 0.8rem;
+}
+
+.toc-panel__item--level-4,
+.toc-panel__item--level-5,
+.toc-panel__item--level-6 {
+  padding-left: 1.4rem;
+}
+
+.toc-panel__link {
+  display: block;
+  padding: 0.45rem 0.55rem;
+  border-radius: 12px;
+  color: var(--text-soft);
+  text-decoration: none;
+}
+
+.toc-panel__link:hover {
+  background: rgba(255, 255, 255, 0.66);
+  color: var(--text);
+}
+
+.article-body__backlink {
+  display: flex;
+}
+
+.post-prose {
+  color: var(--text);
+  font-size: 1rem;
+}
+
+.post-prose :where(h2, h3, h4) {
+  position: relative;
+  margin-top: 2.5rem;
+  margin-bottom: 1rem;
+  font-family: 'Space Grotesk', 'Noto Sans JP', sans-serif;
+  color: var(--text);
+  letter-spacing: -0.03em;
+}
+
+.post-prose :where(h2, h3, h4)::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 1px;
+  margin-top: 0.6rem;
+  background: linear-gradient(90deg, var(--line-strong), transparent);
 }
 
 .post-prose a:not(.heading-anchor) {
-  color: #2563eb;
+  color: #2450d4;
   text-decoration: none;
-  transition: all 0.2s ease-in-out;
-  font-weight: 400;
+  font-weight: 500;
 }
 
 .post-prose a:not(.heading-anchor):hover {
-  color: #1d4ed8;
+  color: #163db0;
   text-decoration: underline;
 }
 
 .post-prose .heading-anchor {
-  color: #6b7280;
+  color: var(--text-muted);
   text-decoration: none;
-  transition: color 0.2s ease-in-out;
-  font-weight: 400;
   margin-right: 0.5rem;
 }
 
 .post-prose .heading-anchor:hover {
-  color: #2563eb;
-  text-decoration: none;
+  color: var(--accent-strong);
 }
 
 .post-prose :not(pre) > code {
-  background-color: #374151;
-  color: #e5e7eb;
-  padding: 0.125rem 0.375rem;
-  border-radius: 0.25rem;
-  font-family: 'Fira Code', 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
-  font-size: 0.875em;
+  padding: 0.12rem 0.42rem;
+  border-radius: 0.3rem;
+  background: rgba(23, 25, 27, 0.92);
+  color: #eef2f5;
+  font-family: 'IBM Plex Mono', 'SF Mono', 'Cascadia Code', 'Roboto Mono', Consolas, monospace;
+  font-size: 0.88em;
   font-weight: 600;
+}
+
+.post-prose blockquote,
+.post-prose .directive-box {
+  padding: 1rem 1rem 1rem 1.2rem;
+  border: 1px solid var(--line);
+  border-left: 4px solid var(--accent-warm);
+  border-radius: 18px 8px 18px 8px;
+  background: rgba(255, 255, 255, 0.6);
 }
 
 .post-prose figure {
@@ -70,93 +855,66 @@ html {
 }
 
 .post-prose figure img {
-  border-radius: 0.5rem;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
   max-width: 100%;
   height: auto;
-  transition: transform 0.2s ease-in-out;
-}
-
-.post-prose figure img:hover {
-  transform: scale(1.02);
+  border-radius: 22px 10px 22px 10px;
+  box-shadow: 0 20px 40px rgba(23, 25, 27, 0.12);
 }
 
 .post-prose figcaption {
-  margin-top: 0.75rem;
-  font-size: 0.875rem;
-  color: #6b7280;
-  font-style: italic;
-  text-align: center;
-  line-height: 1.5;
+  margin-top: 0.8rem;
+  color: var(--text-muted);
+  font-size: 0.88rem;
 }
 
 .post-prose figure[data-rehype-pretty-code-figure] {
-  margin: 1.5rem 0;
-  border-radius: 0.5rem;
   overflow: hidden;
-  border: 1px solid #374151;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+  border: 1px solid rgba(214, 222, 232, 0.16);
+  border-radius: 24px 10px 24px 10px;
+  box-shadow: 0 20px 40px rgba(13, 18, 27, 0.22);
 }
 
 .post-prose figure[data-rehype-pretty-code-figure] pre {
   margin: 0;
   padding: 1rem;
   overflow-x: auto;
-  font-family: 'Fira Code', 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
-  font-size: 0.875rem;
-  line-height: 1.6;
-  background-color: #1a2638;
-  color: #e6edf3;
-  scrollbar-width: thin;
-  scrollbar-color: rgba(255, 255, 255, 0.2) transparent;
+  background: #171d29;
+  color: #edf2f8;
+  font-family: 'IBM Plex Mono', 'SF Mono', 'Cascadia Code', 'Roboto Mono', Consolas, monospace;
+  font-size: 0.9rem;
+  line-height: 1.7;
 }
 
 .post-prose figure[data-rehype-pretty-code-figure] code {
-  font-family: inherit;
-  font-size: inherit;
   background: transparent;
-  border: 0;
+  color: inherit;
   padding: 0;
 }
 
 .post-prose figure[data-rehype-pretty-code-figure] [data-line] {
   display: block;
   border-left: 2px solid transparent;
-  transition: background-color 0.15s ease;
 }
 
 .post-prose figure[data-rehype-pretty-code-figure] [data-line]:hover {
-  background-color: rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.05);
 }
 
 .post-prose .twitter-tweet {
   margin: 2rem auto !important;
   max-width: 550px !important;
-  border-radius: 12px !important;
-  border: 1px solid #e1e8ed !important;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24) !important;
-}
-
-.post-prose iframe[id^='twitter-widget'] {
-  border-radius: 12px !important;
-  max-width: 100% !important;
+  border-radius: 20px !important;
+  box-shadow: 0 16px 40px rgba(23, 25, 27, 0.12) !important;
 }
 
 .amazon-card {
   display: grid;
-  grid-template-columns: 1fr;
   gap: 1rem;
-  padding: 1rem;
-  border: 1px solid #e5e7eb;
-  border-radius: 0.5rem;
-  box-shadow: 0 4px 6px -1px #0000001a, 0 2px 4px -1px #0000000f;
   margin: 1.5rem 0;
-}
-
-@media (min-width: 768px) {
-  .amazon-card {
-    grid-template-columns: 3fr 7fr;
-  }
+  padding: 1rem;
+  border: 1px solid var(--line);
+  border-radius: 22px 10px 22px 10px;
+  background: rgba(255, 255, 255, 0.74);
 }
 
 .amazon-card__image {
@@ -165,18 +923,13 @@ html {
   justify-content: center;
   padding: 0.5rem;
   background: white;
+  border-radius: 16px 8px 16px 8px;
 }
 
 .amazon-card__image img {
   max-width: 100%;
   max-height: 12rem;
   object-fit: contain;
-  transition: all 200ms ease;
-}
-
-.amazon-card__image img:hover {
-  transform: scale(1.05) translateY(-2px);
-  box-shadow: 0 10px 15px -3px #0000001a;
 }
 
 .amazon-card__content {
@@ -186,80 +939,162 @@ html {
 }
 
 .amazon-card__title {
-  font: 500 1.125rem/1.75rem sans-serif;
-  color: #1f2937;
-  margin-bottom: 0.5rem;
+  color: var(--text);
+  font-size: 1.05rem;
+  font-weight: 600;
   text-decoration: none;
 }
 
 .amazon-card__title:hover {
-  color: #2563eb;
-  text-decoration: underline;
+  color: #2450d4;
 }
 
 .amazon-card__cta {
-  display: inline-block;
-  padding: 0.5rem 1rem;
-  background: #fbbf24;
-  color: #1f2937;
-  font: 500 0.875rem/1.25rem sans-serif;
-  border-radius: 0.375rem;
-  text-align: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  min-width: 9rem;
+  min-height: 2.6rem;
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  background: #f6c455;
+  color: #352612;
+  font-size: 0.9rem;
+  font-weight: 700;
   text-decoration: none;
-  width: 10rem;
-  transition: all 200ms ease;
-}
-
-.amazon-card__cta:hover {
-  background: #f59e0b;
-  transform: translateY(-1px);
 }
 
 .post-prose .directive-box {
-  margin: 1rem 0;
-  padding: 1rem 1rem 1rem 3rem;
-  border-radius: 0.25rem;
-  background-color: var(--directive-bg);
   position: relative;
+  padding-left: 3rem;
 }
 
 .post-prose .directive-box::before {
   position: absolute;
   left: 1rem;
-  top: 1.5rem;
-  font-size: 1.1rem;
-  opacity: 0.6;
-  line-height: 1;
-}
-
-.post-prose .directive-box p:first-child {
-  margin-top: 0.25rem;
-}
-
-.post-prose .directive-box p:last-child {
-  margin-bottom: 0.25rem;
+  top: 1.15rem;
+  font-size: 1rem;
+  opacity: 0.7;
 }
 
 .post-prose .directive-info {
-  --directive-bg: #f0fdf4;
+  background: rgba(223, 248, 232, 0.78);
 }
 
 .post-prose .directive-info::before {
-  content: 'ⓘ';
+  content: 'i';
 }
 
 .post-prose .directive-alert {
-  --directive-bg: #fef2f2;
+  background: rgba(253, 227, 227, 0.82);
 }
 
-.post-prose .directive-alert::before {
-  content: '×';
+.post-prose .directive-alert::before,
+.post-prose .directive-warn::before {
+  content: '!';
 }
 
 .post-prose .directive-warn {
-  --directive-bg: #fefce8;
+  background: rgba(255, 244, 210, 0.84);
 }
 
-.post-prose .directive-warn::before {
-  content: '⚠';
+.empty-state {
+  padding: 1.5rem;
+  border-radius: var(--radius-panel);
+}
+
+@media (min-width: 768px) {
+  .site-header__inner {
+    flex-direction: row;
+    align-items: end;
+    justify-content: space-between;
+    gap: 1.5rem;
+    padding: 1.1rem 1.5rem;
+  }
+
+  .site-footer__inner {
+    grid-template-columns: 1.4fr auto;
+    align-items: end;
+  }
+
+  .home-overview__links {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .home-overview__spotlights,
+  .article-header__stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .article-header__stats {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .amazon-card {
+    grid-template-columns: 3fr 7fr;
+  }
+}
+
+@media (min-width: 1024px) {
+  .site-main {
+    width: min(1280px, calc(100% - 2rem));
+  }
+
+  .home-hero {
+    grid-template-columns: minmax(0, 1.05fr) minmax(380px, 0.95fr);
+    align-items: stretch;
+    padding: 1.9rem;
+  }
+
+  .home-overview {
+    grid-template-columns: minmax(300px, 0.74fr) minmax(0, 1.26fr);
+    align-items: start;
+  }
+
+  .post-card--featured {
+    display: grid;
+    grid-template-columns: minmax(0, 1.05fr) minmax(240px, 0.95fr);
+    min-height: 100%;
+  }
+
+  .post-card--featured .post-card__media {
+    min-height: 100%;
+    border-bottom: 0;
+    border-left: 1px solid var(--line);
+  }
+
+  .post-card--featured .post-card__body {
+    padding: 1.35rem;
+  }
+
+  .article-page__layout {
+    grid-template-columns: minmax(0, 1fr) 280px;
+    align-items: start;
+  }
+
+  .article-page__aside {
+    position: sticky;
+    top: 6.5rem;
+  }
+
+  .article-page__toc-mobile {
+    display: none;
+  }
+}
+
+@media (max-width: 1023px) {
+  .article-page__aside {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0s !important;
+  }
 }

--- a/apps/astro-blog/src/components/Footer.astro
+++ b/apps/astro-blog/src/components/Footer.astro
@@ -4,17 +4,46 @@ import { SOCIAL_LINK_GITHUB, SOCIAL_LINK_X } from '$constants';
 const year = new Date().getFullYear();
 ---
 
-<footer class="flex flex-col items-center gap-2 py-6 text-sm text-gray-500">
-  <div class="flex gap-6">
-    <a href={`https://x.com/${SOCIAL_LINK_X}`} target="_blank" rel="noopener noreferrer" aria-label="X (Twitter)">
-      X
-    </a>
-    <a href={`https://github.com/${SOCIAL_LINK_GITHUB}`} target="_blank" rel="noopener noreferrer" aria-label="GitHub">
-      GitHub
-    </a>
-    <a href="/llms.txt" target="_blank" rel="noopener noreferrer" aria-label="AI向け記事一覧" title="LLM-friendly content guide">
-      LLMs
-    </a>
+<footer class="site-footer">
+  <div class="site-main">
+    <div class="site-footer__inner">
+      <div>
+        <p class="section-label">End Signal</p>
+        <p class="site-footer__title">Estrilda</p>
+        <p class="site-footer__copy">
+          株式投資、プログラミング、趣味のログを静かな熱量で整理するためのアーカイブです。
+        </p>
+      </div>
+
+      <div class="site-footer__links">
+        <a
+          href={`https://x.com/${SOCIAL_LINK_X}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="X (Twitter)"
+        >
+          X
+        </a>
+        <a
+          href={`https://github.com/${SOCIAL_LINK_GITHUB}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="GitHub"
+        >
+          GitHub
+        </a>
+        <a
+          href="/llms.txt"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="AI向け記事一覧"
+          title="LLM-friendly content guide"
+        >
+          LLMs
+        </a>
+      </div>
+
+      <p class="site-footer__meta">© {year} Estrivault. All rights reserved.</p>
+    </div>
   </div>
-  <p>© {year} Estrivault. All rights reserved.</p>
 </footer>

--- a/apps/astro-blog/src/components/Header.astro
+++ b/apps/astro-blog/src/components/Header.astro
@@ -1,5 +1,5 @@
 ---
-import { NAVIGATION_LINKS, SITE_TITLE } from '$constants';
+import { NAVIGATION_LINKS, SITE_DESCRIPTION, SITE_TITLE } from '$constants';
 
 interface Props {
   pathname: string;
@@ -18,27 +18,30 @@ function isActive(href: string): boolean {
 }
 ---
 
-<header class="sticky top-0 z-50 w-full px-4 py-4">
-  <div
-    class="mx-auto max-w-6xl rounded-2xl border border-gray-200/50 bg-gradient-to-br from-white to-gray-50 px-6 py-4 shadow-xl shadow-gray-900/10 sm:px-8 lg:px-10"
-  >
-    <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-      <a href="/" class="text-xl font-bold text-gray-900 no-underline">{SITE_TITLE}</a>
+<header class="site-header">
+  <div class="site-main">
+    <div class="site-header__inner">
+      <a href="/" class="site-brand">
+        <span class="site-brand__eyebrow">Estrilda / Signal Archive</span>
+        <span class="site-brand__title">{SITE_TITLE}</span>
+        <span class="site-brand__note">{SITE_DESCRIPTION}</span>
+      </a>
+
       <nav aria-label="Main navigation">
-        <ul class="flex flex-wrap gap-2 text-sm font-medium md:gap-4 md:text-base">
-          {NAVIGATION_LINKS.map(({ label, href }) => (
-            <li>
-              <a
-                href={href}
-                class={`block rounded-md px-2 py-2 transition-colors hover:bg-gray-100 hover:text-gray-900 ${
-                  isActive(href) ? 'bg-gray-100 font-semibold text-gray-900' : 'text-gray-600'
-                }`}
-                aria-current={isActive(href) ? 'page' : undefined}
-              >
-                {label}
-              </a>
-            </li>
-          ))}
+        <ul class="site-nav">
+          {
+            NAVIGATION_LINKS.map(({ label, href }) => (
+              <li>
+                <a
+                  href={href}
+                  class:list={['site-nav__link', isActive(href) && 'is-active']}
+                  aria-current={isActive(href) ? 'page' : undefined}
+                >
+                  {label}
+                </a>
+              </li>
+            ))
+          }
         </ul>
       </nav>
     </div>

--- a/apps/astro-blog/src/components/Pagination.astro
+++ b/apps/astro-blog/src/components/Pagination.astro
@@ -40,70 +40,83 @@ const pageNumbers = getPageNumbers();
 const lastPageNumber = pageNumbers[pageNumbers.length - 1];
 ---
 
-<nav aria-label="ページネーション" class="my-8 flex justify-center">
-  <ul class="flex items-center space-x-1">
+<nav aria-label="ページネーション" class="pagination">
+  <ul class="pagination__list">
     <li>
-      {currentPage > 1 ? (
-        <a
-          href={getPageUrl(currentPage - 1)}
-          class="flex h-10 w-10 items-center justify-center rounded-md border border-gray-300 bg-white text-gray-500 hover:bg-gray-50"
-          aria-label="前のページ"
-        >
-          ‹
-        </a>
-      ) : (
-        <span class="flex h-10 w-10 cursor-not-allowed items-center justify-center rounded-md border border-gray-200 bg-gray-100 text-gray-400" aria-disabled="true">
-          ‹
-        </span>
-      )}
+      {
+        currentPage > 1 ?
+          <a href={getPageUrl(currentPage - 1)} class="pagination__item" aria-label="前のページ">
+            ‹
+          </a>
+        : <span class="pagination__item is-disabled" aria-disabled="true">
+            ‹
+          </span>
+      }
     </li>
 
-    {pageNumbers[0] && pageNumbers[0] > 1 && (
-      <>
-        <li>
-          <a href={getPageUrl(1)} class="flex h-10 w-10 items-center justify-center rounded-md border border-gray-300 bg-white text-gray-700 hover:bg-gray-50" aria-label="1ページ目">1</a>
-        </li>
-        {pageNumbers[0] > 2 && <li><span class="flex h-10 w-10 items-center justify-center text-gray-500">...</span></li>}
-      </>
-    )}
+    {
+      pageNumbers[0] && pageNumbers[0] > 1 && (
+        <>
+          <li>
+            <a href={getPageUrl(1)} class="pagination__item" aria-label="1ページ目">
+              1
+            </a>
+          </li>
+          {pageNumbers[0] > 2 && (
+            <li>
+              <span class="pagination__item is-disabled">...</span>
+            </li>
+          )}
+        </>
+      )
+    }
 
-    {pageNumbers.map((page) => (
-      <li>
-        {page === currentPage ? (
-          <span class="flex h-10 w-10 items-center justify-center rounded-md border border-blue-500 bg-blue-500 font-medium text-white" aria-current="page">{page}</span>
-        ) : (
-          <a href={getPageUrl(page)} class="flex h-10 w-10 items-center justify-center rounded-md border border-gray-300 bg-white text-gray-700 hover:bg-gray-50" aria-label={`${page}ページ目`}>
-            {page}
-          </a>
-        )}
-      </li>
-    ))}
-
-    {lastPageNumber && lastPageNumber < totalPages && (
-      <>
-        {lastPageNumber < totalPages - 1 && <li><span class="flex h-10 w-10 items-center justify-center text-gray-500">...</span></li>}
+    {
+      pageNumbers.map((page) => (
         <li>
-          <a href={getPageUrl(totalPages)} class="flex h-10 w-10 items-center justify-center rounded-md border border-gray-300 bg-white text-gray-700 hover:bg-gray-50" aria-label={`${totalPages}ページ目`}>
-            {totalPages}
-          </a>
+          {page === currentPage ?
+            <span class="pagination__item is-current" aria-current="page">
+              {page}
+            </span>
+          : <a href={getPageUrl(page)} class="pagination__item" aria-label={`${page}ページ目`}>
+              {page}
+            </a>
+          }
         </li>
-      </>
-    )}
+      ))
+    }
+
+    {
+      lastPageNumber && lastPageNumber < totalPages && (
+        <>
+          {lastPageNumber < totalPages - 1 && (
+            <li>
+              <span class="pagination__item is-disabled">...</span>
+            </li>
+          )}
+          <li>
+            <a
+              href={getPageUrl(totalPages)}
+              class="pagination__item"
+              aria-label={`${totalPages}ページ目`}
+            >
+              {totalPages}
+            </a>
+          </li>
+        </>
+      )
+    }
 
     <li>
-      {currentPage < totalPages ? (
-        <a
-          href={getPageUrl(currentPage + 1)}
-          class="flex h-10 w-10 items-center justify-center rounded-md border border-gray-300 bg-white text-gray-500 hover:bg-gray-50"
-          aria-label="次のページ"
-        >
-          ›
-        </a>
-      ) : (
-        <span class="flex h-10 w-10 cursor-not-allowed items-center justify-center rounded-md border border-gray-200 bg-gray-100 text-gray-400" aria-disabled="true">
-          ›
-        </span>
-      )}
+      {
+        currentPage < totalPages ?
+          <a href={getPageUrl(currentPage + 1)} class="pagination__item" aria-label="次のページ">
+            ›
+          </a>
+        : <span class="pagination__item is-disabled" aria-disabled="true">
+            ›
+          </span>
+      }
     </li>
   </ul>
 </nav>

--- a/apps/astro-blog/src/components/PostBody.astro
+++ b/apps/astro-blog/src/components/PostBody.astro
@@ -20,10 +20,12 @@ const proseClasses = [
   .join(' ');
 ---
 
-<div class="container mx-auto px-2 py-8 sm:px-4">
-  <div class={proseClasses} set:html={post.html || 'コンテンツがありません'}></div>
+<div class="article-body">
+  <div class="article-body__inner">
+    <div class={proseClasses} set:html={post.html || 'コンテンツがありません'} />
+  </div>
 
-  <div class="mt-12 border-t border-gray-200 pt-6">
-    <a href="/" class="text-blue-600 hover:underline">← 記事一覧に戻る</a>
+  <div class="article-body__backlink">
+    <a href="/">← 記事一覧に戻る</a>
   </div>
 </div>

--- a/apps/astro-blog/src/components/PostCard.astro
+++ b/apps/astro-blog/src/components/PostCard.astro
@@ -3,52 +3,59 @@ import type { PostMeta } from '@estrivault/content-processor';
 
 interface Props {
   post: PostMeta;
+  variant?: 'default' | 'featured';
 }
 
-const { post } = Astro.props;
+const { post, variant = 'default' } = Astro.props;
+const isFeatured = variant === 'featured';
 
 const dateString = new Intl.DateTimeFormat('ja-JP', {
+  timeZone: 'Asia/Tokyo',
   year: 'numeric',
   month: '2-digit',
   day: '2-digit',
 })
   .format(post.publishedAt)
   .replace(/\//g, '-');
+
+const shownTags = post.tags.slice(0, isFeatured ? 3 : 2);
 ---
 
-<a href={`/post/${post.slug}`} class="block h-full" aria-label={post.title}>
+<a href={`/post/${post.slug}`} class="post-card-link" aria-label={post.title}>
   <article
-    class="group relative flex h-full transform flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition-all duration-100 ease-out hover:scale-[1.01] hover:border-gray-300 hover:shadow-md"
+    class:list={['post-card', isFeatured ? 'post-card--featured' : 'post-card--default']}
     data-testid="post-card"
   >
-    <header>
-      {post.coverImage && (
-        <figure class="relative w-full overflow-hidden pt-[56.25%]">
-          <img src={post.coverImage} alt={post.title} class="absolute inset-0 h-full w-full object-cover" loading="lazy" />
-        </figure>
-      )}
+    <div class="post-card__body">
+      <p class="post-card__eyebrow">Entry / {post.category}</p>
 
-      <div class="flex flex-col justify-between p-4 font-sans text-gray-800">
-        <div class="space-y-1">
-          <div class="flex items-center justify-between">
-            <p class="text-xs uppercase tracking-wide text-gray-500">{post.category}</p>
-            <time datetime={post.publishedAt.toISOString()} class="text-xs text-gray-500">{dateString}</time>
-          </div>
-          <h2 class="text-lg font-semibold text-gray-900 transition-colors group-hover:text-blue-600">{post.title}</h2>
-        </div>
+      <div class="post-card__meta">
+        <time datetime={post.publishedAt.toISOString()}>{dateString}</time>
+        {post.readingTime && <span>約{post.readingTime}分</span>}
       </div>
-    </header>
 
-    <section class="flex-1 px-4 text-sm text-gray-700">
-      <p class="line-clamp-2">{post.description}</p>
-    </section>
+      <h2 class="post-card__title">{post.title}</h2>
 
-    <footer class="p-4">
-      <ul class="mt-2 flex shrink-0 flex-wrap gap-2 text-xs text-gray-500">
-        {post.tags.map((tag) => (
-          <li class="rounded bg-gray-100 px-2 py-0.5">{tag}</li>
-        ))}
-      </ul>
-    </footer>
+      {
+        post.description && (
+          <p class:list={['post-card__description', !isFeatured && 'line-clamp-3']}>
+            {post.description}
+          </p>
+        )
+      }
+
+      <footer class="post-card__footer">
+        {shownTags.map((tag) => <span class="post-card__tag">{tag}</span>)}
+        <span class="post-card__read">Read dossier</span>
+      </footer>
+    </div>
+
+    {
+      post.coverImage && (
+        <figure class="post-card__media">
+          <img src={post.coverImage} alt={post.title} loading="lazy" />
+        </figure>
+      )
+    }
   </article>
 </a>

--- a/apps/astro-blog/src/components/PostHeader.astro
+++ b/apps/astro-blog/src/components/PostHeader.astro
@@ -14,77 +14,67 @@ const shownDateLabel = new Intl.DateTimeFormat('ja-JP', {
   month: '2-digit',
   day: '2-digit',
 }).format(shownDate);
+
+const dateLabel = meta.updatedAt ? 'Updated' : 'Published';
 ---
 
-<header class="bg-white pb-12 pt-8">
-  <div class="container mx-auto px-4">
-    <div class="flex flex-col items-start gap-8 lg:flex-row lg:items-stretch">
+<header class="article-header">
+  <div class="article-header__panel">
+    <div class="article-header__topline">
+      <p class="section-label">Article File</p>
       {
-        meta.coverImage && (
-          <div class="mb-8 w-full lg:mb-0 lg:flex lg:w-1/2 lg:items-center">
-            <div class="w-full overflow-hidden rounded-lg border border-gray-200">
-              <img src={meta.coverImage} alt={meta.title} class="h-auto w-full" loading="lazy" />
-            </div>
-          </div>
+        meta.category && (
+          <a
+            href={`/category/${encodeURIComponent(meta.category.toLowerCase())}/1`}
+            class="article-header__category"
+          >
+            {meta.category}
+          </a>
         )
       }
-
-      <div class="flex w-full flex-col justify-center lg:w-1/2">
-        <div class="mb-4 flex flex-wrap items-center justify-between">
-          {
-            meta.category && (
-              <div class="mb-2 sm:mb-0">
-                <a
-                  href={`/category/${encodeURIComponent(meta.category.toLowerCase())}/1`}
-                  class="text-sm font-medium text-gray-600 transition-colors hover:text-gray-900"
-                >
-                  {meta.category}
-                </a>
-              </div>
-            )
-          }
-
-          <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
-            <div class="flex items-center text-sm text-gray-500">
-              <time datetime={shownDate.toISOString()} class="leading-relaxed"
-                >{shownDateLabel}</time
-              >
-            </div>
-            {
-              meta.readingTime && (
-                <div class="flex items-center text-sm text-gray-500">
-                  <span class="leading-relaxed">約{meta.readingTime}分</span>
-                </div>
-              )
-            }
-          </div>
-        </div>
-
-        <h1 class="mb-6 text-2xl font-bold leading-tight text-gray-900 md:text-3xl lg:text-4xl">
-          {meta.title}
-        </h1>
-
-        {
-          meta.tags.length > 0 && (
-            <div class="mb-6 flex flex-wrap gap-2">
-              {meta.tags.map((tag) => (
-                <a
-                  href={`/tag/${getTagRouteSegment(tag)}/1`}
-                  class="rounded bg-gray-100 px-2 py-1 text-xs text-gray-600 transition-colors hover:bg-gray-200"
-                >
-                  {tag}
-                </a>
-              ))}
-            </div>
-          )
-        }
-
-        {
-          meta.description && (
-            <p class="break-words text-gray-700 lg:line-clamp-3">{meta.description}</p>
-          )
-        }
-      </div>
     </div>
+
+    <h1 class="article-header__title">{meta.title}</h1>
+
+    {meta.description && <p class="article-header__description">{meta.description}</p>}
+
+    <dl class="article-header__stats">
+      <div>
+        <dt>{dateLabel}</dt>
+        <dd>
+          <time datetime={shownDate.toISOString()}>{shownDateLabel}</time>
+        </dd>
+      </div>
+
+      <div>
+        <dt>Reading time</dt>
+        <dd>{meta.readingTime ? `約${meta.readingTime}分` : '短時間で読めます'}</dd>
+      </div>
+
+      <div>
+        <dt>Topics</dt>
+        <dd>{meta.tags.length > 0 ? `${meta.tags.length} tags` : 'タグなし'}</dd>
+      </div>
+    </dl>
+
+    {
+      meta.tags.length > 0 && (
+        <div class="article-header__tags">
+          {meta.tags.map((tag) => (
+            <a href={`/tag/${getTagRouteSegment(tag)}/1`} class="article-header__tag">
+              {tag}
+            </a>
+          ))}
+        </div>
+      )
+    }
   </div>
+
+  {
+    meta.coverImage && (
+      <figure class="article-header__figure">
+        <img src={meta.coverImage} alt={meta.title} loading="lazy" />
+      </figure>
+    )
+  }
 </header>

--- a/apps/astro-blog/src/components/TableOfContents.astro
+++ b/apps/astro-blog/src/components/TableOfContents.astro
@@ -44,12 +44,18 @@ function getTextSizeClass(level: number): string {
 
 {
   headings.length > 0 && (
-    <nav class="table-of-contents mb-8 rounded-2xl border border-gray-200/50 bg-gradient-to-br from-white to-gray-50 p-6 xl:sticky xl:top-24 xl:mb-0 xl:mt-16 xl:max-h-[calc(100vh-16rem)] xl:overflow-y-auto xl:shadow-xl xl:shadow-gray-900/10">
-      <h2 class="mb-4 text-lg font-bold text-gray-900">目次</h2>
-      <ul class="space-y-2">
+    <nav class="toc-panel">
+      <p class="section-label">Jump List</p>
+      <h2 class="toc-panel__title">目次</h2>
+      <ul class="toc-panel__list">
         {headings.map((heading) => (
-          <li class={getIndentClass(heading.level)}>
-            <a href={`#${heading.id}`} class={`block py-1 text-gray-600 transition-colors duration-200 hover:text-gray-900 ${getTextSizeClass(heading.level)}`}>
+          <li
+            class:list={[getIndentClass(heading.level), `toc-panel__item--level-${heading.level}`]}
+          >
+            <a
+              href={`#${heading.id}`}
+              class:list={['toc-panel__link', getTextSizeClass(heading.level)]}
+            >
               {heading.text}
             </a>
           </li>

--- a/apps/astro-blog/src/layouts/BaseLayout.astro
+++ b/apps/astro-blog/src/layouts/BaseLayout.astro
@@ -45,6 +45,12 @@ const pathname = Astro.url.pathname;
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" href="/icon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;800&family=Space+Grotesk:wght@500;700&display=swap"
+    />
 
     <title>{title}</title>
     <meta name="description" content={description} />
@@ -77,27 +83,43 @@ const pathname = Astro.url.pathname;
     {section && <meta property="article:section" content={section} />}
     {tags.map((tag) => <meta property="article:tag" content={tag} />)}
 
-    <link rel="alternate" type="text/markdown" href="/llms.txt" title="LLM-friendly content guide" />
-    <link rel="alternate" type="text/markdown" href="/llms-full.txt" title="Complete content archive" />
+    <link
+      rel="alternate"
+      type="text/markdown"
+      href="/llms.txt"
+      title="LLM-friendly content guide"
+    />
+    <link
+      rel="alternate"
+      type="text/markdown"
+      href="/llms-full.txt"
+      title="Complete content archive"
+    />
 
     <script
       is:inline
       defer
       src="https://static.cloudflareinsights.com/beacon.min.js"
-      data-cf-beacon='{"token": "f0d31da4d3c348078218b627067efa9b"}'
-    ></script>
+      data-cf-beacon='{"token": "f0d31da4d3c348078218b627067efa9b"}'></script>
 
-    {jsonLd && (
-      <script is:inline type="application/ld+json" set:html={JSON.stringify(jsonLd)}></script>
-    )}
+    {jsonLd && <script is:inline type="application/ld+json" set:html={JSON.stringify(jsonLd)} />}
   </head>
-  <body>
-    <Header pathname={pathname} />
+  <body class="site-shell">
+    <div class="site-chrome" aria-hidden="true">
+      <div class="site-chrome__grid"></div>
+      <div class="site-chrome__beam site-chrome__beam--one"></div>
+      <div class="site-chrome__beam site-chrome__beam--two"></div>
+      <div class="site-chrome__grain"></div>
+    </div>
 
-    <main class="mx-auto w-full max-w-6xl px-4 py-4">
-      <slot />
-    </main>
+    <div class="site-frame">
+      <Header pathname={pathname} />
 
-    <Footer />
+      <main id="content" class="site-main">
+        <slot />
+      </main>
+
+      <Footer />
+    </div>
   </body>
 </html>

--- a/apps/astro-blog/src/pages/category/[category]/[page]/index.astro
+++ b/apps/astro-blog/src/pages/category/[category]/[page]/index.astro
@@ -45,35 +45,53 @@ const pageUrl = `${siteBase}/category/${Astro.params.category}/${currentPage}`;
 const pageTitle = `${category.toUpperCase()}の記事一覧${currentPage > 1 ? ` - ページ${currentPage}` : ''} | ${SITE_TITLE}`;
 const pageDescription = `${category.toUpperCase()}カテゴリーの記事一覧${currentPage > 1 ? `（${currentPage}ページ目）` : ''}です。全${result.total}件の記事を掲載しています。`;
 
-const prevUrl = currentPage > 1 ? `${siteBase}/category/${Astro.params.category}/${currentPage > 2 ? currentPage - 1 : 1}` : undefined;
-const nextUrl = currentPage < result.totalPages ? `${siteBase}/category/${Astro.params.category}/${currentPage + 1}` : undefined;
+const prevUrl =
+  currentPage > 1 ?
+    `${siteBase}/category/${Astro.params.category}/${currentPage > 2 ? currentPage - 1 : 1}`
+  : undefined;
+const nextUrl =
+  currentPage < result.totalPages ?
+    `${siteBase}/category/${Astro.params.category}/${currentPage + 1}`
+  : undefined;
 ---
 
-<BaseLayout title={pageTitle} description={pageDescription} canonical={pageUrl} prevUrl={prevUrl} nextUrl={nextUrl}>
-  <div class="container mx-auto px-4 py-8">
-    <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold">{category.toUpperCase()}</h1>
-      <p class="text-gray-600">全{result.total}件の記事（{result.page} / {result.totalPages}ページ）</p>
+<BaseLayout
+  title={pageTitle}
+  description={pageDescription}
+  canonical={pageUrl}
+  prevUrl={prevUrl}
+  nextUrl={nextUrl}
+>
+  <div class="list-page">
+    <div class="list-page__header">
+      <p class="list-page__eyebrow">Category Archive</p>
+      <h1 class="list-page__title">{category.toUpperCase()}</h1>
+      <p class="list-page__description">
+        全{result.total}件の記事（{result.page} / {result.totalPages}ページ）
+      </p>
     </div>
 
-    {result.posts.length > 0 ? (
-      <div class="mb-8">
-        <div class="grid gap-8 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
-          {result.posts.map((post) => (
-            <PostCard post={post} />
-          ))}
-        </div>
-
-        {result.totalPages > 1 && (
-          <div class="mt-12">
-            <Pagination currentPage={result.page} totalPages={result.totalPages} baseUrl={`/category/${Astro.params.category}`} maxVisible={5} />
+    {
+      result.posts.length > 0 ?
+        <div class="grid gap-4">
+          <div class="post-grid">
+            {result.posts.map((post) => (
+              <PostCard post={post} />
+            ))}
           </div>
-        )}
-      </div>
-    ) : (
-      <div class="rounded-lg bg-gray-50 p-8 text-center">
-        <p class="text-gray-500">このカテゴリーにはまだ記事がありません。</p>
-      </div>
-    )}
+
+          {result.totalPages > 1 && (
+            <Pagination
+              currentPage={result.page}
+              totalPages={result.totalPages}
+              baseUrl={`/category/${Astro.params.category}`}
+              maxVisible={5}
+            />
+          )}
+        </div>
+      : <div class="empty-state">
+          <p class="text-gray-700">このカテゴリーにはまだ記事がありません。</p>
+        </div>
+    }
   </div>
 </BaseLayout>

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -2,24 +2,131 @@
 import BaseLayout from '$layouts/BaseLayout.astro';
 import Pagination from '$components/Pagination.astro';
 import PostCard from '$components/PostCard.astro';
-import { POSTS_PER_PAGE, SITE_DESCRIPTION, SITE_TITLE, SITE_URL } from '$constants';
+import {
+  NAVIGATION_LINKS,
+  POSTS_PER_PAGE,
+  SITE_DESCRIPTION,
+  SITE_TITLE,
+  SITE_URL,
+} from '$constants';
 import { getPosts } from '$lib/content';
 
 const pageData = await getPosts({ page: 1, perPage: POSTS_PER_PAGE });
+const [featuredPost, ...remainingPosts] = pageData.posts;
+const spotlightPosts = remainingPosts.slice(0, 2);
+const gridPosts = remainingPosts.slice(2);
+const categoryLinks = NAVIGATION_LINKS.filter(({ href }) => href.startsWith('/category'));
+const latestDate =
+  featuredPost ?
+    new Intl.DateTimeFormat('ja-JP', {
+      timeZone: 'Asia/Tokyo',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    })
+      .format(featuredPost.publishedAt)
+      .replace(/\//g, '-')
+  : '';
 ---
 
 <BaseLayout title={SITE_TITLE} description={SITE_DESCRIPTION} canonical={SITE_URL}>
   <h1 class="sr-only">{SITE_TITLE}</h1>
 
-  <div class="grid gap-8 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
-    {pageData.posts.map((post) => (
-      <PostCard post={post} />
-    ))}
-  </div>
+  {
+    featuredPost ?
+      <div class="home-page">
+        <section class="home-hero">
+          <div class="home-hero__copy">
+            <p class="section-label">Signal Archive</p>
+            <h2 class="home-hero__title">
+              Markets, code, and hobbies arranged with industrial clarity.
+            </h2>
+            <p class="home-hero__lede">{SITE_DESCRIPTION}</p>
 
-  {pageData.totalPages > 1 && (
-    <div class="mt-12">
-      <Pagination currentPage={pageData.page} totalPages={pageData.totalPages} baseUrl="/" />
-    </div>
-  )}
+            <div class="home-hero__actions">
+              <a href="#latest-posts" class="hero-action hero-action--primary">
+                最新記事を見る
+              </a>
+              <a href={`/post/${featuredPost.slug}`} class="hero-action hero-action--secondary">
+                注目記事を読む
+              </a>
+            </div>
+
+            <dl class="home-hero__stats">
+              <div>
+                <dt>Archive</dt>
+                <dd>{pageData.total} entries</dd>
+              </div>
+              <div>
+                <dt>Latest drop</dt>
+                <dd>{latestDate}</dd>
+              </div>
+              <div>
+                <dt>Focus</dt>
+                <dd>{featuredPost.category}</dd>
+              </div>
+            </dl>
+          </div>
+
+          <div class="home-hero__feature">
+            <div>
+              <p class="section-label">Featured Entry</p>
+              <p class="home-hero__feature-note">最新の投稿をフロントに配置しています。</p>
+            </div>
+            <PostCard post={featuredPost} variant="featured" />
+          </div>
+        </section>
+
+        <section class="home-overview">
+          <div class="home-overview__panel">
+            <p class="section-label">Entry Points</p>
+            <h2 class="home-overview__title">カテゴリから読む</h2>
+            <p class="home-overview__copy">
+              テック、投資、趣味、意見の各トピックへ、都市的なUIリズムで素早く移動できます。
+            </p>
+
+            <div class="home-overview__links">
+              {categoryLinks.map(({ label, href }) => (
+                <a href={href}>
+                  <span>{label}</span>
+                  <span>→</span>
+                </a>
+              ))}
+            </div>
+          </div>
+
+          {spotlightPosts.length > 0 && (
+            <div class="home-overview__spotlights">
+              {spotlightPosts.map((post) => (
+                <PostCard post={post} />
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section id="latest-posts" class="home-section">
+          <div>
+            <p class="section-label">Recent Dispatches</p>
+            <h2 class="home-section__title">最新記事</h2>
+            <p class="home-section__copy">
+              新着から順に、情報密度を保ったカードで一覧できるセクションです。
+            </p>
+          </div>
+
+          <div class="post-grid">
+            {gridPosts.map((post) => (
+              <PostCard post={post} />
+            ))}
+          </div>
+        </section>
+
+        {pageData.totalPages > 1 && (
+          <Pagination currentPage={pageData.page} totalPages={pageData.totalPages} baseUrl="/" />
+        )}
+      </div>
+    : <div class="empty-state">
+        <p class="section-label">No Signal</p>
+        <p class="mt-4 text-lg font-semibold">表示できる記事がまだありません。</p>
+      </div>
+  }
 </BaseLayout>

--- a/apps/astro-blog/src/pages/post/[slug]/index.astro
+++ b/apps/astro-blog/src/pages/post/[slug]/index.astro
@@ -60,7 +60,10 @@ const schemaData = {
     '@id': canonical,
   },
   articleSection: post.meta.category,
-  keywords: [post.meta.category].concat(post.meta.tags || []).filter(Boolean).join(', '),
+  keywords: [post.meta.category]
+    .concat(post.meta.tags || [])
+    .filter(Boolean)
+    .join(', '),
   wordCount: post.html ? getJapaneseWordCount(post.html) : 0,
   timeRequired: post.meta.readingTime ? `PT${Math.ceil(post.meta.readingTime)}M` : undefined,
   inLanguage: 'ja-JP',
@@ -80,24 +83,29 @@ const schemaData = {
   section={post.meta.category}
   tags={post.meta.tags}
 >
-  <article class="container mx-auto px-2 sm:px-4 xl:max-w-6xl">
+  <article class="article-page">
     <PostHeader meta={post.meta} />
-    <div class="xl:flex xl:gap-8">
-      <div class="xl:max-w-4xl xl:flex-1">
-        <div class="xl:hidden">
+
+    <div class="article-page__layout">
+      <div class="article-page__main">
+        <div class="article-page__toc-mobile">
           <TableOfContents headings={post.headings} />
         </div>
 
         <PostBody post={post} />
 
-        {post.originalPath && (
-          <div class="post-footer mt-12 rounded-2xl border border-slate-200 bg-gradient-to-br from-slate-50 to-slate-100 p-8">
-            <EditOnGitHub originalPath={post.originalPath} />
-          </div>
-        )}
+        {
+          post.originalPath && (
+            <div class="article-endcap">
+              <p class="section-label">Source</p>
+              <p class="article-endcap__copy">内容の修正提案や履歴確認は GitHub から行えます。</p>
+              <EditOnGitHub originalPath={post.originalPath} />
+            </div>
+          )
+        }
       </div>
 
-      <aside class="hidden xl:block xl:w-64 xl:flex-shrink-0">
+      <aside class="article-page__aside">
         <TableOfContents headings={post.headings} />
       </aside>
     </div>

--- a/apps/astro-blog/src/pages/tag/[tag]/[page]/index.astro
+++ b/apps/astro-blog/src/pages/tag/[tag]/[page]/index.astro
@@ -63,36 +63,35 @@ const nextUrl =
   prevUrl={prevUrl}
   nextUrl={nextUrl}
 >
-  <div class="container mx-auto px-4 py-8">
-    <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold">#{tag.toUpperCase()}</h1>
-      <p class="text-gray-600">
+  <div class="list-page">
+    <div class="list-page__header">
+      <p class="list-page__eyebrow">Tag Archive</p>
+      <h1 class="list-page__title">#{tag.toUpperCase()}</h1>
+      <p class="list-page__description">
         全{result.total}件の記事（{result.page} / {result.totalPages}ページ）
       </p>
     </div>
 
     {
       result.posts.length > 0 ?
-        <div class="mb-8">
-          <div class="grid gap-8 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+        <div class="grid gap-4">
+          <div class="post-grid">
             {result.posts.map((post) => (
               <PostCard post={post} />
             ))}
           </div>
 
           {result.totalPages > 1 && (
-            <div class="mt-12">
-              <Pagination
-                currentPage={result.page}
-                totalPages={result.totalPages}
-                baseUrl={`/tag/${Astro.params.tag}`}
-                maxVisible={5}
-              />
-            </div>
+            <Pagination
+              currentPage={result.page}
+              totalPages={result.totalPages}
+              baseUrl={`/tag/${Astro.params.tag}`}
+              maxVisible={5}
+            />
           )}
         </div>
-      : <div class="rounded-lg bg-gray-50 p-8 text-center">
-          <p class="text-gray-500">このタグにはまだ記事がありません。</p>
+      : <div class="empty-state">
+          <p class="text-gray-700">このタグにはまだ記事がありません。</p>
         </div>
     }
   </div>


### PR DESCRIPTION
## Summary
- redesign the top page into an industrial-pop editorial layout with a featured hero, category entry points, and refreshed post cards
- restyle article pages with a denser header panel, redesigned table of contents, and unified chrome across navigation, pagination, and footer
- introduce a new global visual system in the Astro app with layered backgrounds, typography updates, and reusable panel/card treatments

## Validation
- pnpm install --frozen-lockfile
- pnpm exec prettier --write apps/astro-blog/src/app.css apps/astro-blog/src/layouts/BaseLayout.astro apps/astro-blog/src/components/Header.astro apps/astro-blog/src/components/Footer.astro apps/astro-blog/src/components/PostCard.astro apps/astro-blog/src/components/PostHeader.astro apps/astro-blog/src/components/PostBody.astro apps/astro-blog/src/components/TableOfContents.astro apps/astro-blog/src/components/Pagination.astro apps/astro-blog/src/pages/index.astro apps/astro-blog/src/pages/post/[slug]/index.astro apps/astro-blog/src/pages/category/[category]/[page]/index.astro apps/astro-blog/src/pages/tag/[tag]/[page]/index.astro
- pnpm --filter astro-blog build

## Notes
- pnpm --filter astro-blog check currently fails because of a pre-existing type error in apps/astro-blog/src/pages/post/[slug]/og.png.ts (Response body typing), which is outside this change set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- グローバルビジュアルシステムをCSS変数、レイアウト基盤、コンポーネントスタイルで包括的に刷新した / 新しい「industrial-pop」デザイン言語の統一的な実現のため

- ブログホームページを特集記事ヒーロー、カテゴリー入口、スポットライト記事を備えた編集レイアウトに再構成した / 情報提示とユーザーエンゲージメントの最適化のため

- PostCardに featured/default バリアントを導入し、タグ表示数やレイアウトを動的に切り替える仕様に変更した / 異なる文脈での柔軟で効率的な表示対応のため

- Header、Footer、Pagination などのコンポーネントと BaseLayout をセマンティック命名（site-header、site-footer、pagination など）とBEM原則に統一した / デザインシステムの保守性と拡張性確保のため

<!-- end of auto-generated comment: release notes by coderabbit.ai -->