### PR TITLE
Refresh homepage with monochrome tactical design

### DIFF
--- a/apps/astro-blog/src/app.css
+++ b/apps/astro-blog/src/app.css
@@ -1,9 +1,331 @@
 @import 'tailwindcss';
 @plugin '@tailwindcss/typography';
 
+:root {
+  --font-body:
+    'IBM Plex Sans JP', 'Hiragino Kaku Gothic ProN', 'Hiragino Sans', 'Noto Sans JP', sans-serif;
+  --font-ui: 'Barlow Condensed', 'IBM Plex Sans JP', sans-serif;
+  --page-bg: #efefef;
+  --page-bg-alt: #f8f8f8;
+  --ink-1: #090909;
+  --ink-2: #262626;
+  --ink-3: #575757;
+  --panel-soft: #fafafa;
+  --panel-strong: #080808;
+  --line-soft: rgba(0, 0, 0, 0.12);
+  --line-strong: rgba(255, 255, 255, 0.18);
+  --focus-ring: rgba(0, 0, 0, 0.55);
+}
+
 html {
   scrollbar-gutter: stable;
   overflow-y: scroll;
+  background: var(--page-bg);
+}
+
+body {
+  min-height: 100vh;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.88) 0%, rgba(236, 236, 236, 0.94) 100%),
+    linear-gradient(90deg, rgba(0, 0, 0, 0.035) 1px, transparent 1px),
+    linear-gradient(rgba(0, 0, 0, 0.03) 1px, transparent 1px);
+  background-size: auto, 32px 32px, 32px 32px;
+  color: var(--ink-1);
+  font-family: var(--font-body);
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(circle at top right, rgba(0, 0, 0, 0.08), transparent 30%),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.18), transparent 35%);
+  mix-blend-mode: multiply;
+  opacity: 0.75;
+  z-index: -1;
+}
+
+a:focus-visible,
+button:focus-visible,
+[tabindex]:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 3px;
+}
+
+.font-ui {
+  font-family: var(--font-ui);
+}
+
+.site-main {
+  position: relative;
+}
+
+.site-main--home {
+  padding-top: 1rem;
+}
+
+.site-header-panel {
+  position: relative;
+  box-shadow:
+    0 24px 60px rgba(0, 0, 0, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.site-header-panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(
+      90deg,
+      transparent 0,
+      transparent calc(100% - 72px),
+      rgba(255, 255, 255, 0.08) calc(100% - 72px),
+      rgba(255, 255, 255, 0.08) calc(100% - 48px),
+      transparent calc(100% - 48px)
+    ),
+    linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.06) 0,
+      rgba(255, 255, 255, 0.06) 22px,
+      transparent 22px,
+      transparent 100%
+    );
+}
+
+.site-nav-link {
+  position: relative;
+  font-size: 0.92rem;
+  line-height: 1;
+}
+
+.site-nav-link[aria-current='page']::after {
+  content: '';
+  position: absolute;
+  bottom: -0.4rem;
+  left: 0.55rem;
+  width: 1.3rem;
+  border-bottom: 2px solid currentColor;
+}
+
+.home-shell {
+  position: relative;
+}
+
+.home-hero {
+  position: relative;
+  box-shadow:
+    0 28px 60px rgba(0, 0, 0, 0.26),
+    16px 16px 0 rgba(255, 255, 255, 0.22);
+}
+
+.home-hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(130deg, rgba(255, 255, 255, 0.06) 0 16%, transparent 16% 100%),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.08) 1px, transparent 1px),
+    linear-gradient(rgba(255, 255, 255, 0.06) 1px, transparent 1px);
+  background-size: auto, 28px 28px, 28px 28px;
+  opacity: 0.9;
+}
+
+.home-hero::after {
+  content: '';
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: min(34vw, 18rem);
+  height: min(34vw, 18rem);
+  background: linear-gradient(
+    135deg,
+    transparent 0 45%,
+    rgba(255, 255, 255, 0.09) 45% 55%,
+    transparent 55% 100%
+  );
+  pointer-events: none;
+}
+
+.home-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.06);
+  padding: 0.45rem 0.8rem;
+  font-family: var(--font-ui);
+  font-size: 0.78rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+}
+
+.home-chip::before {
+  content: '';
+  width: 0.7rem;
+  height: 0.7rem;
+  background: white;
+  clip-path: polygon(0 50%, 100% 0, 100% 100%);
+}
+
+.home-panel {
+  position: relative;
+  border: 1px solid rgba(0, 0, 0, 0.7);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(236, 236, 236, 0.94)),
+    repeating-linear-gradient(90deg, rgba(0, 0, 0, 0.02) 0 1px, transparent 1px 14px);
+  padding: 1.15rem;
+}
+
+.home-panel::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 2.5rem;
+  height: 2.5rem;
+  background: linear-gradient(135deg, transparent 0 49.5%, rgba(0, 0, 0, 0.78) 50% 100%);
+}
+
+.home-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  background: rgba(255, 255, 255, 0.56);
+  padding: 0.85rem 0.75rem;
+}
+
+.home-stat__label {
+  font-family: var(--font-ui);
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(0, 0, 0, 0.48);
+}
+
+.home-stat__value {
+  font-family: var(--font-ui);
+  font-size: clamp(1.5rem, 2vw, 1.9rem);
+  line-height: 1;
+  letter-spacing: 0.08em;
+}
+
+.home-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 3rem;
+  border: 1px solid transparent;
+  padding: 0.85rem 1.15rem;
+  font-family: var(--font-ui);
+  font-size: 0.95rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition:
+    transform 180ms ease,
+    background-color 180ms ease,
+    color 180ms ease,
+    border-color 180ms ease;
+}
+
+.home-cta:hover {
+  transform: translateY(-2px);
+}
+
+.home-cta--primary {
+  background: white;
+  color: black;
+}
+
+.home-cta--primary:hover {
+  background: #dfdfdf;
+}
+
+.home-cta--secondary {
+  border-color: rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.04);
+  color: white;
+}
+
+.home-cta--secondary:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.home-rail {
+  position: relative;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.08);
+}
+
+.home-rail::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 10px;
+  background: linear-gradient(90deg, rgba(0, 0, 0, 0.9) 0 14%, transparent 14% 100%);
+}
+
+.home-category-panel {
+  position: relative;
+  border: 1px solid rgba(0, 0, 0, 0.7);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(242, 242, 242, 0.92)),
+    repeating-linear-gradient(90deg, rgba(0, 0, 0, 0.02) 0 1px, transparent 1px 16px);
+  padding: 1.1rem 1.15rem;
+  text-decoration: none;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    background-color 180ms ease;
+}
+
+.home-category-panel::after {
+  content: '';
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 2.6rem;
+  height: 2.6rem;
+  background: linear-gradient(135deg, transparent 0 52%, rgba(0, 0, 0, 0.88) 52% 100%);
+}
+
+.home-category-panel:hover {
+  transform: translateY(-3px);
+  box-shadow: 10px 10px 0 rgba(0, 0, 0, 0.1);
+}
+
+.tactical-card {
+  border-radius: 0;
+}
+
+.tactical-card::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto auto 0;
+  width: 100%;
+  height: 0.45rem;
+  background: linear-gradient(
+    90deg,
+    rgba(0, 0, 0, 0.92) 0 22%,
+    rgba(0, 0, 0, 0.18) 22% 100%
+  );
+}
+
+.tactical-card::after {
+  content: '';
+  position: absolute;
+  right: 0.9rem;
+  top: 0.8rem;
+  width: 2.8rem;
+  height: 2px;
+  background: rgba(0, 0, 0, 0.2);
 }
 
 ::-webkit-scrollbar {
@@ -56,7 +378,15 @@ html {
   color: #e5e7eb;
   padding: 0.125rem 0.375rem;
   border-radius: 0.25rem;
-  font-family: 'Fira Code', 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
+  font-family:
+    'Fira Code',
+    'SF Mono',
+    Monaco,
+    'Cascadia Code',
+    'Roboto Mono',
+    Consolas,
+    'Courier New',
+    monospace;
   font-size: 0.875em;
   font-weight: 600;
 }
@@ -71,7 +401,9 @@ html {
 
 .post-prose figure img {
   border-radius: 0.5rem;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 2px 4px -1px rgba(0, 0, 0, 0.06);
   max-width: 100%;
   height: auto;
   transition: transform 0.2s ease-in-out;
@@ -102,7 +434,15 @@ html {
   margin: 0;
   padding: 1rem;
   overflow-x: auto;
-  font-family: 'Fira Code', 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
+  font-family:
+    'Fira Code',
+    'SF Mono',
+    Monaco,
+    'Cascadia Code',
+    'Roboto Mono',
+    Consolas,
+    'Courier New',
+    monospace;
   font-size: 0.875rem;
   line-height: 1.6;
   background-color: #1a2638;
@@ -134,7 +474,9 @@ html {
   max-width: 550px !important;
   border-radius: 12px !important;
   border: 1px solid #e1e8ed !important;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24) !important;
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.12),
+    0 1px 2px rgba(0, 0, 0, 0.24) !important;
 }
 
 .post-prose iframe[id^='twitter-widget'] {
@@ -245,7 +587,7 @@ html {
 }
 
 .post-prose .directive-info::before {
-  content: 'ⓘ';
+  content: 'i';
 }
 
 .post-prose .directive-alert {
@@ -253,7 +595,7 @@ html {
 }
 
 .post-prose .directive-alert::before {
-  content: '×';
+  content: 'x';
 }
 
 .post-prose .directive-warn {
@@ -261,5 +603,29 @@ html {
 }
 
 .post-prose .directive-warn::before {
-  content: '⚠';
+  content: '!';
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+@media (max-width: 767px) {
+  .site-nav-link[aria-current='page']::after {
+    left: 0.5rem;
+    width: 1rem;
+  }
+
+  .home-hero {
+    box-shadow:
+      0 24px 40px rgba(0, 0, 0, 0.22),
+      8px 8px 0 rgba(255, 255, 255, 0.24);
+  }
 }

--- a/apps/astro-blog/src/components/Header.astro
+++ b/apps/astro-blog/src/components/Header.astro
@@ -19,19 +19,26 @@ function isActive(href: string): boolean {
 ---
 
 <header class="sticky top-0 z-50 w-full px-4 py-4">
-  <div
-    class="mx-auto max-w-6xl rounded-2xl border border-gray-200/50 bg-gradient-to-br from-white to-gray-50 px-6 py-4 shadow-xl shadow-gray-900/10 sm:px-8 lg:px-10"
-  >
-    <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-      <a href="/" class="text-xl font-bold text-gray-900 no-underline">{SITE_TITLE}</a>
+  <div class="site-header-panel mx-auto max-w-6xl border border-white/12 bg-black/92 px-5 py-4 sm:px-7 lg:px-8">
+    <div class="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+      <a href="/" class="flex flex-col gap-1 no-underline">
+        <span class="font-ui text-xs uppercase tracking-[0.32em] text-white/55">
+          Monochrome Archive
+        </span>
+        <span class="text-xl font-semibold tracking-[0.08em] text-white sm:text-2xl">
+          {SITE_TITLE}
+        </span>
+      </a>
       <nav aria-label="Main navigation">
-        <ul class="flex flex-wrap gap-2 text-sm font-medium md:gap-4 md:text-base">
+        <ul class="flex flex-wrap gap-2 text-sm font-medium md:gap-3">
           {NAVIGATION_LINKS.map(({ label, href }) => (
             <li>
               <a
                 href={href}
-                class={`block rounded-md px-2 py-2 transition-colors hover:bg-gray-100 hover:text-gray-900 ${
-                  isActive(href) ? 'bg-gray-100 font-semibold text-gray-900' : 'text-gray-600'
+                class={`site-nav-link font-ui block border px-3 py-2 uppercase tracking-[0.22em] transition ${
+                  isActive(href)
+                    ? 'border-white bg-white text-black'
+                    : 'border-white/12 bg-white/[0.03] text-white/68 hover:border-white/35 hover:bg-white/[0.08] hover:text-white'
                 }`}
                 aria-current={isActive(href) ? 'page' : undefined}
               >

--- a/apps/astro-blog/src/components/Pagination.astro
+++ b/apps/astro-blog/src/components/Pagination.astro
@@ -4,9 +4,11 @@ interface Props {
   totalPages: number;
   baseUrl: string;
   maxVisible?: number;
+  variant?: 'default' | 'tactical';
 }
 
-const { currentPage, totalPages, baseUrl, maxVisible = 5 } = Astro.props;
+const { currentPage, totalPages, baseUrl, maxVisible = 5, variant = 'default' } = Astro.props;
+const isTactical = variant === 'tactical';
 
 function getPageUrl(page: number): string {
   if (page === 1) {
@@ -36,24 +38,48 @@ function getPageNumbers(): number[] {
   return Array.from({ length: endPage - startPage + 1 }, (_, i) => startPage + i);
 }
 
+function getPageItemClass(active = false): string {
+  if (isTactical) {
+    return active ?
+        'font-ui flex h-10 w-10 items-center justify-center border border-black bg-black text-white'
+      : 'font-ui flex h-10 w-10 items-center justify-center border border-black/70 bg-white text-black transition hover:bg-black hover:text-white';
+  }
+
+  return active ?
+      'flex h-10 w-10 items-center justify-center rounded-md border border-blue-500 bg-blue-500 font-medium text-white'
+    : 'flex h-10 w-10 items-center justify-center rounded-md border border-gray-300 bg-white text-gray-700 transition hover:bg-gray-50';
+}
+
+function getArrowClass(disabled = false): string {
+  if (isTactical) {
+    return disabled ?
+        'font-ui flex h-10 min-w-10 cursor-not-allowed items-center justify-center border border-black/12 bg-black/10 px-3 text-black/30'
+      : 'font-ui flex h-10 min-w-10 items-center justify-center border border-black bg-black px-3 text-white transition hover:bg-neutral-800';
+  }
+
+  return disabled ?
+      'flex h-10 min-w-10 cursor-not-allowed items-center justify-center rounded-md border border-gray-200 bg-gray-100 px-3 text-gray-400'
+    : 'flex h-10 min-w-10 items-center justify-center rounded-md border border-gray-300 bg-white px-3 text-gray-500 transition hover:bg-gray-50';
+}
+
 const pageNumbers = getPageNumbers();
 const lastPageNumber = pageNumbers[pageNumbers.length - 1];
 ---
 
-<nav aria-label="ページネーション" class="my-8 flex justify-center">
-  <ul class="flex items-center space-x-1">
+<nav aria-label="Pagination" class="my-8 flex justify-center">
+  <ul class:list={['flex items-center space-x-1', isTactical && 'gap-1.5']}>
     <li>
       {currentPage > 1 ? (
         <a
           href={getPageUrl(currentPage - 1)}
-          class="flex h-10 w-10 items-center justify-center rounded-md border border-gray-300 bg-white text-gray-500 hover:bg-gray-50"
-          aria-label="前のページ"
+          class={getArrowClass()}
+          aria-label="Previous page"
         >
-          ‹
+          {isTactical ? 'PRV' : '<'}
         </a>
       ) : (
-        <span class="flex h-10 w-10 cursor-not-allowed items-center justify-center rounded-md border border-gray-200 bg-gray-100 text-gray-400" aria-disabled="true">
-          ‹
+        <span class={getArrowClass(true)} aria-disabled="true">
+          {isTactical ? 'PRV' : '<'}
         </span>
       )}
     </li>
@@ -61,18 +87,28 @@ const lastPageNumber = pageNumbers[pageNumbers.length - 1];
     {pageNumbers[0] && pageNumbers[0] > 1 && (
       <>
         <li>
-          <a href={getPageUrl(1)} class="flex h-10 w-10 items-center justify-center rounded-md border border-gray-300 bg-white text-gray-700 hover:bg-gray-50" aria-label="1ページ目">1</a>
+          <a href={getPageUrl(1)} class={getPageItemClass()} aria-label="Page 1">
+            1
+          </a>
         </li>
-        {pageNumbers[0] > 2 && <li><span class="flex h-10 w-10 items-center justify-center text-gray-500">...</span></li>}
+        {pageNumbers[0] > 2 && (
+          <li>
+            <span class:list={['flex h-10 w-10 items-center justify-center', isTactical ? 'font-ui text-black/50' : 'text-gray-500']}>
+              ...
+            </span>
+          </li>
+        )}
       </>
     )}
 
     {pageNumbers.map((page) => (
       <li>
         {page === currentPage ? (
-          <span class="flex h-10 w-10 items-center justify-center rounded-md border border-blue-500 bg-blue-500 font-medium text-white" aria-current="page">{page}</span>
+          <span class={getPageItemClass(true)} aria-current="page">
+            {page}
+          </span>
         ) : (
-          <a href={getPageUrl(page)} class="flex h-10 w-10 items-center justify-center rounded-md border border-gray-300 bg-white text-gray-700 hover:bg-gray-50" aria-label={`${page}ページ目`}>
+          <a href={getPageUrl(page)} class={getPageItemClass()} aria-label={`Page ${page}`}>
             {page}
           </a>
         )}
@@ -81,9 +117,15 @@ const lastPageNumber = pageNumbers[pageNumbers.length - 1];
 
     {lastPageNumber && lastPageNumber < totalPages && (
       <>
-        {lastPageNumber < totalPages - 1 && <li><span class="flex h-10 w-10 items-center justify-center text-gray-500">...</span></li>}
+        {lastPageNumber < totalPages - 1 && (
+          <li>
+            <span class:list={['flex h-10 w-10 items-center justify-center', isTactical ? 'font-ui text-black/50' : 'text-gray-500']}>
+              ...
+            </span>
+          </li>
+        )}
         <li>
-          <a href={getPageUrl(totalPages)} class="flex h-10 w-10 items-center justify-center rounded-md border border-gray-300 bg-white text-gray-700 hover:bg-gray-50" aria-label={`${totalPages}ページ目`}>
+          <a href={getPageUrl(totalPages)} class={getPageItemClass()} aria-label={`Page ${totalPages}`}>
             {totalPages}
           </a>
         </li>
@@ -92,16 +134,12 @@ const lastPageNumber = pageNumbers[pageNumbers.length - 1];
 
     <li>
       {currentPage < totalPages ? (
-        <a
-          href={getPageUrl(currentPage + 1)}
-          class="flex h-10 w-10 items-center justify-center rounded-md border border-gray-300 bg-white text-gray-500 hover:bg-gray-50"
-          aria-label="次のページ"
-        >
-          ›
+        <a href={getPageUrl(currentPage + 1)} class={getArrowClass()} aria-label="Next page">
+          {isTactical ? 'NXT' : '>'}
         </a>
       ) : (
-        <span class="flex h-10 w-10 cursor-not-allowed items-center justify-center rounded-md border border-gray-200 bg-gray-100 text-gray-400" aria-disabled="true">
-          ›
+        <span class={getArrowClass(true)} aria-disabled="true">
+          {isTactical ? 'NXT' : '>'}
         </span>
       )}
     </li>

--- a/apps/astro-blog/src/components/PostCard.astro
+++ b/apps/astro-blog/src/components/PostCard.astro
@@ -3,9 +3,11 @@ import type { PostMeta } from '@estrivault/content-processor';
 
 interface Props {
   post: PostMeta;
+  variant?: 'default' | 'tactical';
 }
 
-const { post } = Astro.props;
+const { post, variant = 'default' } = Astro.props;
+const isTactical = variant === 'tactical';
 
 const dateString = new Intl.DateTimeFormat('ja-JP', {
   year: 'numeric',
@@ -18,35 +20,103 @@ const dateString = new Intl.DateTimeFormat('ja-JP', {
 
 <a href={`/post/${post.slug}`} class="block h-full" aria-label={post.title}>
   <article
-    class="group relative flex h-full transform flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition-all duration-100 ease-out hover:scale-[1.01] hover:border-gray-300 hover:shadow-md"
+    class:list={[
+      'group relative flex h-full transform flex-col overflow-hidden transition-all duration-150 ease-out',
+      isTactical
+        ? 'tactical-card border border-black/85 bg-[var(--panel-soft)] text-[var(--ink-1)] shadow-[10px_10px_0_rgba(0,0,0,0.14)] hover:-translate-y-1 hover:shadow-[14px_14px_0_rgba(0,0,0,0.18)]'
+        : 'rounded-xl border border-gray-200 bg-white shadow-sm hover:scale-[1.01] hover:border-gray-300 hover:shadow-md',
+    ]}
     data-testid="post-card"
   >
     <header>
       {post.coverImage && (
-        <figure class="relative w-full overflow-hidden pt-[56.25%]">
-          <img src={post.coverImage} alt={post.title} class="absolute inset-0 h-full w-full object-cover" loading="lazy" />
+        <figure
+          class:list={[
+            'relative w-full overflow-hidden pt-[56.25%]',
+            isTactical && 'border-b border-black/80',
+          ]}
+        >
+          <img
+            src={post.coverImage}
+            alt={post.title}
+            class:list={[
+              'absolute inset-0 h-full w-full object-cover',
+              isTactical && 'transition duration-300 grayscale-[28%] group-hover:scale-[1.03]',
+            ]}
+            loading="lazy"
+          />
+          {
+            isTactical && (
+              <div class="absolute inset-0 bg-[linear-gradient(180deg,transparent_0%,rgba(0,0,0,0.08)_100%)]"></div>
+            )
+          }
         </figure>
       )}
 
-      <div class="flex flex-col justify-between p-4 font-sans text-gray-800">
+      <div
+        class:list={[
+          'flex flex-col justify-between text-gray-800',
+          isTactical ? 'gap-3 p-5' : 'p-4 font-sans',
+        ]}
+      >
         <div class="space-y-1">
-          <div class="flex items-center justify-between">
-            <p class="text-xs uppercase tracking-wide text-gray-500">{post.category}</p>
-            <time datetime={post.publishedAt.toISOString()} class="text-xs text-gray-500">{dateString}</time>
+          <div class="flex items-center justify-between gap-4">
+            <p
+              class:list={[
+                'text-xs uppercase tracking-wide text-gray-500',
+                isTactical && 'font-ui tracking-[0.22em] text-black/58',
+              ]}
+            >
+              {post.category}
+            </p>
+            <time
+              datetime={post.publishedAt.toISOString()}
+              class:list={[
+                'text-xs text-gray-500',
+                isTactical && 'font-ui tracking-[0.18em] text-black/52',
+              ]}
+            >
+              {dateString}
+            </time>
           </div>
-          <h2 class="text-lg font-semibold text-gray-900 transition-colors group-hover:text-blue-600">{post.title}</h2>
+          <h2
+            class:list={[
+              'text-lg font-semibold text-gray-900 transition-colors',
+              isTactical ? 'leading-snug group-hover:text-black/70' : 'group-hover:text-blue-600',
+            ]}
+          >
+            {post.title}
+          </h2>
         </div>
       </div>
     </header>
 
-    <section class="flex-1 px-4 text-sm text-gray-700">
+    <section
+      class:list={[
+        'flex-1 text-sm text-gray-700',
+        isTactical ? 'px-5 pb-2 text-[0.95rem] leading-7 text-black/72' : 'px-4',
+      ]}
+    >
       <p class="line-clamp-2">{post.description}</p>
     </section>
 
-    <footer class="p-4">
-      <ul class="mt-2 flex shrink-0 flex-wrap gap-2 text-xs text-gray-500">
+    <footer class:list={[isTactical ? 'p-5 pt-4' : 'p-4']}>
+      <ul
+        class:list={[
+          'mt-2 flex shrink-0 flex-wrap gap-2 text-xs text-gray-500',
+          isTactical && 'font-ui uppercase tracking-[0.18em] text-black/55',
+        ]}
+      >
         {post.tags.map((tag) => (
-          <li class="rounded bg-gray-100 px-2 py-0.5">{tag}</li>
+          <li
+            class:list={[
+              isTactical
+                ? 'border border-black/15 bg-black/[0.045] px-2 py-1'
+                : 'rounded bg-gray-100 px-2 py-0.5',
+            ]}
+          >
+            {tag}
+          </li>
         ))}
       </ul>
     </footer>

--- a/apps/astro-blog/src/layouts/BaseLayout.astro
+++ b/apps/astro-blog/src/layouts/BaseLayout.astro
@@ -45,6 +45,12 @@ const pathname = Astro.url.pathname;
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" href="/icon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@400;500;600;700&family=IBM+Plex+Sans+JP:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
 
     <title>{title}</title>
     <meta name="description" content={description} />
@@ -91,10 +97,15 @@ const pathname = Astro.url.pathname;
       <script is:inline type="application/ld+json" set:html={JSON.stringify(jsonLd)}></script>
     )}
   </head>
-  <body>
+  <body class="site-body" data-route={pathname}>
     <Header pathname={pathname} />
 
-    <main class="mx-auto w-full max-w-6xl px-4 py-4">
+    <main
+      class:list={[
+        'site-main mx-auto w-full max-w-6xl px-4 py-4 sm:py-6',
+        pathname === '/' && 'site-main--home',
+      ]}
+    >
       <slot />
     </main>
 

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -3,23 +3,161 @@ import BaseLayout from '$layouts/BaseLayout.astro';
 import Pagination from '$components/Pagination.astro';
 import PostCard from '$components/PostCard.astro';
 import { POSTS_PER_PAGE, SITE_DESCRIPTION, SITE_TITLE, SITE_URL } from '$constants';
-import { getPosts } from '$lib/content';
+import { getAllCategories, getPosts } from '$lib/content';
 
 const pageData = await getPosts({ page: 1, perPage: POSTS_PER_PAGE });
+const categories = await getAllCategories();
+const latestPublishedAt = pageData.posts[0]?.publishedAt;
+const latestPublishedLabel =
+  latestPublishedAt ?
+    new Intl.DateTimeFormat('ja-JP', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    })
+      .format(latestPublishedAt)
+      .replace(/\//g, '.')
+  : 'N/A';
 ---
 
 <BaseLayout title={SITE_TITLE} description={SITE_DESCRIPTION} canonical={SITE_URL}>
   <h1 class="sr-only">{SITE_TITLE}</h1>
 
-  <div class="grid gap-8 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
-    {pageData.posts.map((post) => (
-      <PostCard post={post} />
-    ))}
+  <div class="home-shell space-y-10 pb-10">
+    <section class="home-hero overflow-hidden border border-black bg-[var(--panel-strong)] text-white">
+      <div class="grid gap-6 p-6 sm:p-8 lg:grid-cols-[minmax(0,1.55fr)_minmax(18rem,0.95fr)] lg:p-10">
+        <div class="space-y-6">
+          <div class="space-y-4">
+            <p class="font-ui text-sm uppercase tracking-[0.34em] text-white/55">
+              Archive / Surface 01
+            </p>
+            <div class="space-y-4">
+              <p class="home-chip">Record Layered Notes</p>
+              <h2 class="max-w-3xl text-3xl font-semibold leading-tight text-white sm:text-4xl lg:text-5xl">
+                技術と投資と趣味の記録を、
+                <br />
+                白と黒の情報層として積み上げる。
+              </h2>
+              <p class="max-w-2xl text-sm leading-7 text-white/72 sm:text-base">
+                空気感は無機質に、導線は明快に。落ち着いた緊張感を持つインターフェースの中へ、
+                最新の考察やメモを整理して収めています。
+              </p>
+            </div>
+          </div>
+
+          <div class="flex flex-col gap-3 sm:flex-row">
+            <a href="#latest-posts" class="home-cta home-cta--primary">Latest Posts</a>
+            <a href="/post/about" class="home-cta home-cta--secondary">About Archive</a>
+          </div>
+        </div>
+
+        <div class="grid gap-4">
+          <section class="home-panel space-y-4">
+            <div class="flex items-center justify-between">
+              <p class="font-ui text-xs uppercase tracking-[0.28em] text-black/55">System Index</p>
+              <span class="font-ui text-xs tracking-[0.22em] text-black/45">JP</span>
+            </div>
+            <div class="grid grid-cols-3 gap-3">
+              <div class="home-stat">
+                <span class="home-stat__label">Posts</span>
+                <strong class="home-stat__value">{pageData.total}</strong>
+              </div>
+              <div class="home-stat">
+                <span class="home-stat__label">Fields</span>
+                <strong class="home-stat__value">{categories.length}</strong>
+              </div>
+              <div class="home-stat">
+                <span class="home-stat__label">Shown</span>
+                <strong class="home-stat__value">{pageData.posts.length}</strong>
+              </div>
+            </div>
+          </section>
+
+          <section class="home-panel space-y-4">
+            <div class="space-y-2">
+              <p class="font-ui text-xs uppercase tracking-[0.28em] text-black/55">Signal Log</p>
+              <p class="text-sm leading-7 text-black/72">
+                新着の更新を軸に、カテゴリー別の導線と一覧性を並べて配置しています。
+              </p>
+            </div>
+            <dl class="space-y-3 border-t border-black/10 pt-4 text-sm text-black/72">
+              <div class="flex items-center justify-between gap-4">
+                <dt class="font-ui uppercase tracking-[0.18em] text-black/45">Last Update</dt>
+                <dd>{latestPublishedLabel}</dd>
+              </div>
+              <div class="flex items-center justify-between gap-4">
+                <dt class="font-ui uppercase tracking-[0.18em] text-black/45">Structure</dt>
+                <dd>Monochrome / Grid / Panel</dd>
+              </div>
+            </dl>
+          </section>
+        </div>
+      </div>
+    </section>
+
+    <section class="home-rail border border-black/10 bg-white p-5 sm:p-6">
+      <div class="mb-5 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+        <div class="space-y-2">
+          <p class="font-ui text-xs uppercase tracking-[0.28em] text-black/45">
+            Category Axis
+          </p>
+          <h2 class="text-2xl font-semibold tracking-[0.04em] text-black">探索導線</h2>
+        </div>
+        <p class="max-w-2xl text-sm leading-7 text-black/62">
+          カテゴリーごとに思考の断面へ直接入れるよう、コンパクトな操作パネルとして整理しています。
+        </p>
+      </div>
+
+      <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {categories.map((category, index) => (
+          <a
+            href={`/category/${encodeURIComponent(category.toLowerCase())}/1`}
+            class="home-category-panel group"
+          >
+            <span class="font-ui text-xs uppercase tracking-[0.26em] text-black/42">
+              Axis {String(index + 1).padStart(2, '0')}
+            </span>
+            <strong class="mt-3 block text-lg font-semibold tracking-[0.06em] text-black">
+              {category}
+            </strong>
+            <span class="mt-6 inline-flex items-center gap-2 font-ui text-xs uppercase tracking-[0.22em] text-black/58">
+              Open Channel
+              <span aria-hidden="true">/</span>
+            </span>
+          </a>
+        ))}
+      </div>
+    </section>
+
+    <section id="latest-posts" class="space-y-6">
+      <div class="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+        <div class="space-y-2">
+          <p class="font-ui text-xs uppercase tracking-[0.28em] text-black/45">Latest Entries</p>
+          <h2 class="text-2xl font-semibold tracking-[0.04em] text-black sm:text-3xl">
+            最新の記事
+          </h2>
+        </div>
+        <p class="max-w-2xl text-sm leading-7 text-black/62">
+          直近の投稿をモノクロのパネルとして一覧化しています。気になる記録からそのまま奥へ進めます。
+        </p>
+      </div>
+
+      <div class="grid gap-6 sm:grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
+        {pageData.posts.map((post) => (
+          <PostCard post={post} variant="tactical" />
+        ))}
+      </div>
+    </section>
   </div>
 
   {pageData.totalPages > 1 && (
     <div class="mt-12">
-      <Pagination currentPage={pageData.page} totalPages={pageData.totalPages} baseUrl="/" />
+      <Pagination
+        currentPage={pageData.page}
+        totalPages={pageData.totalPages}
+        baseUrl="/"
+        variant="tactical"
+      />
     </div>
   )}
 </BaseLayout>

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -133,9 +133,7 @@ const latestPublishedLabel =
       <div class="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
         <div class="space-y-2">
           <p class="font-ui text-xs uppercase tracking-[0.28em] text-black/45">Latest Entries</p>
-          <h2 class="text-2xl font-semibold tracking-[0.04em] text-black sm:text-3xl">
-            最新の記事
-          </h2>
+          <h2 class="text-2xl font-semibold tracking-[0.04em] text-black sm:text-3xl">最新の記事</h2>
         </div>
         <p class="max-w-2xl text-sm leading-7 text-black/62">
           直近の投稿をモノクロのパネルとして一覧化しています。気になる記録からそのまま奥へ進めます。


### PR DESCRIPTION
## Summary
- redesign the homepage with an Arknights-inspired monochrome tactical aesthetic
- add a new hero, category rail, and tactical variants for homepage post cards and pagination
- restyle the shared header and add typography/theme tokens for the new monochrome direction

## Validation
- git diff --check
- Astro/type checks not run in this environment because workspace dependencies are not installed and pnpm is not initialized in WSL via mise
