### PR TITLE
Add isolated design preview variants

### DIFF
--- a/apps/astro-blog/e2e/design-preview.test.ts
+++ b/apps/astro-blog/e2e/design-preview.test.ts
@@ -1,9 +1,10 @@
 import { expect, test } from '@playwright/test';
 
 const previewRoutes = [
-  '/design-preview/industrial-slate',
-  '/design-preview/archive-grid',
-  '/design-preview/signal-frame',
+  '/design-preview/blue-palette',
+  '/design-preview/luxury-01',
+  '/design-preview/luxury-04',
+  '/design-preview/luxury-07',
 ];
 
 for (const route of previewRoutes) {
@@ -15,6 +16,6 @@ for (const route of previewRoutes) {
       'noindex, nofollow',
     );
     await expect(page.locator('.dp-switcher')).toBeVisible();
-    await expect(page.locator('.dp-featured-card, .dp-empty-state').first()).toBeVisible();
+    await expect(page.locator('.dp-index-shell, .dp-empty-state').first()).toBeVisible();
   });
 }

--- a/apps/astro-blog/e2e/design-preview.test.ts
+++ b/apps/astro-blog/e2e/design-preview.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 const previewRoutes = [
-  '/design-preview/blue-palette',
+  '/design-preview/white-palette',
   '/design-preview/luxury-01',
   '/design-preview/luxury-04',
   '/design-preview/luxury-07',

--- a/apps/astro-blog/e2e/design-preview.test.ts
+++ b/apps/astro-blog/e2e/design-preview.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@playwright/test';
+
+const previewRoutes = [
+  '/design-preview/industrial-slate',
+  '/design-preview/archive-grid',
+  '/design-preview/signal-frame',
+];
+
+for (const route of previewRoutes) {
+  test(`design preview route renders for ${route}`, async ({ page }) => {
+    await page.goto(route);
+
+    await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
+      'content',
+      'noindex, nofollow',
+    );
+    await expect(page.locator('.dp-switcher')).toBeVisible();
+    await expect(page.locator('.dp-featured-card, .dp-empty-state').first()).toBeVisible();
+  });
+}

--- a/apps/astro-blog/src/components/DesignPreviewPage.astro
+++ b/apps/astro-blog/src/components/DesignPreviewPage.astro
@@ -1,12 +1,7 @@
 ---
 import type { PostMeta } from '@estrivault/content-processor';
 import { SITE_TITLE } from '$constants';
-import {
-  INDEX_FRAME_THEMES,
-  type DesignPreviewModel,
-  type DesignPreviewTheme,
-  type IndexFrameTheme,
-} from '$lib/design-preview';
+import type { DesignPreviewModel, DesignPreviewTheme } from '$lib/design-preview';
 import { getTagRouteSegment } from '$lib/url-segments';
 
 interface Props {
@@ -15,7 +10,6 @@ interface Props {
 }
 
 const { model, theme } = Astro.props;
-const variant = theme.variant;
 
 function formatDate(date: Date): string {
   return new Intl.DateTimeFormat('ja-JP', {
@@ -34,356 +28,148 @@ function getReadingTimeLabel(post: PostMeta): string {
   return `${minutes} min read`;
 }
 
-function getIndexThemeStyle(theme: IndexFrameTheme): string {
-  return [
-    `--if-rail:${theme.rail}`,
-    `--if-accent:${theme.accent}`,
-    `--if-accent-soft:${theme.accentSoft}`,
-    `--if-surface:${theme.surface}`,
-    `--if-border:${theme.border}`,
-    `--if-text:${theme.text}`,
-    `--if-text-soft:${theme.textSoft}`,
-  ].join(';');
-}
-
 const featuredPost = model.featuredPost;
-const bannerPosts = model.posts.slice(0, 3);
 ---
 
-<div class={`design-preview design-preview--${variant}`}>
-  {
-    variant !== 'signal-frame' && (
-      <section class={`dp-masthead ${variant === 'archive-grid' ? 'dp-masthead--banner' : ''}`}>
-        <div class="dp-masthead__copy">
-          <p class="dp-kicker">{theme.kicker}</p>
-          <p class="dp-masthead__statement">{theme.title}</p>
-          <h1 class="dp-masthead__site">{SITE_TITLE}</h1>
-          <p class="dp-masthead__description">{theme.description}</p>
-          <p class="dp-masthead__summary">{theme.summary}</p>
+<div class="design-preview design-preview--index">
+  <section class="dp-index-shell">
+    <header class="dp-index-header">
+      <div class="dp-index-header__copy">
+        <p class="dp-kicker">{theme.kicker}</p>
+        <h1 class="dp-index-header__title">{SITE_TITLE}</h1>
+        <p class="dp-index-header__statement">{theme.title}</p>
+        <p class="dp-index-header__description">{theme.description}</p>
+      </div>
+
+      <aside class="dp-index-header__aside">
+        <div class="dp-index-header__summary">
+          <p class="dp-kicker">Palette intent</p>
+          <p class="dp-index-header__summary-copy">{theme.summary}</p>
         </div>
 
-        <dl class="dp-masthead__stats" aria-label="Preview summary">
-          <div class="dp-masthead__stat">
+        <ul class="dp-palette" aria-label={`${theme.name} palette swatches`}>
+          {
+            theme.swatches.map((swatch) => (
+              <li class="dp-palette__item">
+                <span class="dp-palette__dot" style={`background:${swatch};`} aria-hidden="true" />
+                <span class="dp-palette__code">{swatch}</span>
+              </li>
+            ))
+          }
+        </ul>
+
+        <dl class="dp-index-header__stats" aria-label="Preview summary">
+          <div>
             <dt>Lead category</dt>
             <dd>{model.stats.leadCategoryLabel}</dd>
           </div>
-          <div class="dp-masthead__stat">
+          <div>
             <dt>Categories</dt>
             <dd>{model.stats.categoryCount}</dd>
           </div>
-          <div class="dp-masthead__stat">
+          <div>
             <dt>Posts</dt>
             <dd>{model.stats.totalPosts}</dd>
           </div>
-          <div class="dp-masthead__stat">
+          <div>
             <dt>Avg read</dt>
             <dd>{model.stats.averageReadingMinutes || '-'} min</dd>
           </div>
         </dl>
-      </section>
-    )
-  }
+      </aside>
+    </header>
 
-  {
-    variant === 'industrial-slate' && (
-      <section class="dp-variant dp-variant--monolith">
-        {featuredPost ?
-          <a
-            href={`/post/${featuredPost.slug}`}
-            class="dp-featured-card dp-featured-card--monolith"
-          >
-            <p class="dp-entry__category">
-              <span>Category</span>
-              <strong>{featuredPost.category}</strong>
-            </p>
-            <h2 class="dp-featured-card__title">{featuredPost.title}</h2>
-            <p class="dp-featured-card__description">{featuredPost.description}</p>
-            <div class="dp-entry__secondary">
-              <span>{formatDate(featuredPost.publishedAt)}</span>
-              <span>{getReadingTimeLabel(featuredPost)}</span>
-            </div>
-          </a>
-        : <div class="dp-empty-state">No published posts were available for the preview.</div>}
+    <div class="dp-index-head" aria-hidden="true">
+      <span>Metadata</span>
+      <span>Entry</span>
+    </div>
 
-        <section class="dp-list-section">
-          <div class="dp-section-heading">
-            <p class="dp-kicker">Reading field</p>
-            <h2 class="dp-section-heading__title">A single, uninterrupted top-page rhythm</h2>
-          </div>
-
-          <div class="dp-list dp-list--monolith">
-            {model.posts.map((post) => (
-              <a href={`/post/${post.slug}`} class="dp-entry dp-entry--monolith">
-                <p class="dp-entry__category">
-                  <span>Category</span>
-                  <strong>{post.category}</strong>
-                </p>
-                <h3 class="dp-entry__title">{post.title}</h3>
-                <p class="dp-entry__description">{post.description}</p>
-                <div class="dp-entry__secondary">
-                  <span>{formatDate(post.publishedAt)}</span>
-                  <span>{getReadingTimeLabel(post)}</span>
-                </div>
-              </a>
-            ))}
-          </div>
-        </section>
-
-        <section class="dp-support-row">
-          <div class="dp-support-block">
-            <p class="dp-kicker">Categories</p>
-            <ul class="dp-support-list" aria-label="Sample categories">
-              {model.sampleCategories.map((category) => (
-                <li>
-                  <a href={getCategoryHref(category)}>{category}</a>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          <div class="dp-support-block">
-            <p class="dp-kicker">Pagination sample</p>
-            <nav class="dp-pagination-sample" aria-label="Pagination sample">
-              <span class="dp-pagination-sample__button" aria-hidden="true">
-                Prev
-              </span>
-              <span class="dp-pagination-sample__button is-current" aria-current="page">
-                1
-              </span>
-              <span class="dp-pagination-sample__button" aria-hidden="true">
-                2
-              </span>
-              <span class="dp-pagination-sample__button" aria-hidden="true">
-                3
-              </span>
-            </nav>
-          </div>
-        </section>
-      </section>
-    )
-  }
-
-  {
-    variant === 'archive-grid' && (
-      <section class="dp-variant dp-variant--banner">
-        <div class="dp-banner-panel">
-          <p class="dp-kicker">Site face</p>
-          <p class="dp-banner-panel__lede">
-            A white, disciplined top page where category markers cut the field before the article
-            titles take over.
-          </p>
-        </div>
-
-        <div class="dp-banner-grid">
-          {featuredPost ?
-            <a
-              href={`/post/${featuredPost.slug}`}
-              class="dp-featured-card dp-featured-card--banner"
-            >
-              <p class="dp-entry__category">
-                <span>Primary category</span>
+    {
+      featuredPost ?
+        <a href={`/post/${featuredPost.slug}`} class="dp-featured-card dp-featured-card--index">
+          <div class="dp-index-row dp-index-row--featured">
+            <div class="dp-index-row__meta-rail">
+              <p class="dp-index-row__category">
+                <span>Lead category</span>
                 <strong>{featuredPost.category}</strong>
               </p>
+              <div class="dp-index-row__secondary">
+                <span>Published {formatDate(featuredPost.publishedAt)}</span>
+                <span>Reading {getReadingTimeLabel(featuredPost)}</span>
+              </div>
+            </div>
+            <div class="dp-index-row__body">
               <h2 class="dp-featured-card__title">{featuredPost.title}</h2>
               <p class="dp-featured-card__description">{featuredPost.description}</p>
-              <div class="dp-entry__secondary">
-                <span>{formatDate(featuredPost.publishedAt)}</span>
-                <span>{getReadingTimeLabel(featuredPost)}</span>
-              </div>
-            </a>
-          : <div class="dp-empty-state">No published posts were available for the preview.</div>}
+            </div>
+          </div>
+        </a>
+      : <div class="dp-empty-state">No published posts were available for the preview.</div>
+    }
 
-          <div class="dp-banner-stack">
-            {bannerPosts.map((post) => (
-              <a href={`/post/${post.slug}`} class="dp-entry dp-entry--banner">
-                <p class="dp-entry__category">
+    <div class="dp-index-list">
+      {
+        model.posts.map((post) => (
+          <a href={`/post/${post.slug}`} class="dp-entry dp-entry--index">
+            <div class="dp-index-row">
+              <div class="dp-index-row__meta-rail">
+                <p class="dp-index-row__category">
                   <span>Category</span>
                   <strong>{post.category}</strong>
                 </p>
+                <div class="dp-index-row__secondary">
+                  <span>Published {formatDate(post.publishedAt)}</span>
+                  <span>Reading {getReadingTimeLabel(post)}</span>
+                </div>
+              </div>
+              <div class="dp-index-row__body">
                 <h3 class="dp-entry__title">{post.title}</h3>
                 <p class="dp-entry__description">{post.description}</p>
-                <div class="dp-entry__secondary">
-                  <span>{formatDate(post.publishedAt)}</span>
-                </div>
-              </a>
-            ))}
-          </div>
-        </div>
-
-        <section class="dp-support-row dp-support-row--banner">
-          <div class="dp-support-block">
-            <p class="dp-kicker">Top categories</p>
-            <ul class="dp-support-list" aria-label="Sample categories">
-              {model.sampleCategories.map((category) => (
-                <li>
-                  <a href={getCategoryHref(category)}>{category}</a>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          <div class="dp-support-block">
-            <p class="dp-kicker">Selected tags</p>
-            <ul class="dp-chip-list" aria-label="Sample tags">
-              {model.sampleTags.slice(0, 6).map((tag) => (
-                <li>
-                  <a class="dp-chip-list__item" href={`/tag/${getTagRouteSegment(tag)}/1`}>
-                    {tag}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </section>
-      </section>
-    )
-  }
-
-  {
-    variant === 'signal-frame' && (
-      <section class="dp-variant dp-variant--index">
-        <div class="dp-index-shell">
-          <header class="dp-index-header">
-            <div class="dp-index-header__copy">
-              <p class="dp-kicker">Index frame</p>
-              <h2 class="dp-index-header__title">{SITE_TITLE}</h2>
-              <p class="dp-index-header__statement">{theme.title}</p>
-              <p class="dp-index-header__description">
-                Category, publication date, and reading time all sit on the left rail so the title
-                block can stay optically clean.
-              </p>
-            </div>
-
-            <div class="dp-index-header__meta">
-              <div>
-                <span>Lead category</span>
-                <strong>{model.stats.leadCategoryLabel}</strong>
-              </div>
-              <div>
-                <span>Palette studies</span>
-                <strong>{INDEX_FRAME_THEMES.length}</strong>
               </div>
             </div>
-          </header>
+          </a>
+        ))
+      }
+    </div>
 
-          <div class="dp-index-head" aria-hidden="true">
-            <span>Metadata</span>
-            <span>Entry</span>
-          </div>
+    <section class="dp-support-row">
+      <div class="dp-support-block">
+        <p class="dp-kicker">Categories</p>
+        <ul class="dp-support-list" aria-label="Sample categories">
+          {
+            model.sampleCategories.map((category) => (
+              <li>
+                <a href={getCategoryHref(category)}>{category}</a>
+              </li>
+            ))
+          }
+        </ul>
+      </div>
 
-          {featuredPost ?
-            <a href={`/post/${featuredPost.slug}`} class="dp-featured-card dp-featured-card--index">
-              <div class="dp-index-row dp-index-row--featured">
-                <div class="dp-index-row__meta-rail">
-                  <p class="dp-index-row__category">
-                    <span>Lead category</span>
-                    <strong>{featuredPost.category}</strong>
-                  </p>
-                  <div class="dp-index-row__secondary">
-                    <span>{formatDate(featuredPost.publishedAt)}</span>
-                    <span>{getReadingTimeLabel(featuredPost)}</span>
-                  </div>
-                </div>
-                <div class="dp-index-row__body">
-                  <h2 class="dp-featured-card__title">{featuredPost.title}</h2>
-                  <p class="dp-featured-card__description">{featuredPost.description}</p>
-                </div>
-              </div>
-            </a>
-          : <div class="dp-empty-state">No published posts were available for the preview.</div>}
+      <div class="dp-support-block">
+        <p class="dp-kicker">Selected tags</p>
+        <ul class="dp-chip-list" aria-label="Sample tags">
+          {
+            model.sampleTags.slice(0, 6).map((tag) => (
+              <li>
+                <a class="dp-chip-list__item" href={`/tag/${getTagRouteSegment(tag)}/1`}>
+                  {tag}
+                </a>
+              </li>
+            ))
+          }
+        </ul>
+      </div>
 
-          <div class="dp-index-list">
-            {model.posts.map((post) => (
-              <a href={`/post/${post.slug}`} class="dp-entry dp-entry--index">
-                <div class="dp-index-row">
-                  <div class="dp-index-row__meta-rail">
-                    <p class="dp-index-row__category">
-                      <span>Category</span>
-                      <strong>{post.category}</strong>
-                    </p>
-                    <div class="dp-index-row__secondary">
-                      <span>{formatDate(post.publishedAt)}</span>
-                      <span>{getReadingTimeLabel(post)}</span>
-                    </div>
-                  </div>
-                  <div class="dp-index-row__body">
-                    <h3 class="dp-entry__title">{post.title}</h3>
-                    <p class="dp-entry__description">{post.description}</p>
-                  </div>
-                </div>
-              </a>
-            ))}
-          </div>
-        </div>
-
-        <section class="dp-theme-studies">
-          <div class="dp-section-heading">
-            <p class="dp-kicker">Palette studies</p>
-            <h2 class="dp-section-heading__title">
-              Same frame, tuned with the blue palette and themes 01, 04, 07
-            </h2>
-          </div>
-
-          <div class="dp-theme-grid">
-            {INDEX_FRAME_THEMES.map((indexTheme) => (
-              <section class="dp-theme-card" style={getIndexThemeStyle(indexTheme)}>
-                <div class="dp-theme-card__head">
-                  <div>
-                    <p class="dp-kicker">{indexTheme.kicker}</p>
-                    <h3 class="dp-theme-card__title">{indexTheme.name}</h3>
-                  </div>
-                  <div class="dp-theme-card__swatches" aria-hidden="true">
-                    <span class="dp-theme-card__swatch dp-theme-card__swatch--rail" />
-                    <span class="dp-theme-card__swatch dp-theme-card__swatch--accent" />
-                    <span class="dp-theme-card__swatch dp-theme-card__swatch--surface" />
-                  </div>
-                </div>
-
-                <p class="dp-theme-card__note">{indexTheme.note}</p>
-
-                <div class="dp-theme-preview">
-                  {featuredPost && (
-                    <div class="dp-theme-preview__lead">
-                      <div class="dp-theme-preview__meta-rail">
-                        <p class="dp-theme-preview__category">
-                          <span>Lead category</span>
-                          <strong>{featuredPost.category}</strong>
-                        </p>
-                        <div class="dp-theme-preview__secondary">
-                          <span>{formatDate(featuredPost.publishedAt)}</span>
-                          <span>{getReadingTimeLabel(featuredPost)}</span>
-                        </div>
-                      </div>
-                      <div class="dp-theme-preview__body">
-                        <h4>{featuredPost.title}</h4>
-                        <p>{featuredPost.description}</p>
-                      </div>
-                    </div>
-                  )}
-
-                  {model.posts.slice(0, 2).map((post) => (
-                    <div class="dp-theme-preview__row">
-                      <div class="dp-theme-preview__meta-rail">
-                        <p class="dp-theme-preview__category">
-                          <span>Category</span>
-                          <strong>{post.category}</strong>
-                        </p>
-                        <div class="dp-theme-preview__secondary">
-                          <span>{formatDate(post.publishedAt)}</span>
-                        </div>
-                      </div>
-                      <div class="dp-theme-preview__body">
-                        <h4>{post.title}</h4>
-                        <p>{post.description}</p>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </section>
-            ))}
-          </div>
-        </section>
-      </section>
-    )
-  }
+      <div class="dp-support-block">
+        <p class="dp-kicker">Pagination sample</p>
+        <nav class="dp-pagination-sample" aria-label="Pagination sample">
+          <span class="dp-pagination-sample__button" aria-hidden="true"> Prev </span>
+          <span class="dp-pagination-sample__button is-current" aria-current="page"> 1 </span>
+          <span class="dp-pagination-sample__button" aria-hidden="true"> 2 </span>
+          <span class="dp-pagination-sample__button" aria-hidden="true"> 3 </span>
+        </nav>
+      </div>
+    </section>
+  </section>
 </div>

--- a/apps/astro-blog/src/components/DesignPreviewPage.astro
+++ b/apps/astro-blog/src/components/DesignPreviewPage.astro
@@ -125,44 +125,44 @@ const featuredPost = model.featuredPost;
       }
     </div>
 
-    <section class="dp-support-row">
-      <div class="dp-support-block">
-        <p class="dp-kicker">Categories</p>
-        <ul class="dp-support-list" aria-label="Sample categories">
-          {
-            model.sampleCategories.map((category) => (
-              <li>
-                <a href={getCategoryHref(category)}>{category}</a>
-              </li>
-            ))
-          }
-        </ul>
-      </div>
-
-      <div class="dp-support-block">
-        <p class="dp-kicker">Selected tags</p>
-        <ul class="dp-chip-list" aria-label="Sample tags">
-          {
-            model.sampleTags.slice(0, 6).map((tag) => (
-              <li>
-                <a class="dp-chip-list__item" href={`/tag/${getTagRouteSegment(tag)}/1`}>
-                  {tag}
-                </a>
-              </li>
-            ))
-          }
-        </ul>
-      </div>
-
-      <div class="dp-support-block">
-        <p class="dp-kicker">Pagination sample</p>
-        <nav class="dp-pagination-sample" aria-label="Pagination sample">
-          <span class="dp-pagination-sample__button" aria-hidden="true"> Prev </span>
-          <span class="dp-pagination-sample__button is-current" aria-current="page"> 1 </span>
-          <span class="dp-pagination-sample__button" aria-hidden="true"> 2 </span>
-          <span class="dp-pagination-sample__button" aria-hidden="true"> 3 </span>
-        </nav>
-      </div>
+    <section class="dp-pagination-wrap">
+      <p class="dp-kicker">Pagination sample</p>
+      <nav class="dp-pagination-sample" aria-label="Pagination sample">
+        <span class="dp-pagination-sample__button" aria-hidden="true"> Prev </span>
+        <span class="dp-pagination-sample__button is-current" aria-current="page"> 1 </span>
+        <span class="dp-pagination-sample__button" aria-hidden="true"> 2 </span>
+        <span class="dp-pagination-sample__button" aria-hidden="true"> 3 </span>
+      </nav>
     </section>
   </section>
+
+  <footer class="dp-footer-meta">
+    <section class="dp-support-block">
+      <p class="dp-kicker">Categories</p>
+      <ul class="dp-support-list" aria-label="Sample categories">
+        {
+          model.sampleCategories.map((category) => (
+            <li>
+              <a href={getCategoryHref(category)}>{category}</a>
+            </li>
+          ))
+        }
+      </ul>
+    </section>
+
+    <section class="dp-support-block">
+      <p class="dp-kicker">Selected tags</p>
+      <ul class="dp-chip-list" aria-label="Sample tags">
+        {
+          model.sampleTags.slice(0, 6).map((tag) => (
+            <li>
+              <a class="dp-chip-list__item" href={`/tag/${getTagRouteSegment(tag)}/1`}>
+                {tag}
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+    </section>
+  </footer>
 </div>

--- a/apps/astro-blog/src/components/DesignPreviewPage.astro
+++ b/apps/astro-blog/src/components/DesignPreviewPage.astro
@@ -1,7 +1,12 @@
 ---
 import type { PostMeta } from '@estrivault/content-processor';
 import { SITE_TITLE } from '$constants';
-import type { DesignPreviewModel, DesignPreviewTheme } from '$lib/design-preview';
+import {
+  INDEX_FRAME_THEMES,
+  type DesignPreviewModel,
+  type DesignPreviewTheme,
+  type IndexFrameTheme,
+} from '$lib/design-preview';
 import { getTagRouteSegment } from '$lib/url-segments';
 
 interface Props {
@@ -29,39 +34,55 @@ function getReadingTimeLabel(post: PostMeta): string {
   return `${minutes} min read`;
 }
 
+function getIndexThemeStyle(theme: IndexFrameTheme): string {
+  return [
+    `--if-rail:${theme.rail}`,
+    `--if-accent:${theme.accent}`,
+    `--if-accent-soft:${theme.accentSoft}`,
+    `--if-surface:${theme.surface}`,
+    `--if-border:${theme.border}`,
+    `--if-text:${theme.text}`,
+    `--if-text-soft:${theme.textSoft}`,
+  ].join(';');
+}
+
 const featuredPost = model.featuredPost;
 const bannerPosts = model.posts.slice(0, 3);
 ---
 
 <div class={`design-preview design-preview--${variant}`}>
-  <section class={`dp-masthead ${variant === 'archive-grid' ? 'dp-masthead--banner' : ''}`}>
-    <div class="dp-masthead__copy">
-      <p class="dp-kicker">{theme.kicker}</p>
-      <p class="dp-masthead__statement">{theme.title}</p>
-      <h1 class="dp-masthead__site">{SITE_TITLE}</h1>
-      <p class="dp-masthead__description">{theme.description}</p>
-      <p class="dp-masthead__summary">{theme.summary}</p>
-    </div>
+  {
+    variant !== 'signal-frame' && (
+      <section class={`dp-masthead ${variant === 'archive-grid' ? 'dp-masthead--banner' : ''}`}>
+        <div class="dp-masthead__copy">
+          <p class="dp-kicker">{theme.kicker}</p>
+          <p class="dp-masthead__statement">{theme.title}</p>
+          <h1 class="dp-masthead__site">{SITE_TITLE}</h1>
+          <p class="dp-masthead__description">{theme.description}</p>
+          <p class="dp-masthead__summary">{theme.summary}</p>
+        </div>
 
-    <dl class="dp-masthead__stats" aria-label="Preview summary">
-      <div class="dp-masthead__stat">
-        <dt>Lead category</dt>
-        <dd>{model.stats.leadCategoryLabel}</dd>
-      </div>
-      <div class="dp-masthead__stat">
-        <dt>Categories</dt>
-        <dd>{model.stats.categoryCount}</dd>
-      </div>
-      <div class="dp-masthead__stat">
-        <dt>Posts</dt>
-        <dd>{model.stats.totalPosts}</dd>
-      </div>
-      <div class="dp-masthead__stat">
-        <dt>Avg read</dt>
-        <dd>{model.stats.averageReadingMinutes || '-'} min</dd>
-      </div>
-    </dl>
-  </section>
+        <dl class="dp-masthead__stats" aria-label="Preview summary">
+          <div class="dp-masthead__stat">
+            <dt>Lead category</dt>
+            <dd>{model.stats.leadCategoryLabel}</dd>
+          </div>
+          <div class="dp-masthead__stat">
+            <dt>Categories</dt>
+            <dd>{model.stats.categoryCount}</dd>
+          </div>
+          <div class="dp-masthead__stat">
+            <dt>Posts</dt>
+            <dd>{model.stats.totalPosts}</dd>
+          </div>
+          <div class="dp-masthead__stat">
+            <dt>Avg read</dt>
+            <dd>{model.stats.averageReadingMinutes || '-'} min</dd>
+          </div>
+        </dl>
+      </section>
+    )
+  }
 
   {
     variant === 'industrial-slate' && (
@@ -221,76 +242,145 @@ const bannerPosts = model.posts.slice(0, 3);
   {
     variant === 'signal-frame' && (
       <section class="dp-variant dp-variant--index">
-        <div class="dp-index-head" aria-hidden="true">
-          <span>Category</span>
-          <span>Entry</span>
-          <span>Published</span>
-        </div>
+        <div class="dp-index-shell">
+          <header class="dp-index-header">
+            <div class="dp-index-header__copy">
+              <p class="dp-kicker">Index frame</p>
+              <h2 class="dp-index-header__title">{SITE_TITLE}</h2>
+              <p class="dp-index-header__statement">{theme.title}</p>
+              <p class="dp-index-header__description">
+                Category, publication date, and reading time all sit on the left rail so the title
+                block can stay optically clean.
+              </p>
+            </div>
 
-        {featuredPost ?
-          <a href={`/post/${featuredPost.slug}`} class="dp-featured-card dp-featured-card--index">
-            <div class="dp-index-row dp-index-row--featured">
-              <div class="dp-index-row__category">
-                <span>Lead</span>
-                <strong>{featuredPost.category}</strong>
+            <div class="dp-index-header__meta">
+              <div>
+                <span>Lead category</span>
+                <strong>{model.stats.leadCategoryLabel}</strong>
               </div>
-              <div class="dp-index-row__body">
-                <h2 class="dp-featured-card__title">{featuredPost.title}</h2>
-                <p class="dp-featured-card__description">{featuredPost.description}</p>
-              </div>
-              <div class="dp-index-row__meta">
-                <span>{formatDate(featuredPost.publishedAt)}</span>
-                <span>{getReadingTimeLabel(featuredPost)}</span>
+              <div>
+                <span>Palette studies</span>
+                <strong>{INDEX_FRAME_THEMES.length}</strong>
               </div>
             </div>
-          </a>
-        : <div class="dp-empty-state">No published posts were available for the preview.</div>}
+          </header>
 
-        <div class="dp-index-list">
-          {model.posts.map((post) => (
-            <a href={`/post/${post.slug}`} class="dp-entry dp-entry--index">
-              <div class="dp-index-row">
-                <div class="dp-index-row__category">
-                  <span>Category</span>
-                  <strong>{post.category}</strong>
+          <div class="dp-index-head" aria-hidden="true">
+            <span>Metadata</span>
+            <span>Entry</span>
+          </div>
+
+          {featuredPost ?
+            <a href={`/post/${featuredPost.slug}`} class="dp-featured-card dp-featured-card--index">
+              <div class="dp-index-row dp-index-row--featured">
+                <div class="dp-index-row__meta-rail">
+                  <p class="dp-index-row__category">
+                    <span>Lead category</span>
+                    <strong>{featuredPost.category}</strong>
+                  </p>
+                  <div class="dp-index-row__secondary">
+                    <span>{formatDate(featuredPost.publishedAt)}</span>
+                    <span>{getReadingTimeLabel(featuredPost)}</span>
+                  </div>
                 </div>
                 <div class="dp-index-row__body">
-                  <h3 class="dp-entry__title">{post.title}</h3>
-                  <p class="dp-entry__description">{post.description}</p>
-                </div>
-                <div class="dp-index-row__meta">
-                  <span>{formatDate(post.publishedAt)}</span>
+                  <h2 class="dp-featured-card__title">{featuredPost.title}</h2>
+                  <p class="dp-featured-card__description">{featuredPost.description}</p>
                 </div>
               </div>
             </a>
-          ))}
+          : <div class="dp-empty-state">No published posts were available for the preview.</div>}
+
+          <div class="dp-index-list">
+            {model.posts.map((post) => (
+              <a href={`/post/${post.slug}`} class="dp-entry dp-entry--index">
+                <div class="dp-index-row">
+                  <div class="dp-index-row__meta-rail">
+                    <p class="dp-index-row__category">
+                      <span>Category</span>
+                      <strong>{post.category}</strong>
+                    </p>
+                    <div class="dp-index-row__secondary">
+                      <span>{formatDate(post.publishedAt)}</span>
+                      <span>{getReadingTimeLabel(post)}</span>
+                    </div>
+                  </div>
+                  <div class="dp-index-row__body">
+                    <h3 class="dp-entry__title">{post.title}</h3>
+                    <p class="dp-entry__description">{post.description}</p>
+                  </div>
+                </div>
+              </a>
+            ))}
+          </div>
         </div>
 
-        <section class="dp-support-row dp-support-row--index">
-          <div class="dp-support-block">
-            <p class="dp-kicker">Frame note</p>
-            <p class="dp-support-copy">
-              In this route the category column leads the eye before the titles and summaries open
-              into view.
-            </p>
+        <section class="dp-theme-studies">
+          <div class="dp-section-heading">
+            <p class="dp-kicker">Palette studies</p>
+            <h2 class="dp-section-heading__title">
+              Same frame, tuned with the blue palette and themes 01, 04, 07
+            </h2>
           </div>
 
-          <div class="dp-support-block">
-            <p class="dp-kicker">Pagination sample</p>
-            <nav class="dp-pagination-sample" aria-label="Pagination sample">
-              <span class="dp-pagination-sample__button" aria-hidden="true">
-                Prev
-              </span>
-              <span class="dp-pagination-sample__button is-current" aria-current="page">
-                1
-              </span>
-              <span class="dp-pagination-sample__button" aria-hidden="true">
-                2
-              </span>
-              <span class="dp-pagination-sample__button" aria-hidden="true">
-                3
-              </span>
-            </nav>
+          <div class="dp-theme-grid">
+            {INDEX_FRAME_THEMES.map((indexTheme) => (
+              <section class="dp-theme-card" style={getIndexThemeStyle(indexTheme)}>
+                <div class="dp-theme-card__head">
+                  <div>
+                    <p class="dp-kicker">{indexTheme.kicker}</p>
+                    <h3 class="dp-theme-card__title">{indexTheme.name}</h3>
+                  </div>
+                  <div class="dp-theme-card__swatches" aria-hidden="true">
+                    <span class="dp-theme-card__swatch dp-theme-card__swatch--rail" />
+                    <span class="dp-theme-card__swatch dp-theme-card__swatch--accent" />
+                    <span class="dp-theme-card__swatch dp-theme-card__swatch--surface" />
+                  </div>
+                </div>
+
+                <p class="dp-theme-card__note">{indexTheme.note}</p>
+
+                <div class="dp-theme-preview">
+                  {featuredPost && (
+                    <div class="dp-theme-preview__lead">
+                      <div class="dp-theme-preview__meta-rail">
+                        <p class="dp-theme-preview__category">
+                          <span>Lead category</span>
+                          <strong>{featuredPost.category}</strong>
+                        </p>
+                        <div class="dp-theme-preview__secondary">
+                          <span>{formatDate(featuredPost.publishedAt)}</span>
+                          <span>{getReadingTimeLabel(featuredPost)}</span>
+                        </div>
+                      </div>
+                      <div class="dp-theme-preview__body">
+                        <h4>{featuredPost.title}</h4>
+                        <p>{featuredPost.description}</p>
+                      </div>
+                    </div>
+                  )}
+
+                  {model.posts.slice(0, 2).map((post) => (
+                    <div class="dp-theme-preview__row">
+                      <div class="dp-theme-preview__meta-rail">
+                        <p class="dp-theme-preview__category">
+                          <span>Category</span>
+                          <strong>{post.category}</strong>
+                        </p>
+                        <div class="dp-theme-preview__secondary">
+                          <span>{formatDate(post.publishedAt)}</span>
+                        </div>
+                      </div>
+                      <div class="dp-theme-preview__body">
+                        <h4>{post.title}</h4>
+                        <p>{post.description}</p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            ))}
           </div>
         </section>
       </section>

--- a/apps/astro-blog/src/components/DesignPreviewPage.astro
+++ b/apps/astro-blog/src/components/DesignPreviewPage.astro
@@ -1,5 +1,6 @@
 ---
 import type { PostMeta } from '@estrivault/content-processor';
+import { SITE_TITLE } from '$constants';
 import type { DesignPreviewModel, DesignPreviewTheme } from '$lib/design-preview';
 import { getTagRouteSegment } from '$lib/url-segments';
 
@@ -29,190 +30,98 @@ function getReadingTimeLabel(post: PostMeta): string {
 }
 
 const featuredPost = model.featuredPost;
+const bannerPosts = model.posts.slice(0, 3);
 ---
 
 <div class={`design-preview design-preview--${variant}`}>
-  <section class="dp-hero-panel">
-    <div class="dp-hero-panel__body">
-      <p class="dp-hero-panel__eyebrow">{theme.kicker}</p>
-      <h1 class="dp-hero-panel__title">{theme.title}</h1>
-      <p class="dp-hero-panel__description">{theme.description}</p>
-      <p class="dp-hero-panel__summary">{theme.summary}</p>
+  <section class={`dp-masthead ${variant === 'archive-grid' ? 'dp-masthead--banner' : ''}`}>
+    <div class="dp-masthead__copy">
+      <p class="dp-kicker">{theme.kicker}</p>
+      <p class="dp-masthead__statement">{theme.title}</p>
+      <h1 class="dp-masthead__site">{SITE_TITLE}</h1>
+      <p class="dp-masthead__description">{theme.description}</p>
+      <p class="dp-masthead__summary">{theme.summary}</p>
     </div>
 
-    <dl class="dp-hero-meta" aria-label="Preview summary">
-      <div class="dp-hero-meta__item">
-        <dt>Posts</dt>
-        <dd>{model.stats.totalPosts}</dd>
+    <dl class="dp-masthead__stats" aria-label="Preview summary">
+      <div class="dp-masthead__stat">
+        <dt>Lead category</dt>
+        <dd>{model.stats.leadCategoryLabel}</dd>
       </div>
-      <div class="dp-hero-meta__item">
+      <div class="dp-masthead__stat">
         <dt>Categories</dt>
         <dd>{model.stats.categoryCount}</dd>
       </div>
-      <div class="dp-hero-meta__item">
+      <div class="dp-masthead__stat">
+        <dt>Posts</dt>
+        <dd>{model.stats.totalPosts}</dd>
+      </div>
+      <div class="dp-masthead__stat">
         <dt>Avg read</dt>
         <dd>{model.stats.averageReadingMinutes || '-'} min</dd>
-      </div>
-      <div class="dp-hero-meta__item">
-        <dt>Latest</dt>
-        <dd>{model.stats.latestPublishedLabel}</dd>
       </div>
     </dl>
   </section>
 
   {
     variant === 'industrial-slate' && (
-      <section class="dp-layout dp-layout--essay">
-        {featuredPost && (
-          <a href={`/post/${featuredPost.slug}`} class="dp-featured-card dp-featured-card--essay">
-            <div class="dp-card-meta">
-              <span>{featuredPost.category}</span>
+      <section class="dp-variant dp-variant--monolith">
+        {featuredPost ?
+          <a
+            href={`/post/${featuredPost.slug}`}
+            class="dp-featured-card dp-featured-card--monolith"
+          >
+            <p class="dp-entry__category">
+              <span>Category</span>
+              <strong>{featuredPost.category}</strong>
+            </p>
+            <h2 class="dp-featured-card__title">{featuredPost.title}</h2>
+            <p class="dp-featured-card__description">{featuredPost.description}</p>
+            <div class="dp-entry__secondary">
               <span>{formatDate(featuredPost.publishedAt)}</span>
               <span>{getReadingTimeLabel(featuredPost)}</span>
             </div>
-            <h2 class="dp-featured-card__title">{featuredPost.title}</h2>
-            <p class="dp-featured-card__description">{featuredPost.description}</p>
-
-            <ul class="dp-chip-list" aria-label="Featured tags">
-              {featuredPost.tags.slice(0, 4).map((tag) => (
-                <li class="dp-chip-list__item">{tag}</li>
-              ))}
-            </ul>
           </a>
-        )}
+        : <div class="dp-empty-state">No published posts were available for the preview.</div>}
 
         <section class="dp-list-section">
           <div class="dp-section-heading">
-            <p class="dp-section-heading__eyebrow">Recent writing</p>
-            <h2 class="dp-section-heading__title">A steady vertical reading flow</h2>
+            <p class="dp-kicker">Reading field</p>
+            <h2 class="dp-section-heading__title">A single, uninterrupted top-page rhythm</h2>
           </div>
 
-          <div class="dp-list dp-list--essay">
+          <div class="dp-list dp-list--monolith">
             {model.posts.map((post) => (
-              <a href={`/post/${post.slug}`} class="dp-entry dp-entry--essay">
-                <div class="dp-card-meta">
-                  <span>{post.category}</span>
+              <a href={`/post/${post.slug}`} class="dp-entry dp-entry--monolith">
+                <p class="dp-entry__category">
+                  <span>Category</span>
+                  <strong>{post.category}</strong>
+                </p>
+                <h3 class="dp-entry__title">{post.title}</h3>
+                <p class="dp-entry__description">{post.description}</p>
+                <div class="dp-entry__secondary">
                   <span>{formatDate(post.publishedAt)}</span>
                   <span>{getReadingTimeLabel(post)}</span>
                 </div>
-                <h3 class="dp-entry__title">{post.title}</h3>
-                <p class="dp-entry__description">{post.description}</p>
-                <ul class="dp-chip-list" aria-label={`${post.title} tags`}>
-                  {post.tags.slice(0, 3).map((tag) => (
-                    <li class="dp-chip-list__item">{tag}</li>
-                  ))}
-                </ul>
               </a>
             ))}
           </div>
         </section>
 
-        <section class="dp-support-grid dp-support-grid--essay">
+        <section class="dp-support-row">
           <div class="dp-support-block">
-            <p class="dp-support-block__label">Sample categories</p>
-            <ul class="dp-chip-list" aria-label="Sample categories">
-              {model.sampleCategories.map((category) => (
-                <li>
-                  <a class="dp-chip-list__item" href={getCategoryHref(category)}>
-                    {category}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          <div class="dp-support-block">
-            <p class="dp-support-block__label">Sample tags</p>
-            <ul class="dp-chip-list" aria-label="Sample tags">
-              {model.sampleTags.map((tag) => (
-                <li>
-                  <a class="dp-chip-list__item" href={`/tag/${getTagRouteSegment(tag)}/1`}>
-                    {tag}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </section>
-      </section>
-    )
-  }
-
-  {
-    variant === 'archive-grid' && (
-      <section class="dp-layout dp-layout--split">
-        <div class="dp-split-main">
-          {featuredPost && (
-            <a href={`/post/${featuredPost.slug}`} class="dp-featured-card dp-featured-card--split">
-              <div class="dp-card-meta">
-                <span>{featuredPost.category}</span>
-                <span>{formatDate(featuredPost.publishedAt)}</span>
-                <span>{getReadingTimeLabel(featuredPost)}</span>
-              </div>
-              <h2 class="dp-featured-card__title">{featuredPost.title}</h2>
-              <p class="dp-featured-card__description">{featuredPost.description}</p>
-            </a>
-          )}
-
-          <div class="dp-list-section">
-            <div class="dp-section-heading">
-              <p class="dp-section-heading__eyebrow">Recent writing</p>
-              <h2 class="dp-section-heading__title">
-                Main column for reading, side column for context
-              </h2>
-            </div>
-
-            <div class="dp-list dp-list--split">
-              {model.posts.map((post) => (
-                <a href={`/post/${post.slug}`} class="dp-entry dp-entry--split">
-                  <div class="dp-card-meta">
-                    <span>{post.category}</span>
-                    <span>{formatDate(post.publishedAt)}</span>
-                    <span>{getReadingTimeLabel(post)}</span>
-                  </div>
-                  <h3 class="dp-entry__title">{post.title}</h3>
-                  <p class="dp-entry__description">{post.description}</p>
-                </a>
-              ))}
-            </div>
-          </div>
-        </div>
-
-        <aside class="dp-sidebar">
-          <section class="dp-support-block">
-            <p class="dp-support-block__label">Latest note</p>
-            <p class="dp-sidebar__body">
-              A narrow companion rail keeps taxonomy and navigation visible without interrupting the
-              article titles.
-            </p>
-          </section>
-
-          <section class="dp-support-block">
-            <p class="dp-support-block__label">Categories</p>
-            <ul class="dp-sidebar-list" aria-label="Sample categories">
+            <p class="dp-kicker">Categories</p>
+            <ul class="dp-support-list" aria-label="Sample categories">
               {model.sampleCategories.map((category) => (
                 <li>
                   <a href={getCategoryHref(category)}>{category}</a>
                 </li>
               ))}
             </ul>
-          </section>
+          </div>
 
-          <section class="dp-support-block">
-            <p class="dp-support-block__label">Tags</p>
-            <ul class="dp-chip-list" aria-label="Sample tags">
-              {model.sampleTags.map((tag) => (
-                <li>
-                  <a class="dp-chip-list__item" href={`/tag/${getTagRouteSegment(tag)}/1`}>
-                    {tag}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </section>
-
-          <section class="dp-support-block">
-            <p class="dp-support-block__label">Pagination sample</p>
+          <div class="dp-support-block">
+            <p class="dp-kicker">Pagination sample</p>
             <nav class="dp-pagination-sample" aria-label="Pagination sample">
               <span class="dp-pagination-sample__button" aria-hidden="true">
                 Prev
@@ -227,70 +136,75 @@ const featuredPost = model.featuredPost;
                 3
               </span>
             </nav>
-          </section>
-        </aside>
+          </div>
+        </section>
       </section>
     )
   }
 
   {
-    variant === 'signal-frame' && (
-      <section class="dp-layout dp-layout--ledger">
-        <div class="dp-ledger-head" aria-hidden="true">
-          <span>Entry</span>
-          <span>Category</span>
-          <span>Published</span>
-          <span>Read</span>
+    variant === 'archive-grid' && (
+      <section class="dp-variant dp-variant--banner">
+        <div class="dp-banner-panel">
+          <p class="dp-kicker">Site face</p>
+          <p class="dp-banner-panel__lede">
+            A white, disciplined top page where category markers cut the field before the article
+            titles take over.
+          </p>
         </div>
 
-        {featuredPost && (
-          <a href={`/post/${featuredPost.slug}`} class="dp-featured-card dp-featured-card--ledger">
-            <div class="dp-ledger-row">
-              <div class="dp-ledger-row__main">
-                <p class="dp-ledger-row__label">Lead entry</p>
-                <h2 class="dp-featured-card__title">{featuredPost.title}</h2>
-                <p class="dp-featured-card__description">{featuredPost.description}</p>
-              </div>
-              <div class="dp-ledger-row__meta">
-                <span>{featuredPost.category}</span>
+        <div class="dp-banner-grid">
+          {featuredPost ?
+            <a
+              href={`/post/${featuredPost.slug}`}
+              class="dp-featured-card dp-featured-card--banner"
+            >
+              <p class="dp-entry__category">
+                <span>Primary category</span>
+                <strong>{featuredPost.category}</strong>
+              </p>
+              <h2 class="dp-featured-card__title">{featuredPost.title}</h2>
+              <p class="dp-featured-card__description">{featuredPost.description}</p>
+              <div class="dp-entry__secondary">
                 <span>{formatDate(featuredPost.publishedAt)}</span>
                 <span>{getReadingTimeLabel(featuredPost)}</span>
               </div>
-            </div>
-          </a>
-        )}
-
-        <div class="dp-ledger-list">
-          {model.posts.map((post) => (
-            <a href={`/post/${post.slug}`} class="dp-entry dp-entry--ledger">
-              <div class="dp-ledger-row">
-                <div class="dp-ledger-row__main">
-                  <h3 class="dp-entry__title">{post.title}</h3>
-                  <p class="dp-entry__description">{post.description}</p>
-                </div>
-                <div class="dp-ledger-row__meta">
-                  <span>{post.category}</span>
-                  <span>{formatDate(post.publishedAt)}</span>
-                  <span>{getReadingTimeLabel(post)}</span>
-                </div>
-              </div>
             </a>
-          ))}
+          : <div class="dp-empty-state">No published posts were available for the preview.</div>}
+
+          <div class="dp-banner-stack">
+            {bannerPosts.map((post) => (
+              <a href={`/post/${post.slug}`} class="dp-entry dp-entry--banner">
+                <p class="dp-entry__category">
+                  <span>Category</span>
+                  <strong>{post.category}</strong>
+                </p>
+                <h3 class="dp-entry__title">{post.title}</h3>
+                <p class="dp-entry__description">{post.description}</p>
+                <div class="dp-entry__secondary">
+                  <span>{formatDate(post.publishedAt)}</span>
+                </div>
+              </a>
+            ))}
+          </div>
         </div>
 
-        <div class="dp-support-grid dp-support-grid--ledger">
-          <section class="dp-support-block">
-            <p class="dp-support-block__label">Index note</p>
-            <p class="dp-sidebar__body">
-              This route minimizes card styling and lets alignment carry most of the visual
-              structure.
-            </p>
-          </section>
+        <section class="dp-support-row dp-support-row--banner">
+          <div class="dp-support-block">
+            <p class="dp-kicker">Top categories</p>
+            <ul class="dp-support-list" aria-label="Sample categories">
+              {model.sampleCategories.map((category) => (
+                <li>
+                  <a href={getCategoryHref(category)}>{category}</a>
+                </li>
+              ))}
+            </ul>
+          </div>
 
-          <section class="dp-support-block">
-            <p class="dp-support-block__label">Tags</p>
+          <div class="dp-support-block">
+            <p class="dp-kicker">Selected tags</p>
             <ul class="dp-chip-list" aria-label="Sample tags">
-              {model.sampleTags.map((tag) => (
+              {model.sampleTags.slice(0, 6).map((tag) => (
                 <li>
                   <a class="dp-chip-list__item" href={`/tag/${getTagRouteSegment(tag)}/1`}>
                     {tag}
@@ -298,8 +212,87 @@ const featuredPost = model.featuredPost;
                 </li>
               ))}
             </ul>
-          </section>
+          </div>
+        </section>
+      </section>
+    )
+  }
+
+  {
+    variant === 'signal-frame' && (
+      <section class="dp-variant dp-variant--index">
+        <div class="dp-index-head" aria-hidden="true">
+          <span>Category</span>
+          <span>Entry</span>
+          <span>Published</span>
         </div>
+
+        {featuredPost ?
+          <a href={`/post/${featuredPost.slug}`} class="dp-featured-card dp-featured-card--index">
+            <div class="dp-index-row dp-index-row--featured">
+              <div class="dp-index-row__category">
+                <span>Lead</span>
+                <strong>{featuredPost.category}</strong>
+              </div>
+              <div class="dp-index-row__body">
+                <h2 class="dp-featured-card__title">{featuredPost.title}</h2>
+                <p class="dp-featured-card__description">{featuredPost.description}</p>
+              </div>
+              <div class="dp-index-row__meta">
+                <span>{formatDate(featuredPost.publishedAt)}</span>
+                <span>{getReadingTimeLabel(featuredPost)}</span>
+              </div>
+            </div>
+          </a>
+        : <div class="dp-empty-state">No published posts were available for the preview.</div>}
+
+        <div class="dp-index-list">
+          {model.posts.map((post) => (
+            <a href={`/post/${post.slug}`} class="dp-entry dp-entry--index">
+              <div class="dp-index-row">
+                <div class="dp-index-row__category">
+                  <span>Category</span>
+                  <strong>{post.category}</strong>
+                </div>
+                <div class="dp-index-row__body">
+                  <h3 class="dp-entry__title">{post.title}</h3>
+                  <p class="dp-entry__description">{post.description}</p>
+                </div>
+                <div class="dp-index-row__meta">
+                  <span>{formatDate(post.publishedAt)}</span>
+                </div>
+              </div>
+            </a>
+          ))}
+        </div>
+
+        <section class="dp-support-row dp-support-row--index">
+          <div class="dp-support-block">
+            <p class="dp-kicker">Frame note</p>
+            <p class="dp-support-copy">
+              In this route the category column leads the eye before the titles and summaries open
+              into view.
+            </p>
+          </div>
+
+          <div class="dp-support-block">
+            <p class="dp-kicker">Pagination sample</p>
+            <nav class="dp-pagination-sample" aria-label="Pagination sample">
+              <span class="dp-pagination-sample__button" aria-hidden="true">
+                Prev
+              </span>
+              <span class="dp-pagination-sample__button is-current" aria-current="page">
+                1
+              </span>
+              <span class="dp-pagination-sample__button" aria-hidden="true">
+                2
+              </span>
+              <span class="dp-pagination-sample__button" aria-hidden="true">
+                3
+              </span>
+            </nav>
+          </div>
+        </section>
       </section>
     )
   }

--- a/apps/astro-blog/src/components/DesignPreviewPage.astro
+++ b/apps/astro-blog/src/components/DesignPreviewPage.astro
@@ -79,18 +79,12 @@ const featuredPost = model.featuredPost;
       </aside>
     </header>
 
-    <div class="dp-index-head" aria-hidden="true">
-      <span>Metadata</span>
-      <span>Entry</span>
-    </div>
-
     {
       featuredPost ?
         <a href={`/post/${featuredPost.slug}`} class="dp-featured-card dp-featured-card--index">
           <div class="dp-index-row dp-index-row--featured">
             <div class="dp-index-row__meta-rail">
               <p class="dp-index-row__category">
-                <span>Lead category</span>
                 <strong>{featuredPost.category}</strong>
               </p>
               <div class="dp-index-row__secondary">
@@ -114,7 +108,6 @@ const featuredPost = model.featuredPost;
             <div class="dp-index-row">
               <div class="dp-index-row__meta-rail">
                 <p class="dp-index-row__category">
-                  <span>Category</span>
                   <strong>{post.category}</strong>
                 </p>
                 <div class="dp-index-row__secondary">

--- a/apps/astro-blog/src/components/DesignPreviewPage.astro
+++ b/apps/astro-blog/src/components/DesignPreviewPage.astro
@@ -1,0 +1,207 @@
+---
+import type { PostMeta } from '@estrivault/content-processor';
+import type { DesignPreviewModel, DesignPreviewTheme } from '$lib/design-preview';
+import { getTagRouteSegment } from '$lib/url-segments';
+
+interface Props {
+  model: DesignPreviewModel;
+  theme: DesignPreviewTheme;
+}
+
+const { model, theme } = Astro.props;
+
+function formatDate(date: Date): string {
+  return new Intl.DateTimeFormat('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date);
+}
+
+function getCategoryHref(category: string): string {
+  return `/category/${encodeURIComponent(category.toLowerCase())}/1`;
+}
+
+function getReadingTimeLabel(post: PostMeta): string {
+  const minutes = Math.max(1, Math.ceil(post.readingTime ?? 0));
+  return `${minutes} min read`;
+}
+
+const featuredPost = model.featuredPost;
+---
+
+<div class={`design-preview design-preview--${theme.variant}`}>
+  <section class="dp-hero-panel">
+    <div class="dp-hero-panel__lead">
+      <p class="dp-hero-panel__eyebrow">{theme.kicker}</p>
+      <h1 class="dp-hero-panel__title">{theme.title}</h1>
+      <p class="dp-hero-panel__description">{theme.description}</p>
+
+      <ul class="dp-metric-list" aria-label="Concept metrics">
+        {theme.metrics.map((metric) => <li class="dp-metric-list__item">{metric}</li>)}
+      </ul>
+    </div>
+
+    <aside class="dp-status-panel" aria-label="Preview summary">
+      <p class="dp-status-panel__label">{theme.panelTitle}</p>
+      <p class="dp-status-panel__body">{theme.panelBody}</p>
+
+      <dl class="dp-stat-grid">
+        <div class="dp-stat-grid__item">
+          <dt>Posts</dt>
+          <dd>{model.stats.totalPosts}</dd>
+        </div>
+        <div class="dp-stat-grid__item">
+          <dt>Categories</dt>
+          <dd>{model.stats.categoryCount}</dd>
+        </div>
+        <div class="dp-stat-grid__item">
+          <dt>Avg read</dt>
+          <dd>{model.stats.averageReadingMinutes || '-'} min</dd>
+        </div>
+        <div class="dp-stat-grid__item">
+          <dt>Latest</dt>
+          <dd>{model.stats.latestPublishedLabel}</dd>
+        </div>
+      </dl>
+    </aside>
+  </section>
+
+  <section class="dp-content-panel">
+    <div class="dp-section-heading">
+      <p class="dp-section-heading__eyebrow">Featured surface</p>
+      <h2 class="dp-section-heading__title">Lead story card</h2>
+    </div>
+
+    {
+      featuredPost ?
+        <a href={`/post/${featuredPost.slug}`} class="dp-featured-card">
+          <div class="dp-featured-card__copy">
+            <div class="dp-card-meta">
+              <span>{featuredPost.category}</span>
+              <span>{formatDate(featuredPost.publishedAt)}</span>
+              <span>{getReadingTimeLabel(featuredPost)}</span>
+            </div>
+            <h3 class="dp-featured-card__title">{featuredPost.title}</h3>
+            <p class="dp-featured-card__description">{featuredPost.description}</p>
+
+            <ul class="dp-chip-list" aria-label="Featured tags">
+              {featuredPost.tags.slice(0, 4).map((tag) => (
+                <li class="dp-chip-list__item">{tag}</li>
+              ))}
+            </ul>
+          </div>
+
+          <div class="dp-featured-card__media" aria-hidden="true">
+            {featuredPost.coverImage ?
+              <img
+                src={featuredPost.coverImage}
+                alt=""
+                class="dp-featured-card__image"
+                loading="lazy"
+              />
+            : <div class="dp-featured-card__placeholder">
+                <span>Material sample</span>
+              </div>
+            }
+          </div>
+        </a>
+      : <div class="dp-empty-state">No published posts were available for the preview.</div>
+    }
+  </section>
+
+  <section class="dp-content-panel">
+    <div class="dp-section-heading">
+      <p class="dp-section-heading__eyebrow">Index grid</p>
+      <h2 class="dp-section-heading__title">Compact article cards</h2>
+    </div>
+
+    <div class="dp-card-grid">
+      {
+        model.posts.map((post) => (
+          <a href={`/post/${post.slug}`} class="dp-post-card">
+            <div class="dp-card-meta">
+              <span>{post.category}</span>
+              <span>{formatDate(post.publishedAt)}</span>
+            </div>
+            <h3 class="dp-post-card__title">{post.title}</h3>
+            <p class="dp-post-card__description">{post.description}</p>
+
+            <div class="dp-post-card__footer">
+              <span class="dp-post-card__reading">{getReadingTimeLabel(post)}</span>
+              <ul class="dp-chip-list" aria-label={`${post.title} tags`}>
+                {post.tags.slice(0, 3).map((tag) => (
+                  <li class="dp-chip-list__item">{tag}</li>
+                ))}
+              </ul>
+            </div>
+          </a>
+        ))
+      }
+    </div>
+  </section>
+
+  <section class="dp-utility-grid">
+    <div class="dp-content-panel">
+      <div class="dp-section-heading">
+        <p class="dp-section-heading__eyebrow">Taxonomy check</p>
+        <h2 class="dp-section-heading__title">Tag and category density</h2>
+      </div>
+
+      <div class="dp-taxonomy-columns">
+        <div>
+          <h3 class="dp-subheading">Sample tags</h3>
+          <ul class="dp-chip-list" aria-label="Sample tags">
+            {
+              model.sampleTags.map((tag) => (
+                <li>
+                  <a class="dp-chip-list__item" href={`/tag/${getTagRouteSegment(tag)}/1`}>
+                    {tag}
+                  </a>
+                </li>
+              ))
+            }
+          </ul>
+        </div>
+
+        <div>
+          <h3 class="dp-subheading">Sample categories</h3>
+          <ul class="dp-chip-list" aria-label="Sample categories">
+            {
+              model.sampleCategories.map((category) => (
+                <li>
+                  <a class="dp-chip-list__item" href={getCategoryHref(category)}>
+                    {category}
+                  </a>
+                </li>
+              ))
+            }
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <aside class="dp-content-panel dp-content-panel--support">
+      <div class="dp-section-heading">
+        <p class="dp-section-heading__eyebrow">Support panel</p>
+        <h2 class="dp-section-heading__title">Pagination and utility block</h2>
+      </div>
+
+      <nav class="dp-pagination-sample" aria-label="Pagination sample">
+        <span class="dp-pagination-sample__button" aria-hidden="true"> Prev </span>
+        <span class="dp-pagination-sample__button is-current" aria-current="page"> 1 </span>
+        <span class="dp-pagination-sample__button" aria-hidden="true"> 2 </span>
+        <span class="dp-pagination-sample__button" aria-hidden="true"> 3 </span>
+        <span class="dp-pagination-sample__button" aria-hidden="true"> Next </span>
+      </nav>
+
+      <div class="dp-note-block">
+        <p class="dp-note-block__title">System note</p>
+        <p class="dp-note-block__body">
+          These routes are comparison surfaces only. The production home page, article page, and
+          shared navigation remain untouched.
+        </p>
+      </div>
+    </aside>
+  </section>
+</div>

--- a/apps/astro-blog/src/components/DesignPreviewPage.astro
+++ b/apps/astro-blog/src/components/DesignPreviewPage.astro
@@ -9,6 +9,7 @@ interface Props {
 }
 
 const { model, theme } = Astro.props;
+const variant = theme.variant;
 
 function formatDate(date: Date): string {
   return new Intl.DateTimeFormat('ja-JP', {
@@ -30,59 +31,46 @@ function getReadingTimeLabel(post: PostMeta): string {
 const featuredPost = model.featuredPost;
 ---
 
-<div class={`design-preview design-preview--${theme.variant}`}>
+<div class={`design-preview design-preview--${variant}`}>
   <section class="dp-hero-panel">
-    <div class="dp-hero-panel__lead">
+    <div class="dp-hero-panel__body">
       <p class="dp-hero-panel__eyebrow">{theme.kicker}</p>
       <h1 class="dp-hero-panel__title">{theme.title}</h1>
       <p class="dp-hero-panel__description">{theme.description}</p>
-
-      <ul class="dp-metric-list" aria-label="Concept metrics">
-        {theme.metrics.map((metric) => <li class="dp-metric-list__item">{metric}</li>)}
-      </ul>
+      <p class="dp-hero-panel__summary">{theme.summary}</p>
     </div>
 
-    <aside class="dp-status-panel" aria-label="Preview summary">
-      <p class="dp-status-panel__label">{theme.panelTitle}</p>
-      <p class="dp-status-panel__body">{theme.panelBody}</p>
-
-      <dl class="dp-stat-grid">
-        <div class="dp-stat-grid__item">
-          <dt>Posts</dt>
-          <dd>{model.stats.totalPosts}</dd>
-        </div>
-        <div class="dp-stat-grid__item">
-          <dt>Categories</dt>
-          <dd>{model.stats.categoryCount}</dd>
-        </div>
-        <div class="dp-stat-grid__item">
-          <dt>Avg read</dt>
-          <dd>{model.stats.averageReadingMinutes || '-'} min</dd>
-        </div>
-        <div class="dp-stat-grid__item">
-          <dt>Latest</dt>
-          <dd>{model.stats.latestPublishedLabel}</dd>
-        </div>
-      </dl>
-    </aside>
+    <dl class="dp-hero-meta" aria-label="Preview summary">
+      <div class="dp-hero-meta__item">
+        <dt>Posts</dt>
+        <dd>{model.stats.totalPosts}</dd>
+      </div>
+      <div class="dp-hero-meta__item">
+        <dt>Categories</dt>
+        <dd>{model.stats.categoryCount}</dd>
+      </div>
+      <div class="dp-hero-meta__item">
+        <dt>Avg read</dt>
+        <dd>{model.stats.averageReadingMinutes || '-'} min</dd>
+      </div>
+      <div class="dp-hero-meta__item">
+        <dt>Latest</dt>
+        <dd>{model.stats.latestPublishedLabel}</dd>
+      </div>
+    </dl>
   </section>
 
-  <section class="dp-content-panel">
-    <div class="dp-section-heading">
-      <p class="dp-section-heading__eyebrow">Featured surface</p>
-      <h2 class="dp-section-heading__title">Lead story card</h2>
-    </div>
-
-    {
-      featuredPost ?
-        <a href={`/post/${featuredPost.slug}`} class="dp-featured-card">
-          <div class="dp-featured-card__copy">
+  {
+    variant === 'industrial-slate' && (
+      <section class="dp-layout dp-layout--essay">
+        {featuredPost && (
+          <a href={`/post/${featuredPost.slug}`} class="dp-featured-card dp-featured-card--essay">
             <div class="dp-card-meta">
               <span>{featuredPost.category}</span>
               <span>{formatDate(featuredPost.publishedAt)}</span>
               <span>{getReadingTimeLabel(featuredPost)}</span>
             </div>
-            <h3 class="dp-featured-card__title">{featuredPost.title}</h3>
+            <h2 class="dp-featured-card__title">{featuredPost.title}</h2>
             <p class="dp-featured-card__description">{featuredPost.description}</p>
 
             <ul class="dp-chip-list" aria-label="Featured tags">
@@ -90,118 +78,229 @@ const featuredPost = model.featuredPost;
                 <li class="dp-chip-list__item">{tag}</li>
               ))}
             </ul>
-          </div>
-
-          <div class="dp-featured-card__media" aria-hidden="true">
-            {featuredPost.coverImage ?
-              <img
-                src={featuredPost.coverImage}
-                alt=""
-                class="dp-featured-card__image"
-                loading="lazy"
-              />
-            : <div class="dp-featured-card__placeholder">
-                <span>Material sample</span>
-              </div>
-            }
-          </div>
-        </a>
-      : <div class="dp-empty-state">No published posts were available for the preview.</div>
-    }
-  </section>
-
-  <section class="dp-content-panel">
-    <div class="dp-section-heading">
-      <p class="dp-section-heading__eyebrow">Index grid</p>
-      <h2 class="dp-section-heading__title">Compact article cards</h2>
-    </div>
-
-    <div class="dp-card-grid">
-      {
-        model.posts.map((post) => (
-          <a href={`/post/${post.slug}`} class="dp-post-card">
-            <div class="dp-card-meta">
-              <span>{post.category}</span>
-              <span>{formatDate(post.publishedAt)}</span>
-            </div>
-            <h3 class="dp-post-card__title">{post.title}</h3>
-            <p class="dp-post-card__description">{post.description}</p>
-
-            <div class="dp-post-card__footer">
-              <span class="dp-post-card__reading">{getReadingTimeLabel(post)}</span>
-              <ul class="dp-chip-list" aria-label={`${post.title} tags`}>
-                {post.tags.slice(0, 3).map((tag) => (
-                  <li class="dp-chip-list__item">{tag}</li>
-                ))}
-              </ul>
-            </div>
           </a>
-        ))
-      }
-    </div>
-  </section>
+        )}
 
-  <section class="dp-utility-grid">
-    <div class="dp-content-panel">
-      <div class="dp-section-heading">
-        <p class="dp-section-heading__eyebrow">Taxonomy check</p>
-        <h2 class="dp-section-heading__title">Tag and category density</h2>
-      </div>
+        <section class="dp-list-section">
+          <div class="dp-section-heading">
+            <p class="dp-section-heading__eyebrow">Recent writing</p>
+            <h2 class="dp-section-heading__title">A steady vertical reading flow</h2>
+          </div>
 
-      <div class="dp-taxonomy-columns">
-        <div>
-          <h3 class="dp-subheading">Sample tags</h3>
-          <ul class="dp-chip-list" aria-label="Sample tags">
-            {
-              model.sampleTags.map((tag) => (
-                <li>
-                  <a class="dp-chip-list__item" href={`/tag/${getTagRouteSegment(tag)}/1`}>
-                    {tag}
-                  </a>
-                </li>
-              ))
-            }
-          </ul>
-        </div>
+          <div class="dp-list dp-list--essay">
+            {model.posts.map((post) => (
+              <a href={`/post/${post.slug}`} class="dp-entry dp-entry--essay">
+                <div class="dp-card-meta">
+                  <span>{post.category}</span>
+                  <span>{formatDate(post.publishedAt)}</span>
+                  <span>{getReadingTimeLabel(post)}</span>
+                </div>
+                <h3 class="dp-entry__title">{post.title}</h3>
+                <p class="dp-entry__description">{post.description}</p>
+                <ul class="dp-chip-list" aria-label={`${post.title} tags`}>
+                  {post.tags.slice(0, 3).map((tag) => (
+                    <li class="dp-chip-list__item">{tag}</li>
+                  ))}
+                </ul>
+              </a>
+            ))}
+          </div>
+        </section>
 
-        <div>
-          <h3 class="dp-subheading">Sample categories</h3>
-          <ul class="dp-chip-list" aria-label="Sample categories">
-            {
-              model.sampleCategories.map((category) => (
+        <section class="dp-support-grid dp-support-grid--essay">
+          <div class="dp-support-block">
+            <p class="dp-support-block__label">Sample categories</p>
+            <ul class="dp-chip-list" aria-label="Sample categories">
+              {model.sampleCategories.map((category) => (
                 <li>
                   <a class="dp-chip-list__item" href={getCategoryHref(category)}>
                     {category}
                   </a>
                 </li>
-              ))
-            }
-          </ul>
+              ))}
+            </ul>
+          </div>
+
+          <div class="dp-support-block">
+            <p class="dp-support-block__label">Sample tags</p>
+            <ul class="dp-chip-list" aria-label="Sample tags">
+              {model.sampleTags.map((tag) => (
+                <li>
+                  <a class="dp-chip-list__item" href={`/tag/${getTagRouteSegment(tag)}/1`}>
+                    {tag}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+      </section>
+    )
+  }
+
+  {
+    variant === 'archive-grid' && (
+      <section class="dp-layout dp-layout--split">
+        <div class="dp-split-main">
+          {featuredPost && (
+            <a href={`/post/${featuredPost.slug}`} class="dp-featured-card dp-featured-card--split">
+              <div class="dp-card-meta">
+                <span>{featuredPost.category}</span>
+                <span>{formatDate(featuredPost.publishedAt)}</span>
+                <span>{getReadingTimeLabel(featuredPost)}</span>
+              </div>
+              <h2 class="dp-featured-card__title">{featuredPost.title}</h2>
+              <p class="dp-featured-card__description">{featuredPost.description}</p>
+            </a>
+          )}
+
+          <div class="dp-list-section">
+            <div class="dp-section-heading">
+              <p class="dp-section-heading__eyebrow">Recent writing</p>
+              <h2 class="dp-section-heading__title">
+                Main column for reading, side column for context
+              </h2>
+            </div>
+
+            <div class="dp-list dp-list--split">
+              {model.posts.map((post) => (
+                <a href={`/post/${post.slug}`} class="dp-entry dp-entry--split">
+                  <div class="dp-card-meta">
+                    <span>{post.category}</span>
+                    <span>{formatDate(post.publishedAt)}</span>
+                    <span>{getReadingTimeLabel(post)}</span>
+                  </div>
+                  <h3 class="dp-entry__title">{post.title}</h3>
+                  <p class="dp-entry__description">{post.description}</p>
+                </a>
+              ))}
+            </div>
+          </div>
         </div>
-      </div>
-    </div>
 
-    <aside class="dp-content-panel dp-content-panel--support">
-      <div class="dp-section-heading">
-        <p class="dp-section-heading__eyebrow">Support panel</p>
-        <h2 class="dp-section-heading__title">Pagination and utility block</h2>
-      </div>
+        <aside class="dp-sidebar">
+          <section class="dp-support-block">
+            <p class="dp-support-block__label">Latest note</p>
+            <p class="dp-sidebar__body">
+              A narrow companion rail keeps taxonomy and navigation visible without interrupting the
+              article titles.
+            </p>
+          </section>
 
-      <nav class="dp-pagination-sample" aria-label="Pagination sample">
-        <span class="dp-pagination-sample__button" aria-hidden="true"> Prev </span>
-        <span class="dp-pagination-sample__button is-current" aria-current="page"> 1 </span>
-        <span class="dp-pagination-sample__button" aria-hidden="true"> 2 </span>
-        <span class="dp-pagination-sample__button" aria-hidden="true"> 3 </span>
-        <span class="dp-pagination-sample__button" aria-hidden="true"> Next </span>
-      </nav>
+          <section class="dp-support-block">
+            <p class="dp-support-block__label">Categories</p>
+            <ul class="dp-sidebar-list" aria-label="Sample categories">
+              {model.sampleCategories.map((category) => (
+                <li>
+                  <a href={getCategoryHref(category)}>{category}</a>
+                </li>
+              ))}
+            </ul>
+          </section>
 
-      <div class="dp-note-block">
-        <p class="dp-note-block__title">System note</p>
-        <p class="dp-note-block__body">
-          These routes are comparison surfaces only. The production home page, article page, and
-          shared navigation remain untouched.
-        </p>
-      </div>
-    </aside>
-  </section>
+          <section class="dp-support-block">
+            <p class="dp-support-block__label">Tags</p>
+            <ul class="dp-chip-list" aria-label="Sample tags">
+              {model.sampleTags.map((tag) => (
+                <li>
+                  <a class="dp-chip-list__item" href={`/tag/${getTagRouteSegment(tag)}/1`}>
+                    {tag}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section class="dp-support-block">
+            <p class="dp-support-block__label">Pagination sample</p>
+            <nav class="dp-pagination-sample" aria-label="Pagination sample">
+              <span class="dp-pagination-sample__button" aria-hidden="true">
+                Prev
+              </span>
+              <span class="dp-pagination-sample__button is-current" aria-current="page">
+                1
+              </span>
+              <span class="dp-pagination-sample__button" aria-hidden="true">
+                2
+              </span>
+              <span class="dp-pagination-sample__button" aria-hidden="true">
+                3
+              </span>
+            </nav>
+          </section>
+        </aside>
+      </section>
+    )
+  }
+
+  {
+    variant === 'signal-frame' && (
+      <section class="dp-layout dp-layout--ledger">
+        <div class="dp-ledger-head" aria-hidden="true">
+          <span>Entry</span>
+          <span>Category</span>
+          <span>Published</span>
+          <span>Read</span>
+        </div>
+
+        {featuredPost && (
+          <a href={`/post/${featuredPost.slug}`} class="dp-featured-card dp-featured-card--ledger">
+            <div class="dp-ledger-row">
+              <div class="dp-ledger-row__main">
+                <p class="dp-ledger-row__label">Lead entry</p>
+                <h2 class="dp-featured-card__title">{featuredPost.title}</h2>
+                <p class="dp-featured-card__description">{featuredPost.description}</p>
+              </div>
+              <div class="dp-ledger-row__meta">
+                <span>{featuredPost.category}</span>
+                <span>{formatDate(featuredPost.publishedAt)}</span>
+                <span>{getReadingTimeLabel(featuredPost)}</span>
+              </div>
+            </div>
+          </a>
+        )}
+
+        <div class="dp-ledger-list">
+          {model.posts.map((post) => (
+            <a href={`/post/${post.slug}`} class="dp-entry dp-entry--ledger">
+              <div class="dp-ledger-row">
+                <div class="dp-ledger-row__main">
+                  <h3 class="dp-entry__title">{post.title}</h3>
+                  <p class="dp-entry__description">{post.description}</p>
+                </div>
+                <div class="dp-ledger-row__meta">
+                  <span>{post.category}</span>
+                  <span>{formatDate(post.publishedAt)}</span>
+                  <span>{getReadingTimeLabel(post)}</span>
+                </div>
+              </div>
+            </a>
+          ))}
+        </div>
+
+        <div class="dp-support-grid dp-support-grid--ledger">
+          <section class="dp-support-block">
+            <p class="dp-support-block__label">Index note</p>
+            <p class="dp-sidebar__body">
+              This route minimizes card styling and lets alignment carry most of the visual
+              structure.
+            </p>
+          </section>
+
+          <section class="dp-support-block">
+            <p class="dp-support-block__label">Tags</p>
+            <ul class="dp-chip-list" aria-label="Sample tags">
+              {model.sampleTags.map((tag) => (
+                <li>
+                  <a class="dp-chip-list__item" href={`/tag/${getTagRouteSegment(tag)}/1`}>
+                    {tag}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </section>
+        </div>
+      </section>
+    )
+  }
 </div>

--- a/apps/astro-blog/src/components/TopPageFooter.astro
+++ b/apps/astro-blog/src/components/TopPageFooter.astro
@@ -1,0 +1,23 @@
+---
+import { SOCIAL_LINK_GITHUB, SOCIAL_LINK_X } from '$constants';
+
+const year = new Date().getFullYear();
+---
+
+<footer class="tp-global-footer">
+  <div class="tp-global-footer__links">
+    <a href={`https://x.com/${SOCIAL_LINK_X}`} target="_blank" rel="noopener noreferrer"> X </a>
+    <a href={`https://github.com/${SOCIAL_LINK_GITHUB}`} target="_blank" rel="noopener noreferrer">
+      GitHub
+    </a>
+    <a
+      href="/llms.txt"
+      target="_blank"
+      rel="noopener noreferrer"
+      title="LLM-friendly content guide"
+    >
+      LLMs
+    </a>
+  </div>
+  <p class="tp-global-footer__copy">© {year} Estrivault. All rights reserved.</p>
+</footer>

--- a/apps/astro-blog/src/components/TopPageHeader.astro
+++ b/apps/astro-blog/src/components/TopPageHeader.astro
@@ -1,0 +1,43 @@
+---
+import { NAVIGATION_LINKS, SITE_TITLE } from '$constants';
+
+interface Props {
+  pathname: string;
+}
+
+const { pathname } = Astro.props;
+
+function normalizePath(path: string): string {
+  return path.replace(/\/$/, '') || '/';
+}
+
+function isActive(href: string): boolean {
+  const normalizedPath = normalizePath(pathname);
+  const normalizedHref = normalizePath(href);
+  return normalizedPath === normalizedHref || normalizedPath.startsWith(`${normalizedHref}/`);
+}
+---
+
+<header class="tp-header">
+  <div class="tp-header__frame">
+    <a href="/" class="tp-header__brand">{SITE_TITLE}</a>
+
+    <nav aria-label="Main navigation" class="tp-header__nav">
+      <ul class="tp-header__nav-list">
+        {
+          NAVIGATION_LINKS.map(({ label, href }) => (
+            <li>
+              <a
+                href={href}
+                class={`tp-header__nav-link ${isActive(href) ? 'is-current' : ''}`}
+                aria-current={isActive(href) ? 'page' : undefined}
+              >
+                {label}
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+    </nav>
+  </div>
+</header>

--- a/apps/astro-blog/src/components/TopPageHeader.astro
+++ b/apps/astro-blog/src/components/TopPageHeader.astro
@@ -3,9 +3,10 @@ import { NAVIGATION_LINKS, SITE_TITLE } from '$constants';
 
 interface Props {
   pathname: string;
+  scrollReveal?: boolean;
 }
 
-const { pathname } = Astro.props;
+const { pathname, scrollReveal = false } = Astro.props;
 
 function normalizePath(path: string): string {
   return path.replace(/\/$/, '') || '/';
@@ -18,7 +19,10 @@ function isActive(href: string): boolean {
 }
 ---
 
-<header class="tp-header">
+<header
+  class={`tp-header ${scrollReveal ? 'is-scroll-reveal' : ''}`}
+  data-scroll-reveal-header={scrollReveal ? '' : undefined}
+>
   <div class="tp-header__frame">
     <a href="/" class="tp-header__brand">{SITE_TITLE}</a>
 

--- a/apps/astro-blog/src/components/TopPageIndex.astro
+++ b/apps/astro-blog/src/components/TopPageIndex.astro
@@ -1,0 +1,163 @@
+---
+import type { PostMeta } from '@estrivault/content-processor';
+import TopPagePagination from '$components/TopPagePagination.astro';
+import { SITE_DESCRIPTION, SITE_TITLE } from '$constants';
+import type { TopPageModel } from '$lib/top-page';
+import { getTagRouteSegment } from '$lib/url-segments';
+
+interface Props {
+  model: TopPageModel;
+}
+
+const { model } = Astro.props;
+
+function formatDate(date: Date): string {
+  return new Intl.DateTimeFormat('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date);
+}
+
+function getReadingTimeLabel(post: PostMeta): string {
+  const minutes = Math.max(1, Math.ceil(post.readingTime ?? 0));
+  return `${minutes} min read`;
+}
+
+function getCategoryHref(category: string): string {
+  return `/category/${encodeURIComponent(category.toLowerCase())}/1`;
+}
+
+const featuredPost = model.featuredPost;
+---
+
+<div class="top-page">
+  <section class="tp-shell">
+    <header class="tp-hero">
+      <div class="tp-hero__copy">
+        <p class="tp-kicker">White Palette</p>
+        <h1 class="tp-hero__title">{SITE_TITLE}</h1>
+        <p class="tp-hero__statement">Text-first writing, arranged on a pale mineral field.</p>
+        <p class="tp-hero__description">{SITE_DESCRIPTION}</p>
+      </div>
+
+      <aside class="tp-hero__aside">
+        <div class="tp-hero__summary">
+          <p class="tp-kicker">Index note</p>
+          <p>
+            White Palette is now the live top-page direction: pale structure, cold grey rails, and
+            one graphite anchor to keep the reading surface severe.
+          </p>
+        </div>
+
+        <dl class="tp-hero__stats" aria-label="Top page summary">
+          <div>
+            <dt>Lead category</dt>
+            <dd>{model.stats.leadCategoryLabel}</dd>
+          </div>
+          <div>
+            <dt>Categories</dt>
+            <dd>{model.stats.categoryCount}</dd>
+          </div>
+          <div>
+            <dt>Posts</dt>
+            <dd>{model.stats.totalPosts}</dd>
+          </div>
+          <div>
+            <dt>Avg read</dt>
+            <dd>{model.stats.averageReadingMinutes || '-'} min</dd>
+          </div>
+        </dl>
+      </aside>
+    </header>
+
+    {
+      featuredPost ?
+        <a href={`/post/${featuredPost.slug}`} class="tp-featured">
+          <div class="tp-row tp-row--featured">
+            <div class="tp-row__meta">
+              <p class="tp-row__category">
+                <strong>{featuredPost.category}</strong>
+              </p>
+              <div class="tp-row__secondary">
+                <span>Published {formatDate(featuredPost.publishedAt)}</span>
+                <span>Reading {getReadingTimeLabel(featuredPost)}</span>
+              </div>
+            </div>
+
+            <div class="tp-row__body">
+              <h2 class="tp-row__title">{featuredPost.title}</h2>
+              <p class="tp-row__description">{featuredPost.description}</p>
+            </div>
+          </div>
+        </a>
+      : <div class="tp-empty-state">No published posts were available.</div>
+    }
+
+    <div class="tp-list">
+      {
+        model.posts.map((post) => (
+          <a href={`/post/${post.slug}`} class="tp-entry">
+            <div class="tp-row">
+              <div class="tp-row__meta">
+                <p class="tp-row__category">
+                  <strong>{post.category}</strong>
+                </p>
+                <div class="tp-row__secondary">
+                  <span>Published {formatDate(post.publishedAt)}</span>
+                  <span>Reading {getReadingTimeLabel(post)}</span>
+                </div>
+              </div>
+
+              <div class="tp-row__body">
+                <h2 class="tp-row__title">{post.title}</h2>
+                <p class="tp-row__description">{post.description}</p>
+              </div>
+            </div>
+          </a>
+        ))
+      }
+    </div>
+
+    {
+      model.totalPages > 1 && (
+        <section class="tp-pagination-wrap">
+          <p class="tp-kicker">Pagination</p>
+          <TopPagePagination
+            currentPage={model.currentPage}
+            totalPages={model.totalPages}
+            baseUrl="/"
+          />
+        </section>
+      )
+    }
+  </section>
+
+  <footer class="tp-meta-footer">
+    <section class="tp-meta-footer__block">
+      <p class="tp-kicker">Categories</p>
+      <ul class="tp-meta-footer__list" aria-label="Sample categories">
+        {
+          model.sampleCategories.map((category) => (
+            <li>
+              <a href={getCategoryHref(category)}>{category}</a>
+            </li>
+          ))
+        }
+      </ul>
+    </section>
+
+    <section class="tp-meta-footer__block">
+      <p class="tp-kicker">Selected tags</p>
+      <ul class="tp-meta-footer__chips" aria-label="Sample tags">
+        {
+          model.sampleTags.slice(0, 6).map((tag) => (
+            <li>
+              <a href={`/tag/${getTagRouteSegment(tag)}/1`}>{tag}</a>
+            </li>
+          ))
+        }
+      </ul>
+    </section>
+  </footer>
+</div>

--- a/apps/astro-blog/src/components/TopPageIndex.astro
+++ b/apps/astro-blog/src/components/TopPageIndex.astro
@@ -33,7 +33,7 @@ const featuredPost = model.featuredPost;
 
 <div class="top-page">
   <section class="tp-shell">
-    <header class="tp-hero">
+    <header class="tp-hero" data-top-hero>
       <div class="tp-hero__copy">
         <p class="tp-kicker">White Palette</p>
         <h1 class="tp-hero__title">{SITE_TITLE}</h1>
@@ -70,6 +70,8 @@ const featuredPost = model.featuredPost;
         </dl>
       </aside>
     </header>
+
+    <div class="tp-header-trigger" data-header-trigger aria-hidden="true"></div>
 
     {
       featuredPost ?

--- a/apps/astro-blog/src/components/TopPagePagination.astro
+++ b/apps/astro-blog/src/components/TopPagePagination.astro
@@ -1,0 +1,130 @@
+---
+interface Props {
+  currentPage: number;
+  totalPages: number;
+  baseUrl: string;
+  maxVisible?: number;
+}
+
+const { currentPage, totalPages, baseUrl, maxVisible = 5 } = Astro.props;
+
+function getPageUrl(page: number): string {
+  if (page === 1) {
+    return baseUrl === '/' ? '/' : `${baseUrl}/1`;
+  }
+
+  if (baseUrl === '/') {
+    return `/${page}`;
+  }
+
+  return `${baseUrl}/${page}`;
+}
+
+function getPageNumbers(): number[] {
+  if (totalPages <= maxVisible) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+
+  const halfVisible = Math.floor(maxVisible / 2);
+  let startPage = Math.max(currentPage - halfVisible, 1);
+  let endPage = Math.min(startPage + maxVisible - 1, totalPages);
+
+  if (endPage === totalPages) {
+    startPage = Math.max(endPage - maxVisible + 1, 1);
+  }
+
+  return Array.from({ length: endPage - startPage + 1 }, (_, i) => startPage + i);
+}
+
+const pageNumbers = getPageNumbers();
+const lastPageNumber = pageNumbers[pageNumbers.length - 1];
+---
+
+<nav aria-label="Pagination" class="tp-pagination">
+  <ul class="tp-pagination__list">
+    <li>
+      {
+        currentPage > 1 ?
+          <a
+            href={getPageUrl(currentPage - 1)}
+            class="tp-pagination__button"
+            aria-label="Previous page"
+          >
+            Prev
+          </a>
+        : <span class="tp-pagination__button is-disabled" aria-disabled="true">
+            Prev
+          </span>
+      }
+    </li>
+
+    {
+      pageNumbers[0] && pageNumbers[0] > 1 && (
+        <>
+          <li>
+            <a href={getPageUrl(1)} class="tp-pagination__button" aria-label="Page 1">
+              1
+            </a>
+          </li>
+          {pageNumbers[0] > 2 && (
+            <li>
+              <span class="tp-pagination__ellipsis">...</span>
+            </li>
+          )}
+        </>
+      )
+    }
+
+    {
+      pageNumbers.map((page) => (
+        <li>
+          {page === currentPage ?
+            <span class="tp-pagination__button is-current" aria-current="page">
+              {page}
+            </span>
+          : <a href={getPageUrl(page)} class="tp-pagination__button" aria-label={`Page ${page}`}>
+              {page}
+            </a>
+          }
+        </li>
+      ))
+    }
+
+    {
+      lastPageNumber && lastPageNumber < totalPages && (
+        <>
+          {lastPageNumber < totalPages - 1 && (
+            <li>
+              <span class="tp-pagination__ellipsis">...</span>
+            </li>
+          )}
+          <li>
+            <a
+              href={getPageUrl(totalPages)}
+              class="tp-pagination__button"
+              aria-label={`Page ${totalPages}`}
+            >
+              {totalPages}
+            </a>
+          </li>
+        </>
+      )
+    }
+
+    <li>
+      {
+        currentPage < totalPages ?
+          <a
+            href={getPageUrl(currentPage + 1)}
+            class="tp-pagination__button"
+            aria-label="Next page"
+          >
+            Next
+          </a>
+        : <span class="tp-pagination__button is-disabled" aria-disabled="true">
+            Next
+          </span>
+      }
+    </li>
+  </ul>
+</nav>

--- a/apps/astro-blog/src/design-preview.css
+++ b/apps/astro-blog/src/design-preview.css
@@ -1,0 +1,580 @@
+.design-preview-shell {
+  --dp-bg: #101216;
+  --dp-bg-secondary: #171a20;
+  --dp-panel: rgb(18 22 28 / 82%);
+  --dp-panel-strong: rgb(23 28 34 / 92%);
+  --dp-text: #edf0f3;
+  --dp-text-muted: #96a0aa;
+  --dp-border: rgb(255 255 255 / 0.12);
+  --dp-grid: rgb(255 255 255 / 0.05);
+  --dp-accent: #e1a94b;
+  --dp-accent-strong: #f0c87d;
+  --dp-shadow: 0 24px 60px rgb(0 0 0 / 0.28);
+  --dp-font-display:
+    'Bahnschrift', 'DIN Alternate', 'Arial Narrow', 'Yu Gothic UI', 'Segoe UI', sans-serif;
+  --dp-font-body: 'Aptos', 'Yu Gothic UI', 'Hiragino Sans', 'Segoe UI', sans-serif;
+  --dp-font-mono: 'IBM Plex Mono', 'Cascadia Mono', 'Cascadia Code', monospace;
+  background:
+    radial-gradient(circle at top, rgb(255 255 255 / 0.07), transparent 28%),
+    linear-gradient(180deg, var(--dp-bg), #090b0f 76%);
+  color: var(--dp-text);
+  font-family: var(--dp-font-body);
+  min-height: 100vh;
+}
+
+.design-preview-shell *,
+.design-preview-shell *::before,
+.design-preview-shell *::after {
+  box-sizing: border-box;
+}
+
+.design-preview-shell a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.design-preview-shell--archive-grid {
+  --dp-bg: #dce2e5;
+  --dp-bg-secondary: #eef2f3;
+  --dp-panel: rgb(249 250 250 / 0.82);
+  --dp-panel-strong: rgb(255 255 255 / 0.92);
+  --dp-text: #182126;
+  --dp-text-muted: #60717a;
+  --dp-border: rgb(24 33 38 / 0.18);
+  --dp-grid: rgb(24 33 38 / 0.07);
+  --dp-accent: #2f9fb3;
+  --dp-accent-strong: #256f80;
+  --dp-shadow: 0 20px 48px rgb(78 96 104 / 0.14);
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 0.45), transparent 18%),
+    linear-gradient(90deg, rgb(255 255 255 / 0.25) 1px, transparent 1px),
+    linear-gradient(rgb(255 255 255 / 0.25) 1px, transparent 1px),
+    linear-gradient(180deg, #d6dde0, #edf2f3 35%, #d8dfe2);
+  background-size:
+    auto,
+    28px 28px,
+    28px 28px,
+    auto;
+}
+
+.design-preview-shell--signal-frame {
+  --dp-bg: #0d1116;
+  --dp-bg-secondary: #141921;
+  --dp-panel: rgb(17 22 29 / 0.84);
+  --dp-panel-strong: rgb(18 23 31 / 0.94);
+  --dp-text: #ecf1ee;
+  --dp-text-muted: #8f9a93;
+  --dp-border: rgb(255 177 70 / 0.16);
+  --dp-grid: rgb(255 177 70 / 0.06);
+  --dp-accent: #c77733;
+  --dp-accent-strong: #ebbb64;
+  --dp-shadow: 0 28px 80px rgb(0 0 0 / 0.34);
+  background:
+    radial-gradient(circle at top right, rgb(199 119 51 / 0.12), transparent 24%),
+    radial-gradient(circle at left, rgb(255 255 255 / 0.04), transparent 18%),
+    linear-gradient(180deg, #131821, #090b10 78%);
+}
+
+.dp-shell {
+  padding: 24px;
+}
+
+.dp-switcher {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  padding-bottom: 20px;
+}
+
+.dp-switcher__frame {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 0 auto;
+  max-width: 1320px;
+  padding: 18px 22px;
+  border: 1px solid var(--dp-border);
+  background: color-mix(in srgb, var(--dp-panel-strong) 92%, transparent);
+  backdrop-filter: blur(18px);
+  box-shadow: var(--dp-shadow);
+}
+
+.design-preview-shell--industrial-slate .dp-switcher__frame {
+  border-radius: 22px 8px 22px 8px;
+}
+
+.design-preview-shell--archive-grid .dp-switcher__frame {
+  border-radius: 8px;
+}
+
+.design-preview-shell--signal-frame .dp-switcher__frame {
+  border-radius: 18px;
+  position: relative;
+  overflow: hidden;
+}
+
+.design-preview-shell--signal-frame .dp-switcher__frame::after {
+  content: '';
+  position: absolute;
+  inset: auto 18px 0 18px;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--dp-accent), transparent);
+}
+
+.dp-switcher__intro {
+  display: grid;
+  gap: 4px;
+}
+
+.dp-switcher__eyebrow,
+.dp-hero-panel__eyebrow,
+.dp-section-heading__eyebrow,
+.dp-status-panel__label,
+.dp-note-block__title {
+  margin: 0;
+  color: var(--dp-accent);
+  font-family: var(--dp-font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.dp-switcher__copy {
+  margin: 0;
+  color: var(--dp-text-muted);
+  font-size: 0.94rem;
+}
+
+.dp-switcher__nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.dp-switcher__link {
+  display: grid;
+  gap: 4px;
+  min-width: 184px;
+  padding: 12px 14px;
+  border: 1px solid var(--dp-border);
+  background: color-mix(in srgb, var(--dp-panel) 92%, transparent);
+  transition:
+    border-color 180ms ease,
+    transform 180ms ease,
+    background-color 180ms ease;
+}
+
+.dp-switcher__link:hover {
+  transform: translateY(-1px);
+  border-color: color-mix(in srgb, var(--dp-accent) 60%, var(--dp-border));
+}
+
+.dp-switcher__link.is-current {
+  border-color: color-mix(in srgb, var(--dp-accent) 80%, var(--dp-border));
+  background: color-mix(in srgb, var(--dp-accent) 14%, var(--dp-panel));
+}
+
+.dp-switcher__link-name {
+  font-family: var(--dp-font-display);
+  font-size: 0.98rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.dp-switcher__link-kicker {
+  color: var(--dp-text-muted);
+  font-family: var(--dp-font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.dp-main {
+  margin: 0 auto;
+  max-width: 1320px;
+}
+
+.design-preview {
+  display: grid;
+  gap: 22px;
+}
+
+.dp-hero-panel,
+.dp-content-panel {
+  border: 1px solid var(--dp-border);
+  background: var(--dp-panel);
+  box-shadow: var(--dp-shadow);
+}
+
+.dp-hero-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(280px, 0.8fr);
+  gap: 24px;
+  padding: 28px;
+}
+
+.dp-content-panel {
+  padding: 24px;
+}
+
+.design-preview-shell--industrial-slate .dp-content-panel,
+.design-preview-shell--industrial-slate .dp-hero-panel {
+  border-radius: 26px 12px 26px 12px;
+}
+
+.design-preview-shell--archive-grid .dp-content-panel,
+.design-preview-shell--archive-grid .dp-hero-panel {
+  border-radius: 10px;
+}
+
+.design-preview-shell--signal-frame .dp-content-panel,
+.design-preview-shell--signal-frame .dp-hero-panel {
+  border-radius: 20px;
+  position: relative;
+  overflow: hidden;
+}
+
+.design-preview-shell--signal-frame .dp-content-panel::before,
+.design-preview-shell--signal-frame .dp-hero-panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border: 1px solid rgb(255 255 255 / 0.04);
+}
+
+.dp-hero-panel__lead {
+  display: grid;
+  gap: 16px;
+}
+
+.dp-hero-panel__title {
+  margin: 0;
+  max-width: 12ch;
+  font-family: var(--dp-font-display);
+  font-size: clamp(2.6rem, 6vw, 4.9rem);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  line-height: 0.95;
+  text-transform: uppercase;
+}
+
+.dp-hero-panel__description,
+.dp-status-panel__body,
+.dp-featured-card__description,
+.dp-post-card__description,
+.dp-note-block__body {
+  margin: 0;
+  color: var(--dp-text-muted);
+  line-height: 1.7;
+}
+
+.dp-metric-list,
+.dp-chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.dp-metric-list__item,
+.dp-chip-list__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 36px;
+  padding: 0 14px;
+  border: 1px solid var(--dp-border);
+  background: color-mix(in srgb, var(--dp-panel-strong) 90%, transparent);
+  color: inherit;
+}
+
+.design-preview-shell--industrial-slate .dp-metric-list__item,
+.design-preview-shell--industrial-slate .dp-chip-list__item {
+  border-radius: 999px;
+}
+
+.design-preview-shell--archive-grid .dp-metric-list__item,
+.design-preview-shell--archive-grid .dp-chip-list__item {
+  border-radius: 4px;
+}
+
+.design-preview-shell--signal-frame .dp-metric-list__item,
+.design-preview-shell--signal-frame .dp-chip-list__item {
+  border-radius: 10px;
+}
+
+.dp-status-panel {
+  display: grid;
+  align-content: start;
+  gap: 16px;
+  padding: 18px;
+  border: 1px solid var(--dp-border);
+  background: color-mix(in srgb, var(--dp-panel-strong) 94%, transparent);
+}
+
+.dp-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin: 0;
+}
+
+.dp-stat-grid__item {
+  padding: 12px 14px;
+  border: 1px solid var(--dp-border);
+  background: color-mix(in srgb, var(--dp-panel) 88%, transparent);
+}
+
+.dp-stat-grid__item dt {
+  color: var(--dp-text-muted);
+  font-family: var(--dp-font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.dp-stat-grid__item dd {
+  margin: 8px 0 0;
+  font-family: var(--dp-font-display);
+  font-size: 1.18rem;
+  font-weight: 700;
+}
+
+.dp-section-heading {
+  display: grid;
+  gap: 4px;
+  margin-bottom: 18px;
+}
+
+.dp-section-heading__title,
+.dp-subheading,
+.dp-featured-card__title,
+.dp-post-card__title {
+  margin: 0;
+  font-family: var(--dp-font-display);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.dp-section-heading__title {
+  font-size: clamp(1.3rem, 2vw, 1.8rem);
+  text-transform: uppercase;
+}
+
+.dp-featured-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(240px, 0.85fr);
+  gap: 18px;
+  min-height: 340px;
+  padding: 18px;
+  border: 1px solid var(--dp-border);
+  background: color-mix(in srgb, var(--dp-panel-strong) 94%, transparent);
+}
+
+.dp-featured-card__copy {
+  display: grid;
+  align-content: start;
+  gap: 18px;
+}
+
+.dp-featured-card__title {
+  font-size: clamp(1.8rem, 3vw, 2.8rem);
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.dp-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  color: var(--dp-text-muted);
+  font-family: var(--dp-font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.dp-featured-card__media {
+  position: relative;
+  min-height: 220px;
+  overflow: hidden;
+  border: 1px solid var(--dp-border);
+  background:
+    linear-gradient(135deg, var(--dp-grid) 25%, transparent 25%),
+    linear-gradient(225deg, var(--dp-grid) 25%, transparent 25%),
+    linear-gradient(45deg, var(--dp-grid) 25%, transparent 25%),
+    linear-gradient(315deg, var(--dp-grid) 25%, var(--dp-bg-secondary) 25%);
+  background-position:
+    12px 0,
+    12px 0,
+    0 0,
+    0 0;
+  background-size: 24px 24px;
+}
+
+.dp-featured-card__image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  mix-blend-mode: luminosity;
+  opacity: 0.88;
+}
+
+.design-preview-shell--archive-grid .dp-featured-card__image {
+  mix-blend-mode: normal;
+  opacity: 0.96;
+}
+
+.design-preview-shell--signal-frame .dp-featured-card__image {
+  mix-blend-mode: screen;
+  opacity: 0.52;
+}
+
+.dp-featured-card__placeholder {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: var(--dp-accent);
+  font-family: var(--dp-font-mono);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.dp-card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.dp-post-card {
+  display: grid;
+  align-content: start;
+  gap: 14px;
+  min-height: 250px;
+  padding: 18px;
+  border: 1px solid var(--dp-border);
+  background: color-mix(in srgb, var(--dp-panel-strong) 94%, transparent);
+  transition:
+    transform 180ms ease,
+    border-color 180ms ease;
+}
+
+.dp-post-card:hover,
+.dp-featured-card:hover {
+  transform: translateY(-2px);
+  border-color: color-mix(in srgb, var(--dp-accent) 72%, var(--dp-border));
+}
+
+.dp-post-card__title {
+  font-size: 1.28rem;
+  line-height: 1.1;
+}
+
+.dp-post-card__footer {
+  display: grid;
+  gap: 12px;
+  margin-top: auto;
+}
+
+.dp-post-card__reading,
+.dp-subheading {
+  color: var(--dp-text-muted);
+  font-family: var(--dp-font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.dp-utility-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(280px, 0.85fr);
+  gap: 22px;
+}
+
+.dp-taxonomy-columns {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.dp-content-panel--support {
+  display: grid;
+  align-content: start;
+  gap: 18px;
+}
+
+.dp-pagination-sample {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.dp-pagination-sample__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 52px;
+  min-height: 44px;
+  padding: 0 16px;
+  border: 1px solid var(--dp-border);
+  background: color-mix(in srgb, var(--dp-panel-strong) 92%, transparent);
+  font-family: var(--dp-font-mono);
+  font-size: 0.86rem;
+}
+
+.dp-pagination-sample__button.is-current {
+  border-color: color-mix(in srgb, var(--dp-accent) 72%, var(--dp-border));
+  background: color-mix(in srgb, var(--dp-accent) 14%, var(--dp-panel));
+}
+
+.dp-note-block {
+  display: grid;
+  gap: 10px;
+  padding: 18px;
+  border: 1px solid var(--dp-border);
+  background: color-mix(in srgb, var(--dp-panel-strong) 92%, transparent);
+}
+
+.dp-empty-state {
+  padding: 22px;
+  border: 1px dashed var(--dp-border);
+  color: var(--dp-text-muted);
+}
+
+@media (max-width: 1080px) {
+  .dp-hero-panel,
+  .dp-utility-grid,
+  .dp-featured-card,
+  .dp-card-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .dp-shell {
+    padding: 14px;
+  }
+
+  .dp-switcher__frame,
+  .dp-hero-panel,
+  .dp-content-panel {
+    padding: 16px;
+  }
+
+  .dp-taxonomy-columns,
+  .dp-stat-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .dp-featured-card {
+    min-height: unset;
+  }
+}

--- a/apps/astro-blog/src/design-preview.css
+++ b/apps/astro-blog/src/design-preview.css
@@ -223,7 +223,10 @@
 
 .dp-variant--index {
   gap: 0;
-  border-top: 1px solid var(--dp-border);
+}
+
+.design-preview--signal-frame {
+  gap: 22px;
 }
 
 .dp-list-section {
@@ -455,7 +458,7 @@
 
 .dp-index-head {
   display: grid;
-  grid-template-columns: 180px minmax(0, 1fr) 120px;
+  grid-template-columns: 220px minmax(0, 1fr);
   gap: 18px;
   padding: 0 0 12px;
   color: var(--dp-text-soft);
@@ -475,13 +478,92 @@
 
 .dp-index-row {
   display: grid;
-  grid-template-columns: 180px minmax(0, 1fr) 120px;
+  grid-template-columns: 220px minmax(0, 1fr);
   gap: 18px;
   padding: 18px 0;
 }
 
 .dp-index-row--featured {
   border-bottom: 2px solid var(--dp-text);
+}
+
+.dp-index-shell {
+  display: grid;
+  gap: 0;
+  padding: 28px 28px 20px;
+  border: 1px solid var(--dp-border);
+  border-radius: 24px;
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 0.82), rgb(247 246 242 / 0.96)),
+    linear-gradient(90deg, rgb(17 17 17 / 0.02) 0 1px, transparent 1px);
+  background-size:
+    auto,
+    26px 26px;
+  box-shadow: var(--dp-shadow);
+}
+
+.dp-index-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(220px, 0.8fr);
+  gap: 18px;
+  padding: 0 0 24px;
+  border-bottom: 1px solid var(--dp-border);
+  margin-bottom: 18px;
+}
+
+.dp-index-header__copy {
+  display: grid;
+  gap: 10px;
+}
+
+.dp-index-header__title {
+  margin: 0;
+  font-size: clamp(2.7rem, 6vw, 5rem);
+  font-weight: 800;
+  letter-spacing: -0.05em;
+  line-height: 0.95;
+  text-transform: uppercase;
+}
+
+.dp-index-header__statement {
+  margin: 0;
+  max-width: 24ch;
+  font-size: clamp(1.15rem, 2.2vw, 1.4rem);
+  line-height: 1.45;
+}
+
+.dp-index-header__description {
+  margin: 0;
+  max-width: 62ch;
+  color: var(--dp-text-soft);
+  line-height: 1.75;
+}
+
+.dp-index-header__meta {
+  display: grid;
+  align-content: end;
+  gap: 12px;
+}
+
+.dp-index-header__meta div {
+  padding-top: 10px;
+  border-top: 1px solid var(--dp-border);
+}
+
+.dp-index-header__meta span {
+  display: block;
+  color: var(--dp-text-soft);
+  font-family: var(--dp-font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.dp-index-header__meta strong {
+  display: block;
+  margin-top: 7px;
+  font-size: 0.98rem;
+  font-weight: 700;
 }
 
 .dp-index-row__category {
@@ -496,10 +578,153 @@
   min-width: 0;
 }
 
-.dp-index-row__meta {
+.dp-index-row__meta,
+.dp-index-row__meta-rail,
+.dp-index-row__secondary {
   display: grid;
   align-content: start;
   gap: 8px;
+}
+
+.dp-index-row__secondary {
+  color: var(--dp-text-soft);
+  font-family: var(--dp-font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.dp-theme-studies {
+  display: grid;
+  gap: 14px;
+}
+
+.dp-theme-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.dp-theme-card {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+  border: 1px solid var(--if-border);
+  border-radius: 18px;
+  background: linear-gradient(180deg, var(--if-surface), #ffffff);
+  box-shadow: 0 16px 34px rgb(17 17 17 / 0.05);
+  color: var(--if-text);
+}
+
+.dp-theme-card__head {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.dp-theme-card__title {
+  margin: 4px 0 0;
+  font-size: 1.15rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.dp-theme-card__note {
+  margin: 0;
+  color: var(--if-text-soft);
+  line-height: 1.65;
+}
+
+.dp-theme-card__swatches {
+  display: flex;
+  gap: 6px;
+}
+
+.dp-theme-card__swatch {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  border: 1px solid rgb(17 17 17 / 0.08);
+}
+
+.dp-theme-card__swatch--rail {
+  background: var(--if-rail);
+}
+
+.dp-theme-card__swatch--accent {
+  background: var(--if-accent);
+}
+
+.dp-theme-card__swatch--surface {
+  background: var(--if-surface);
+}
+
+.dp-theme-preview {
+  display: grid;
+  gap: 0;
+  border-top: 1px solid var(--if-border);
+}
+
+.dp-theme-preview__lead,
+.dp-theme-preview__row {
+  display: grid;
+  grid-template-columns: 170px minmax(0, 1fr);
+  gap: 14px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--if-border);
+}
+
+.dp-theme-preview__meta-rail {
+  display: grid;
+  gap: 8px;
+}
+
+.dp-theme-preview__category {
+  display: grid;
+  gap: 4px;
+  margin: 0;
+}
+
+.dp-theme-preview__category span,
+.dp-theme-preview__secondary {
+  color: var(--if-text-soft);
+  font-family: var(--dp-font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.dp-theme-preview__category strong {
+  color: var(--if-rail);
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.dp-theme-preview__secondary {
+  display: grid;
+  gap: 6px;
+}
+
+.dp-theme-preview__body {
+  display: grid;
+  gap: 8px;
+}
+
+.dp-theme-preview__body h4 {
+  margin: 0;
+  color: var(--if-text);
+  font-size: 1.02rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: 1.25;
+}
+
+.dp-theme-preview__body p {
+  margin: 0;
+  color: var(--if-text-soft);
+  line-height: 1.65;
 }
 
 .dp-empty-state {
@@ -515,6 +740,10 @@
   .dp-banner-grid,
   .dp-support-row--banner,
   .dp-support-row--index,
+  .dp-theme-grid,
+  .dp-theme-preview__lead,
+  .dp-theme-preview__row,
+  .dp-index-header,
   .dp-index-head,
   .dp-index-row {
     grid-template-columns: 1fr;

--- a/apps/astro-blog/src/design-preview.css
+++ b/apps/astro-blog/src/design-preview.css
@@ -1,5 +1,5 @@
 .design-preview-shell {
-  --dp-shadow: 0 28px 80px rgb(0 0 0 / 0.28);
+  --dp-shadow: 0 18px 44px rgb(0 0 0 / 0.22);
   --dp-font-display:
     'Aptos', 'Segoe UI', 'Yu Gothic UI', 'Hiragino Sans', 'Helvetica Neue', sans-serif;
   --dp-font-body:
@@ -7,8 +7,8 @@
   --dp-font-mono: 'IBM Plex Mono', 'Cascadia Code', 'Courier New', monospace;
   min-height: 100vh;
   background:
-    radial-gradient(circle at 14% 8%, var(--dp-bg-aura), transparent 30%),
-    radial-gradient(circle at 82% 0%, var(--dp-bg-aura), transparent 24%),
+    radial-gradient(circle at 14% 8%, var(--dp-bg-aura), transparent 24%),
+    radial-gradient(circle at 82% 0%, var(--dp-bg-aura), transparent 18%),
     linear-gradient(180deg, var(--dp-bg), var(--dp-bg-deep));
   color: var(--dp-text);
   font-family: var(--dp-font-body);
@@ -46,11 +46,10 @@
   margin: 0 auto;
   padding: 15px 18px;
   border: 1px solid var(--dp-border);
-  border-radius: 18px;
-  background:
-    linear-gradient(180deg, rgb(255 255 255 / 0.05), rgb(255 255 255 / 0.01)), rgb(7 10 16 / 0.28);
+  border-radius: 8px;
+  background: rgb(7 10 16 / 0.34);
   box-shadow: var(--dp-shadow);
-  backdrop-filter: blur(12px);
+  backdrop-filter: blur(6px);
 }
 
 .dp-switcher__intro {
@@ -86,8 +85,8 @@
   min-width: 176px;
   padding: 12px 13px;
   border: 1px solid var(--dp-border);
-  border-radius: 14px;
-  background: linear-gradient(180deg, rgb(255 255 255 / 0.04), transparent), var(--dp-panel-alt);
+  border-radius: 4px;
+  background: var(--dp-panel-alt);
   transition:
     transform 180ms ease,
     border-color 180ms ease,
@@ -100,9 +99,8 @@
 }
 
 .dp-switcher__link.is-current {
-  border-color: var(--dp-accent);
-  background:
-    linear-gradient(180deg, rgb(255 255 255 / 0.06), transparent), rgb(255 255 255 / 0.04);
+  border-color: var(--dp-rail);
+  background: rgb(255 255 255 / 0.03);
 }
 
 .dp-switcher__link-name {
@@ -133,15 +131,11 @@
   gap: 0;
   padding: 30px 30px 24px;
   border: 1px solid var(--dp-border);
-  border-radius: 28px;
+  border-radius: 8px;
   background:
-    linear-gradient(180deg, rgb(255 255 255 / 0.05), transparent 20%),
-    linear-gradient(90deg, rgb(255 255 255 / 0.03) 0 1px, transparent 1px),
-    linear-gradient(180deg, var(--dp-panel), rgb(0 0 0 / 0.08));
-  background-size:
-    auto,
-    28px 28px,
-    auto;
+    linear-gradient(180deg, rgb(255 255 255 / 0.03), transparent 16%),
+    linear-gradient(180deg, var(--dp-panel), rgb(0 0 0 / 0.12));
+  background-size: auto, auto;
   box-shadow: var(--dp-shadow);
 }
 
@@ -151,7 +145,7 @@
   gap: 22px;
   padding: 0 0 26px;
   margin-bottom: 18px;
-  border-bottom: 1px solid var(--dp-border);
+  border-bottom: 1px solid var(--dp-border-strong);
 }
 
 .dp-index-header__copy {
@@ -162,10 +156,10 @@
 .dp-index-header__title {
   margin: 0;
   font-family: var(--dp-font-display);
-  font-size: clamp(2.7rem, 6vw, 5rem);
-  font-weight: 800;
-  letter-spacing: -0.05em;
-  line-height: 0.94;
+  font-size: clamp(2.6rem, 5.4vw, 4.5rem);
+  font-weight: 780;
+  letter-spacing: -0.04em;
+  line-height: 0.98;
   text-transform: uppercase;
 }
 
@@ -195,7 +189,7 @@
   display: grid;
   gap: 8px;
   padding: 0 0 14px;
-  border-bottom: 1px solid var(--dp-border);
+  border-bottom: 1px solid var(--dp-border-strong);
 }
 
 .dp-palette {
@@ -213,16 +207,15 @@
   min-height: 36px;
   padding: 8px 10px;
   border: 1px solid var(--dp-border);
-  border-radius: 14px;
+  border-radius: 4px;
   background: var(--dp-panel-alt);
 }
 
 .dp-palette__dot {
-  width: 16px;
-  height: 16px;
-  border-radius: 999px;
-  border: 1px solid rgb(255 255 255 / 0.18);
-  box-shadow: 0 0 0 1px rgb(0 0 0 / 0.12);
+  width: 22px;
+  height: 10px;
+  border-radius: 0;
+  border: 1px solid rgb(255 255 255 / 0.1);
 }
 
 .dp-palette__code {
@@ -241,7 +234,7 @@
 
 .dp-index-header__stats div {
   padding-top: 10px;
-  border-top: 1px solid var(--dp-border);
+  border-top: 1px solid var(--dp-border-strong);
 }
 
 .dp-index-header__stats dt {
@@ -256,18 +249,6 @@
   margin: 7px 0 0;
   font-size: 0.98rem;
   font-weight: 700;
-}
-
-.dp-index-head {
-  display: grid;
-  grid-template-columns: 220px minmax(0, 1fr);
-  gap: 18px;
-  padding: 0 0 12px;
-  color: var(--dp-text-soft);
-  font-family: var(--dp-font-mono);
-  font-size: 0.72rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
 }
 
 .dp-featured-card {
@@ -310,17 +291,9 @@
   margin: 0;
 }
 
-.dp-index-row__category span {
-  color: var(--dp-text-soft);
-  font-family: var(--dp-font-mono);
-  font-size: 0.68rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-}
-
 .dp-index-row__category strong {
   color: var(--dp-rail);
-  font-size: 0.96rem;
+  font-size: 1.04rem;
   font-weight: 700;
   letter-spacing: 0.02em;
   text-transform: uppercase;
@@ -331,8 +304,8 @@
   gap: 8px;
   color: var(--dp-text-soft);
   font-family: var(--dp-font-mono);
-  font-size: 0.72rem;
-  letter-spacing: 0.08em;
+  font-size: 0.76rem;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
@@ -345,10 +318,10 @@
 .dp-featured-card__title,
 .dp-entry__title {
   margin: 0;
-  font-size: clamp(1.24rem, 2.3vw, 1.98rem);
-  font-weight: 760;
-  letter-spacing: -0.03em;
-  line-height: 1.16;
+  font-size: clamp(1.08rem, 1.8vw, 1.48rem);
+  font-weight: 740;
+  letter-spacing: -0.02em;
+  line-height: 1.22;
 }
 
 .dp-support-row {
@@ -363,8 +336,8 @@
   gap: 12px;
   padding: 18px;
   border: 1px solid var(--dp-border);
-  border-radius: 18px;
-  background: linear-gradient(180deg, rgb(255 255 255 / 0.04), transparent), var(--dp-panel-alt);
+  border-radius: 4px;
+  background: var(--dp-panel-alt);
 }
 
 .dp-support-list {
@@ -394,8 +367,8 @@
   min-height: 30px;
   padding: 0 10px;
   border: 1px solid var(--dp-border);
-  border-radius: 999px;
-  background: rgb(255 255 255 / 0.05);
+  border-radius: 2px;
+  background: rgb(255 255 255 / 0.03);
   color: var(--dp-text-soft);
   font-size: 0.8rem;
 }
@@ -414,28 +387,27 @@
   min-height: 36px;
   padding: 0 12px;
   border: 1px solid var(--dp-border);
-  border-radius: 999px;
-  background: rgb(255 255 255 / 0.05);
+  border-radius: 2px;
+  background: rgb(255 255 255 / 0.03);
   font-family: var(--dp-font-mono);
   font-size: 0.8rem;
 }
 
 .dp-pagination-sample__button.is-current {
-  border-color: var(--dp-accent);
+  border-color: var(--dp-rail);
   color: var(--dp-rail);
 }
 
 .dp-empty-state {
   padding: 22px;
   border: 1px dashed var(--dp-border);
-  border-radius: 18px;
+  border-radius: 4px;
   background: var(--dp-panel-alt);
   color: var(--dp-text-soft);
 }
 
 @media (max-width: 1080px) {
   .dp-index-header,
-  .dp-index-head,
   .dp-index-row,
   .dp-support-row {
     grid-template-columns: 1fr;

--- a/apps/astro-blog/src/design-preview.css
+++ b/apps/astro-blog/src/design-preview.css
@@ -47,7 +47,9 @@
   padding: 15px 18px;
   border: 1px solid var(--dp-border);
   border-radius: 8px;
-  background: rgb(7 10 16 / 0.34);
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 0.04), transparent),
+    color-mix(in srgb, var(--dp-panel) 82%, var(--dp-bg-deep) 18%);
   box-shadow: var(--dp-shadow);
   backdrop-filter: blur(6px);
 }
@@ -100,7 +102,7 @@
 
 .dp-switcher__link.is-current {
   border-color: var(--dp-rail);
-  background: rgb(255 255 255 / 0.03);
+  background: color-mix(in srgb, var(--dp-panel-alt) 72%, transparent);
 }
 
 .dp-switcher__link-name {

--- a/apps/astro-blog/src/design-preview.css
+++ b/apps/astro-blog/src/design-preview.css
@@ -14,6 +14,13 @@
   font-family: var(--dp-font-body);
 }
 
+.design-preview-shell--white-palette {
+  background:
+    radial-gradient(circle at 14% 8%, var(--dp-bg-aura), transparent 22%),
+    radial-gradient(circle at 82% 0%, rgb(255 255 255 / 0.28), transparent 18%),
+    linear-gradient(180deg, var(--dp-bg) 0%, #dde2e2 55%, var(--dp-bg-deep) 100%);
+}
+
 .design-preview-shell *,
 .design-preview-shell *::before,
 .design-preview-shell *::after {
@@ -333,6 +340,21 @@
   margin-top: 22px;
 }
 
+.dp-pagination-wrap {
+  display: grid;
+  gap: 10px;
+  margin-top: 22px;
+  padding-top: 16px;
+  border-top: 1px solid var(--dp-border);
+}
+
+.dp-footer-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 14px;
+}
+
 .dp-support-block {
   display: grid;
   gap: 12px;
@@ -411,7 +433,8 @@
 @media (max-width: 1080px) {
   .dp-index-header,
   .dp-index-row,
-  .dp-support-row {
+  .dp-support-row,
+  .dp-footer-meta {
     grid-template-columns: 1fr;
   }
 }

--- a/apps/astro-blog/src/design-preview.css
+++ b/apps/astro-blog/src/design-preview.css
@@ -1,23 +1,17 @@
 .design-preview-shell {
-  --dp-bg: #f5f4ef;
-  --dp-panel: #ffffff;
-  --dp-panel-alt: #f8f7f3;
-  --dp-text: #111111;
-  --dp-text-soft: #5f5a54;
-  --dp-border: #d7d2ca;
-  --dp-border-strong: #b7b0a6;
-  --dp-shadow: 0 18px 46px rgb(17 17 17 / 0.04);
+  --dp-shadow: 0 28px 80px rgb(0 0 0 / 0.28);
   --dp-font-display:
     'Aptos', 'Segoe UI', 'Yu Gothic UI', 'Hiragino Sans', 'Helvetica Neue', sans-serif;
   --dp-font-body:
     'Aptos', 'Segoe UI', 'Yu Gothic UI', 'Hiragino Sans', 'Helvetica Neue', sans-serif;
   --dp-font-mono: 'IBM Plex Mono', 'Cascadia Code', 'Courier New', monospace;
+  min-height: 100vh;
   background:
-    linear-gradient(180deg, rgb(255 255 255 / 0.65), transparent 18%),
-    linear-gradient(180deg, var(--dp-bg), #f1efe9);
+    radial-gradient(circle at 14% 8%, var(--dp-bg-aura), transparent 30%),
+    radial-gradient(circle at 82% 0%, var(--dp-bg-aura), transparent 24%),
+    linear-gradient(180deg, var(--dp-bg), var(--dp-bg-deep));
   color: var(--dp-text);
   font-family: var(--dp-font-body);
-  min-height: 100vh;
 }
 
 .design-preview-shell *,
@@ -39,7 +33,7 @@
   position: sticky;
   top: 0;
   z-index: 30;
-  padding-bottom: 16px;
+  padding-bottom: 18px;
 }
 
 .dp-switcher__frame {
@@ -48,14 +42,15 @@
   align-items: center;
   justify-content: space-between;
   gap: 14px;
-  margin: 0 auto;
   max-width: 1280px;
+  margin: 0 auto;
   padding: 15px 18px;
   border: 1px solid var(--dp-border);
   border-radius: 18px;
-  background: rgb(255 255 255 / 0.88);
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 0.05), rgb(255 255 255 / 0.01)), rgb(7 10 16 / 0.28);
   box-shadow: var(--dp-shadow);
-  backdrop-filter: blur(10px);
+  backdrop-filter: blur(12px);
 }
 
 .dp-switcher__intro {
@@ -88,14 +83,15 @@
 .dp-switcher__link {
   display: grid;
   gap: 4px;
-  min-width: 184px;
-  padding: 11px 12px;
+  min-width: 176px;
+  padding: 12px 13px;
   border: 1px solid var(--dp-border);
-  border-radius: 12px;
-  background: var(--dp-panel);
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgb(255 255 255 / 0.04), transparent), var(--dp-panel-alt);
   transition:
+    transform 180ms ease,
     border-color 180ms ease,
-    transform 180ms ease;
+    background-color 180ms ease;
 }
 
 .dp-switcher__link:hover {
@@ -104,7 +100,9 @@
 }
 
 .dp-switcher__link.is-current {
-  border-color: var(--dp-text);
+  border-color: var(--dp-accent);
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 0.06), transparent), rgb(255 255 255 / 0.04);
 }
 
 .dp-switcher__link-name {
@@ -122,78 +120,131 @@
 }
 
 .dp-main {
-  margin: 0 auto;
   max-width: 1280px;
+  margin: 0 auto;
 }
 
 .design-preview {
   display: grid;
-  gap: 18px;
 }
 
-.dp-masthead {
+.dp-index-shell {
   display: grid;
-  grid-template-columns: minmax(0, 1.25fr) minmax(260px, 0.75fr);
-  gap: 18px;
-  padding: 24px 28px 28px;
+  gap: 0;
+  padding: 30px 30px 24px;
   border: 1px solid var(--dp-border);
-  border-radius: 24px;
-  background: var(--dp-panel);
+  border-radius: 28px;
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 0.05), transparent 20%),
+    linear-gradient(90deg, rgb(255 255 255 / 0.03) 0 1px, transparent 1px),
+    linear-gradient(180deg, var(--dp-panel), rgb(0 0 0 / 0.08));
+  background-size:
+    auto,
+    28px 28px,
+    auto;
   box-shadow: var(--dp-shadow);
 }
 
-.dp-masthead--banner {
-  padding-top: 30px;
+.dp-index-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
+  gap: 22px;
+  padding: 0 0 26px;
+  margin-bottom: 18px;
+  border-bottom: 1px solid var(--dp-border);
 }
 
-.dp-masthead__copy {
+.dp-index-header__copy {
   display: grid;
   gap: 10px;
 }
 
-.dp-masthead__statement {
-  margin: 0;
-  max-width: 26ch;
-  color: var(--dp-text);
-  font-size: clamp(1.1rem, 2vw, 1.35rem);
-  line-height: 1.45;
-}
-
-.dp-masthead__site {
+.dp-index-header__title {
   margin: 0;
   font-family: var(--dp-font-display);
-  font-size: clamp(3rem, 7vw, 6rem);
+  font-size: clamp(2.7rem, 6vw, 5rem);
   font-weight: 800;
-  letter-spacing: -0.04em;
-  line-height: 0.92;
+  letter-spacing: -0.05em;
+  line-height: 0.94;
   text-transform: uppercase;
 }
 
-.dp-masthead__description,
-.dp-masthead__summary,
-.dp-featured-card__description,
-.dp-entry__description,
-.dp-support-copy {
+.dp-index-header__statement {
   margin: 0;
-  max-width: 62ch;
-  color: var(--dp-text-soft);
-  line-height: 1.75;
+  max-width: 24ch;
+  font-size: clamp(1.18rem, 2vw, 1.42rem);
+  line-height: 1.45;
 }
 
-.dp-masthead__stats {
+.dp-index-header__description,
+.dp-featured-card__description,
+.dp-entry__description,
+.dp-index-header__summary-copy {
+  margin: 0;
+  color: var(--dp-text-soft);
+  line-height: 1.72;
+}
+
+.dp-index-header__aside {
+  display: grid;
+  gap: 16px;
+  align-content: start;
+}
+
+.dp-index-header__summary {
+  display: grid;
+  gap: 8px;
+  padding: 0 0 14px;
+  border-bottom: 1px solid var(--dp-border);
+}
+
+.dp-palette {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.dp-palette__item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 36px;
+  padding: 8px 10px;
+  border: 1px solid var(--dp-border);
+  border-radius: 14px;
+  background: var(--dp-panel-alt);
+}
+
+.dp-palette__dot {
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  border: 1px solid rgb(255 255 255 / 0.18);
+  box-shadow: 0 0 0 1px rgb(0 0 0 / 0.12);
+}
+
+.dp-palette__code {
+  font-family: var(--dp-font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.dp-index-header__stats {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px;
   margin: 0;
-  align-self: end;
 }
 
-.dp-masthead__stat {
-  padding: 12px 0 0;
+.dp-index-header__stats div {
+  padding-top: 10px;
   border-top: 1px solid var(--dp-border);
 }
 
-.dp-masthead__stat dt {
+.dp-index-header__stats dt {
   color: var(--dp-text-soft);
   font-family: var(--dp-font-mono);
   font-size: 0.7rem;
@@ -201,97 +252,64 @@
   text-transform: uppercase;
 }
 
-.dp-masthead__stat dd {
+.dp-index-header__stats dd {
   margin: 7px 0 0;
-  font-size: 1rem;
+  font-size: 0.98rem;
   font-weight: 700;
 }
 
-.dp-variant {
+.dp-index-head {
   display: grid;
+  grid-template-columns: 220px minmax(0, 1fr);
   gap: 18px;
-}
-
-.dp-variant--monolith {
-  max-width: 820px;
-  margin: 0 auto;
-}
-
-.dp-variant--banner {
-  gap: 22px;
-}
-
-.dp-variant--index {
-  gap: 0;
-}
-
-.design-preview--signal-frame {
-  gap: 22px;
-}
-
-.dp-list-section {
-  display: grid;
-  gap: 12px;
-}
-
-.dp-section-heading {
-  display: grid;
-  gap: 4px;
-}
-
-.dp-section-heading__title {
-  margin: 0;
-  font-size: clamp(1.2rem, 2vw, 1.5rem);
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  line-height: 1.2;
-}
-
-.dp-featured-card,
-.dp-support-block,
-.dp-banner-panel {
-  border: 1px solid var(--dp-border);
-  border-radius: 18px;
-  background: var(--dp-panel);
+  padding: 0 0 12px;
+  color: var(--dp-text-soft);
+  font-family: var(--dp-font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
 }
 
 .dp-featured-card {
   display: grid;
-  gap: 12px;
-  padding: 22px 24px;
-  box-shadow: var(--dp-shadow);
-}
-
-.dp-featured-card--banner {
-  min-height: 100%;
 }
 
 .dp-featured-card--index {
-  padding: 0;
-  border: 0;
-  border-radius: 0;
-  box-shadow: none;
-  background: transparent;
+  border-bottom: 1px solid var(--dp-border-strong);
 }
 
-.dp-featured-card__title,
-.dp-entry__title {
+.dp-index-list {
+  display: grid;
+}
+
+.dp-entry--index {
+  border-bottom: 1px solid var(--dp-border);
+}
+
+.dp-index-row {
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr);
+  gap: 18px;
+  padding: 18px 0;
+}
+
+.dp-index-row--featured {
+  padding-top: 0;
+  padding-bottom: 24px;
+}
+
+.dp-index-row__meta-rail {
+  display: grid;
+  align-content: start;
+  gap: 10px;
+}
+
+.dp-index-row__category {
+  display: grid;
+  gap: 6px;
   margin: 0;
-  font-size: clamp(1.2rem, 2.5vw, 1.95rem);
-  font-weight: 750;
-  letter-spacing: -0.03em;
-  line-height: 1.16;
 }
 
-.dp-entry__category {
-  display: inline-flex;
-  align-items: baseline;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin: 0;
-}
-
-.dp-entry__category span,
 .dp-index-row__category span {
   color: var(--dp-text-soft);
   font-family: var(--dp-font-mono);
@@ -300,19 +318,17 @@
   text-transform: uppercase;
 }
 
-.dp-entry__category strong,
 .dp-index-row__category strong {
-  font-size: 0.95rem;
+  color: var(--dp-rail);
+  font-size: 0.96rem;
   font-weight: 700;
-  letter-spacing: 0.01em;
+  letter-spacing: 0.02em;
   text-transform: uppercase;
 }
 
-.dp-entry__secondary,
-.dp-index-row__meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px 14px;
+.dp-index-row__secondary {
+  display: grid;
+  gap: 8px;
   color: var(--dp-text-soft);
   font-family: var(--dp-font-mono);
   font-size: 0.72rem;
@@ -320,79 +336,35 @@
   text-transform: uppercase;
 }
 
-.dp-list {
+.dp-index-row__body {
   display: grid;
+  gap: 8px;
+  min-width: 0;
 }
 
-.dp-list--monolith {
-  gap: 0;
-  border-top: 1px solid var(--dp-border);
-}
-
-.dp-entry {
-  display: grid;
-  gap: 10px;
-}
-
-.dp-entry--monolith {
-  padding: 18px 0;
-  border-top: 1px solid var(--dp-border);
-}
-
-.dp-banner-panel {
-  padding: 16px 18px;
-  background:
-    linear-gradient(90deg, rgb(17 17 17 / 0.02) 0 1px, transparent 1px),
-    linear-gradient(180deg, rgb(17 17 17 / 0.02) 0 1px, transparent 1px), var(--dp-panel);
-  background-size:
-    22px 22px,
-    22px 22px,
-    auto;
-}
-
-.dp-banner-panel__lede {
+.dp-featured-card__title,
+.dp-entry__title {
   margin: 0;
-  max-width: 64ch;
-  font-size: 1rem;
-  line-height: 1.7;
-}
-
-.dp-banner-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
-  gap: 18px;
-}
-
-.dp-banner-stack {
-  display: grid;
-  gap: 12px;
-}
-
-.dp-entry--banner {
-  padding: 18px 18px 20px;
-  border: 1px solid var(--dp-border);
-  border-radius: 14px;
-  background: var(--dp-panel-alt);
+  font-size: clamp(1.24rem, 2.3vw, 1.98rem);
+  font-weight: 760;
+  letter-spacing: -0.03em;
+  line-height: 1.16;
 }
 
 .dp-support-row {
   display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 12px;
-}
-
-.dp-support-row--banner {
-  grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.15fr);
-}
-
-.dp-support-row--index {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  margin-top: 18px;
+  margin-top: 22px;
 }
 
 .dp-support-block {
   display: grid;
   gap: 12px;
   padding: 18px;
+  border: 1px solid var(--dp-border);
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgb(255 255 255 / 0.04), transparent), var(--dp-panel-alt);
 }
 
 .dp-support-list {
@@ -401,10 +373,6 @@
   margin: 0;
   padding: 0;
   list-style: none;
-}
-
-.dp-support-list a {
-  color: var(--dp-text);
 }
 
 .dp-support-list a:hover {
@@ -423,11 +391,11 @@
 .dp-chip-list__item {
   display: inline-flex;
   align-items: center;
-  min-height: 28px;
+  min-height: 30px;
   padding: 0 10px;
   border: 1px solid var(--dp-border);
   border-radius: 999px;
-  background: var(--dp-panel-alt);
+  background: rgb(255 255 255 / 0.05);
   color: var(--dp-text-soft);
   font-size: 0.8rem;
 }
@@ -447,305 +415,29 @@
   padding: 0 12px;
   border: 1px solid var(--dp-border);
   border-radius: 999px;
-  background: var(--dp-panel-alt);
+  background: rgb(255 255 255 / 0.05);
   font-family: var(--dp-font-mono);
   font-size: 0.8rem;
 }
 
 .dp-pagination-sample__button.is-current {
-  border-color: var(--dp-text);
-}
-
-.dp-index-head {
-  display: grid;
-  grid-template-columns: 220px minmax(0, 1fr);
-  gap: 18px;
-  padding: 0 0 12px;
-  color: var(--dp-text-soft);
-  font-family: var(--dp-font-mono);
-  font-size: 0.72rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-}
-
-.dp-index-list {
-  display: grid;
-}
-
-.dp-entry--index {
-  border-bottom: 1px solid var(--dp-border);
-}
-
-.dp-index-row {
-  display: grid;
-  grid-template-columns: 220px minmax(0, 1fr);
-  gap: 18px;
-  padding: 18px 0;
-}
-
-.dp-index-row--featured {
-  border-bottom: 2px solid var(--dp-text);
-}
-
-.dp-index-shell {
-  display: grid;
-  gap: 0;
-  padding: 28px 28px 20px;
-  border: 1px solid var(--dp-border);
-  border-radius: 24px;
-  background:
-    linear-gradient(180deg, rgb(255 255 255 / 0.82), rgb(247 246 242 / 0.96)),
-    linear-gradient(90deg, rgb(17 17 17 / 0.02) 0 1px, transparent 1px);
-  background-size:
-    auto,
-    26px 26px;
-  box-shadow: var(--dp-shadow);
-}
-
-.dp-index-header {
-  display: grid;
-  grid-template-columns: minmax(0, 1.2fr) minmax(220px, 0.8fr);
-  gap: 18px;
-  padding: 0 0 24px;
-  border-bottom: 1px solid var(--dp-border);
-  margin-bottom: 18px;
-}
-
-.dp-index-header__copy {
-  display: grid;
-  gap: 10px;
-}
-
-.dp-index-header__title {
-  margin: 0;
-  font-size: clamp(2.7rem, 6vw, 5rem);
-  font-weight: 800;
-  letter-spacing: -0.05em;
-  line-height: 0.95;
-  text-transform: uppercase;
-}
-
-.dp-index-header__statement {
-  margin: 0;
-  max-width: 24ch;
-  font-size: clamp(1.15rem, 2.2vw, 1.4rem);
-  line-height: 1.45;
-}
-
-.dp-index-header__description {
-  margin: 0;
-  max-width: 62ch;
-  color: var(--dp-text-soft);
-  line-height: 1.75;
-}
-
-.dp-index-header__meta {
-  display: grid;
-  align-content: end;
-  gap: 12px;
-}
-
-.dp-index-header__meta div {
-  padding-top: 10px;
-  border-top: 1px solid var(--dp-border);
-}
-
-.dp-index-header__meta span {
-  display: block;
-  color: var(--dp-text-soft);
-  font-family: var(--dp-font-mono);
-  font-size: 0.72rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.dp-index-header__meta strong {
-  display: block;
-  margin-top: 7px;
-  font-size: 0.98rem;
-  font-weight: 700;
-}
-
-.dp-index-row__category {
-  display: grid;
-  align-content: start;
-  gap: 6px;
-}
-
-.dp-index-row__body {
-  display: grid;
-  gap: 8px;
-  min-width: 0;
-}
-
-.dp-index-row__meta,
-.dp-index-row__meta-rail,
-.dp-index-row__secondary {
-  display: grid;
-  align-content: start;
-  gap: 8px;
-}
-
-.dp-index-row__secondary {
-  color: var(--dp-text-soft);
-  font-family: var(--dp-font-mono);
-  font-size: 0.72rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.dp-theme-studies {
-  display: grid;
-  gap: 14px;
-}
-
-.dp-theme-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 14px;
-}
-
-.dp-theme-card {
-  display: grid;
-  gap: 14px;
-  padding: 18px;
-  border: 1px solid var(--if-border);
-  border-radius: 18px;
-  background: linear-gradient(180deg, var(--if-surface), #ffffff);
-  box-shadow: 0 16px 34px rgb(17 17 17 / 0.05);
-  color: var(--if-text);
-}
-
-.dp-theme-card__head {
-  display: flex;
-  align-items: start;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.dp-theme-card__title {
-  margin: 4px 0 0;
-  font-size: 1.15rem;
-  font-weight: 800;
-  letter-spacing: -0.02em;
-}
-
-.dp-theme-card__note {
-  margin: 0;
-  color: var(--if-text-soft);
-  line-height: 1.65;
-}
-
-.dp-theme-card__swatches {
-  display: flex;
-  gap: 6px;
-}
-
-.dp-theme-card__swatch {
-  width: 18px;
-  height: 18px;
-  border-radius: 999px;
-  border: 1px solid rgb(17 17 17 / 0.08);
-}
-
-.dp-theme-card__swatch--rail {
-  background: var(--if-rail);
-}
-
-.dp-theme-card__swatch--accent {
-  background: var(--if-accent);
-}
-
-.dp-theme-card__swatch--surface {
-  background: var(--if-surface);
-}
-
-.dp-theme-preview {
-  display: grid;
-  gap: 0;
-  border-top: 1px solid var(--if-border);
-}
-
-.dp-theme-preview__lead,
-.dp-theme-preview__row {
-  display: grid;
-  grid-template-columns: 170px minmax(0, 1fr);
-  gap: 14px;
-  padding: 14px 0;
-  border-bottom: 1px solid var(--if-border);
-}
-
-.dp-theme-preview__meta-rail {
-  display: grid;
-  gap: 8px;
-}
-
-.dp-theme-preview__category {
-  display: grid;
-  gap: 4px;
-  margin: 0;
-}
-
-.dp-theme-preview__category span,
-.dp-theme-preview__secondary {
-  color: var(--if-text-soft);
-  font-family: var(--dp-font-mono);
-  font-size: 0.68rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.dp-theme-preview__category strong {
-  color: var(--if-rail);
-  font-size: 0.9rem;
-  font-weight: 700;
-  text-transform: uppercase;
-}
-
-.dp-theme-preview__secondary {
-  display: grid;
-  gap: 6px;
-}
-
-.dp-theme-preview__body {
-  display: grid;
-  gap: 8px;
-}
-
-.dp-theme-preview__body h4 {
-  margin: 0;
-  color: var(--if-text);
-  font-size: 1.02rem;
-  font-weight: 800;
-  letter-spacing: -0.02em;
-  line-height: 1.25;
-}
-
-.dp-theme-preview__body p {
-  margin: 0;
-  color: var(--if-text-soft);
-  line-height: 1.65;
+  border-color: var(--dp-accent);
+  color: var(--dp-rail);
 }
 
 .dp-empty-state {
   padding: 22px;
   border: 1px dashed var(--dp-border);
   border-radius: 18px;
-  background: var(--dp-panel);
+  background: var(--dp-panel-alt);
   color: var(--dp-text-soft);
 }
 
 @media (max-width: 1080px) {
-  .dp-masthead,
-  .dp-banner-grid,
-  .dp-support-row--banner,
-  .dp-support-row--index,
-  .dp-theme-grid,
-  .dp-theme-preview__lead,
-  .dp-theme-preview__row,
   .dp-index-header,
   .dp-index-head,
-  .dp-index-row {
+  .dp-index-row,
+  .dp-support-row {
     grid-template-columns: 1fr;
   }
 }
@@ -756,10 +448,8 @@
   }
 
   .dp-switcher__frame,
-  .dp-masthead,
-  .dp-featured-card,
-  .dp-support-block,
-  .dp-banner-panel {
+  .dp-index-shell,
+  .dp-support-block {
     padding: 16px;
   }
 
@@ -768,7 +458,10 @@
     flex: 1 1 100%;
   }
 
-  .dp-entry--monolith,
+  .dp-index-header__stats {
+    grid-template-columns: 1fr;
+  }
+
   .dp-index-row,
   .dp-index-row--featured {
     padding-top: 16px;

--- a/apps/astro-blog/src/design-preview.css
+++ b/apps/astro-blog/src/design-preview.css
@@ -1,16 +1,20 @@
 .design-preview-shell {
-  --dp-bg: #f7f6f2;
+  --dp-bg: #f5f4ef;
   --dp-panel: #ffffff;
-  --dp-panel-muted: #fbfbf9;
-  --dp-text: #141414;
-  --dp-text-muted: #66635f;
-  --dp-border: #dad6cf;
-  --dp-border-strong: #bdb7ae;
-  --dp-shadow: 0 14px 40px rgb(20 20 20 / 0.04);
-  --dp-font-display: Georgia, 'Times New Roman', 'Yu Mincho', serif;
-  --dp-font-body: 'Aptos', 'Yu Gothic UI', 'Hiragino Sans', 'Segoe UI', sans-serif;
+  --dp-panel-alt: #f8f7f3;
+  --dp-text: #111111;
+  --dp-text-soft: #5f5a54;
+  --dp-border: #d7d2ca;
+  --dp-border-strong: #b7b0a6;
+  --dp-shadow: 0 18px 46px rgb(17 17 17 / 0.04);
+  --dp-font-display:
+    'Aptos', 'Segoe UI', 'Yu Gothic UI', 'Hiragino Sans', 'Helvetica Neue', sans-serif;
+  --dp-font-body:
+    'Aptos', 'Segoe UI', 'Yu Gothic UI', 'Hiragino Sans', 'Helvetica Neue', sans-serif;
   --dp-font-mono: 'IBM Plex Mono', 'Cascadia Code', 'Courier New', monospace;
-  background: var(--dp-bg);
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 0.65), transparent 18%),
+    linear-gradient(180deg, var(--dp-bg), #f1efe9);
   color: var(--dp-text);
   font-family: var(--dp-font-body);
   min-height: 100vh;
@@ -28,21 +32,14 @@
 }
 
 .dp-shell {
-  padding: 24px 20px 48px;
+  padding: 24px 18px 56px;
 }
 
 .dp-switcher {
   position: sticky;
   top: 0;
   z-index: 30;
-  padding-bottom: 18px;
-}
-
-.dp-switcher__frame,
-.dp-featured-card,
-.dp-support-block,
-.dp-hero-panel {
-  border-radius: 16px;
+  padding-bottom: 16px;
 }
 
 .dp-switcher__frame {
@@ -50,14 +47,15 @@
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
+  gap: 14px;
   margin: 0 auto;
-  max-width: 1180px;
-  padding: 16px 20px;
+  max-width: 1280px;
+  padding: 15px 18px;
   border: 1px solid var(--dp-border);
-  background: rgb(255 255 255 / 0.9);
+  border-radius: 18px;
+  background: rgb(255 255 255 / 0.88);
   box-shadow: var(--dp-shadow);
-  backdrop-filter: blur(12px);
+  backdrop-filter: blur(10px);
 }
 
 .dp-switcher__intro {
@@ -65,22 +63,19 @@
   gap: 4px;
 }
 
-.dp-switcher__eyebrow,
-.dp-hero-panel__eyebrow,
-.dp-section-heading__eyebrow,
-.dp-support-block__label,
-.dp-ledger-row__label {
+.dp-kicker,
+.dp-switcher__eyebrow {
   margin: 0;
-  color: var(--dp-text-muted);
+  color: var(--dp-text-soft);
   font-family: var(--dp-font-mono);
   font-size: 0.72rem;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
 }
 
 .dp-switcher__copy {
   margin: 0;
-  color: var(--dp-text-muted);
+  color: var(--dp-text-soft);
   font-size: 0.92rem;
 }
 
@@ -94,13 +89,13 @@
   display: grid;
   gap: 4px;
   min-width: 184px;
-  padding: 11px 13px;
+  padding: 11px 12px;
   border: 1px solid var(--dp-border);
+  border-radius: 12px;
   background: var(--dp-panel);
   transition:
     border-color 180ms ease,
-    transform 180ms ease,
-    background-color 180ms ease;
+    transform 180ms ease;
 }
 
 .dp-switcher__link:hover {
@@ -113,14 +108,13 @@
 }
 
 .dp-switcher__link-name {
-  font-family: var(--dp-font-body);
   font-size: 0.96rem;
   font-weight: 700;
   letter-spacing: 0.01em;
 }
 
 .dp-switcher__link-kicker {
-  color: var(--dp-text-muted);
+  color: var(--dp-text-soft);
   font-family: var(--dp-font-mono);
   font-size: 0.72rem;
   letter-spacing: 0.08em;
@@ -129,7 +123,7 @@
 
 .dp-main {
   margin: 0 auto;
-  max-width: 1180px;
+  max-width: 1280px;
 }
 
 .design-preview {
@@ -137,115 +131,124 @@
   gap: 18px;
 }
 
-.dp-hero-panel {
+.dp-masthead {
   display: grid;
-  grid-template-columns: minmax(0, 1.35fr) minmax(260px, 0.65fr);
+  grid-template-columns: minmax(0, 1.25fr) minmax(260px, 0.75fr);
   gap: 18px;
-  padding: 28px 30px;
+  padding: 24px 28px 28px;
   border: 1px solid var(--dp-border);
+  border-radius: 24px;
   background: var(--dp-panel);
   box-shadow: var(--dp-shadow);
 }
 
-.dp-hero-panel__body {
+.dp-masthead--banner {
+  padding-top: 30px;
+}
+
+.dp-masthead__copy {
   display: grid;
   gap: 10px;
 }
 
-.dp-hero-panel__title {
+.dp-masthead__statement {
   margin: 0;
-  max-width: 16ch;
-  font-family: var(--dp-font-display);
-  font-size: clamp(2rem, 4vw, 3.35rem);
-  font-weight: 700;
-  letter-spacing: 0.01em;
-  line-height: 1.05;
+  max-width: 26ch;
+  color: var(--dp-text);
+  font-size: clamp(1.1rem, 2vw, 1.35rem);
+  line-height: 1.45;
 }
 
-.dp-hero-panel__description,
+.dp-masthead__site {
+  margin: 0;
+  font-family: var(--dp-font-display);
+  font-size: clamp(3rem, 7vw, 6rem);
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  line-height: 0.92;
+  text-transform: uppercase;
+}
+
+.dp-masthead__description,
+.dp-masthead__summary,
 .dp-featured-card__description,
 .dp-entry__description,
-.dp-sidebar__body,
-.dp-hero-panel__summary {
+.dp-support-copy {
   margin: 0;
-  color: var(--dp-text-muted);
+  max-width: 62ch;
+  color: var(--dp-text-soft);
   line-height: 1.75;
 }
 
-.dp-hero-panel__summary {
-  max-width: 60ch;
-}
-
-.dp-hero-meta {
+.dp-masthead__stats {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px;
   margin: 0;
+  align-self: end;
 }
 
-.dp-hero-meta__item {
-  padding: 12px 0;
+.dp-masthead__stat {
+  padding: 12px 0 0;
   border-top: 1px solid var(--dp-border);
 }
 
-.dp-hero-meta__item dt {
-  color: var(--dp-text-muted);
+.dp-masthead__stat dt {
+  color: var(--dp-text-soft);
   font-family: var(--dp-font-mono);
-  font-size: 0.72rem;
+  font-size: 0.7rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
-.dp-hero-meta__item dd {
-  margin: 8px 0 0;
+.dp-masthead__stat dd {
+  margin: 7px 0 0;
   font-size: 1rem;
-  font-weight: 600;
+  font-weight: 700;
 }
 
-.dp-layout {
+.dp-variant {
   display: grid;
   gap: 18px;
 }
 
-.dp-layout--essay {
-  max-width: 840px;
+.dp-variant--monolith {
+  max-width: 820px;
   margin: 0 auto;
 }
 
-.dp-layout--split {
-  grid-template-columns: minmax(0, 1fr) 280px;
-  align-items: start;
+.dp-variant--banner {
+  gap: 22px;
 }
 
-.dp-layout--ledger {
+.dp-variant--index {
   gap: 0;
   border-top: 1px solid var(--dp-border);
 }
 
 .dp-list-section {
   display: grid;
-  gap: 14px;
+  gap: 12px;
 }
 
 .dp-section-heading {
   display: grid;
-  gap: 5px;
-  padding-top: 10px;
+  gap: 4px;
 }
 
 .dp-section-heading__title {
   margin: 0;
-  font-family: var(--dp-font-display);
-  font-size: clamp(1.2rem, 2vw, 1.55rem);
+  font-size: clamp(1.2rem, 2vw, 1.5rem);
   font-weight: 700;
+  letter-spacing: -0.02em;
   line-height: 1.2;
 }
 
 .dp-featured-card,
-.dp-entry,
 .dp-support-block,
-.dp-sidebar {
+.dp-banner-panel {
   border: 1px solid var(--dp-border);
+  border-radius: 18px;
   background: var(--dp-panel);
 }
 
@@ -256,71 +259,153 @@
   box-shadow: var(--dp-shadow);
 }
 
-.dp-featured-card--essay,
-.dp-featured-card--split {
-  margin-bottom: 8px;
+.dp-featured-card--banner {
+  min-height: 100%;
 }
 
-.dp-card-meta,
-.dp-ledger-row__meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px 14px;
-  margin: 0;
-  color: var(--dp-text-muted);
-  font-family: var(--dp-font-mono);
-  font-size: 0.74rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+.dp-featured-card--index {
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  background: transparent;
 }
 
 .dp-featured-card__title,
 .dp-entry__title {
   margin: 0;
-  font-family: var(--dp-font-display);
+  font-size: clamp(1.2rem, 2.5vw, 1.95rem);
+  font-weight: 750;
+  letter-spacing: -0.03em;
+  line-height: 1.16;
+}
+
+.dp-entry__category {
+  display: inline-flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0;
+}
+
+.dp-entry__category span,
+.dp-index-row__category span {
+  color: var(--dp-text-soft);
+  font-family: var(--dp-font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.dp-entry__category strong,
+.dp-index-row__category strong {
+  font-size: 0.95rem;
   font-weight: 700;
-  line-height: 1.18;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
 }
 
-.dp-featured-card__title {
-  font-size: clamp(1.7rem, 3vw, 2.35rem);
-}
-
-.dp-entry__title {
-  font-size: clamp(1.15rem, 2vw, 1.45rem);
+.dp-entry__secondary,
+.dp-index-row__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 14px;
+  color: var(--dp-text-soft);
+  font-family: var(--dp-font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .dp-list {
   display: grid;
 }
 
-.dp-list--essay {
+.dp-list--monolith {
   gap: 0;
   border-top: 1px solid var(--dp-border);
-}
-
-.dp-list--split {
-  gap: 0;
 }
 
 .dp-entry {
   display: grid;
   gap: 10px;
-  padding: 20px 0;
+}
+
+.dp-entry--monolith {
+  padding: 18px 0;
   border-top: 1px solid var(--dp-border);
-  background: transparent;
 }
 
-.dp-entry--essay,
-.dp-entry--split {
-  border-right: 0;
-  border-bottom: 0;
-  border-left: 0;
-  border-radius: 0;
+.dp-banner-panel {
+  padding: 16px 18px;
+  background:
+    linear-gradient(90deg, rgb(17 17 17 / 0.02) 0 1px, transparent 1px),
+    linear-gradient(180deg, rgb(17 17 17 / 0.02) 0 1px, transparent 1px), var(--dp-panel);
+  background-size:
+    22px 22px,
+    22px 22px,
+    auto;
 }
 
-.dp-entry--split {
-  padding-right: 6px;
+.dp-banner-panel__lede {
+  margin: 0;
+  max-width: 64ch;
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.dp-banner-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
+  gap: 18px;
+}
+
+.dp-banner-stack {
+  display: grid;
+  gap: 12px;
+}
+
+.dp-entry--banner {
+  padding: 18px 18px 20px;
+  border: 1px solid var(--dp-border);
+  border-radius: 14px;
+  background: var(--dp-panel-alt);
+}
+
+.dp-support-row {
+  display: grid;
+  gap: 12px;
+}
+
+.dp-support-row--banner {
+  grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.15fr);
+}
+
+.dp-support-row--index {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 18px;
+}
+
+.dp-support-block {
+  display: grid;
+  gap: 12px;
+  padding: 18px;
+}
+
+.dp-support-list {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.dp-support-list a {
+  color: var(--dp-text);
+}
+
+.dp-support-list a:hover {
+  text-decoration: underline;
 }
 
 .dp-chip-list {
@@ -339,57 +424,9 @@
   padding: 0 10px;
   border: 1px solid var(--dp-border);
   border-radius: 999px;
-  background: var(--dp-panel-muted);
-  color: var(--dp-text-muted);
-  font-size: 0.82rem;
-}
-
-.dp-support-grid {
-  display: grid;
-  gap: 12px;
-}
-
-.dp-support-grid--essay {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.dp-support-grid--ledger {
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
-  margin-top: 18px;
-}
-
-.dp-support-block,
-.dp-sidebar {
-  display: grid;
-  gap: 12px;
-  padding: 18px;
-}
-
-.dp-split-main {
-  display: grid;
-  gap: 18px;
-}
-
-.dp-sidebar {
-  position: sticky;
-  top: 84px;
-  gap: 14px;
-}
-
-.dp-sidebar-list {
-  display: grid;
-  gap: 10px;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.dp-sidebar-list a {
-  color: var(--dp-text);
-}
-
-.dp-sidebar-list a:hover {
-  text-decoration: underline;
+  background: var(--dp-panel-alt);
+  color: var(--dp-text-soft);
+  font-size: 0.8rem;
 }
 
 .dp-pagination-sample {
@@ -407,90 +444,80 @@
   padding: 0 12px;
   border: 1px solid var(--dp-border);
   border-radius: 999px;
-  background: var(--dp-panel-muted);
+  background: var(--dp-panel-alt);
   font-family: var(--dp-font-mono);
   font-size: 0.8rem;
 }
 
 .dp-pagination-sample__button.is-current {
   border-color: var(--dp-text);
-  color: var(--dp-text);
 }
 
-.dp-ledger-head {
+.dp-index-head {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 140px 120px 100px;
-  gap: 16px;
-  padding: 0 0 10px;
-  color: var(--dp-text-muted);
+  grid-template-columns: 180px minmax(0, 1fr) 120px;
+  gap: 18px;
+  padding: 0 0 12px;
+  color: var(--dp-text-soft);
   font-family: var(--dp-font-mono);
   font-size: 0.72rem;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
-.dp-ledger-list {
+.dp-index-list {
   display: grid;
 }
 
-.dp-featured-card--ledger {
-  margin: 0 0 12px;
-  padding: 0;
-  border: 0;
-  box-shadow: none;
-}
-
-.dp-entry--ledger {
-  padding: 0;
-  border-right: 0;
-  border-bottom: 0;
-  border-left: 0;
-  border-radius: 0;
-}
-
-.dp-ledger-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 140px;
-  gap: 16px;
-  padding: 18px 0;
+.dp-entry--index {
   border-bottom: 1px solid var(--dp-border);
 }
 
-.dp-ledger-row__main {
+.dp-index-row {
+  display: grid;
+  grid-template-columns: 180px minmax(0, 1fr) 120px;
+  gap: 18px;
+  padding: 18px 0;
+}
+
+.dp-index-row--featured {
+  border-bottom: 2px solid var(--dp-text);
+}
+
+.dp-index-row__category {
+  display: grid;
+  align-content: start;
+  gap: 6px;
+}
+
+.dp-index-row__body {
   display: grid;
   gap: 8px;
   min-width: 0;
 }
 
-.dp-ledger-row__meta {
+.dp-index-row__meta {
   display: grid;
-  grid-auto-rows: min-content;
-  justify-items: start;
   align-content: start;
   gap: 8px;
-  min-width: 0;
 }
 
 .dp-empty-state {
   padding: 22px;
   border: 1px dashed var(--dp-border);
-  border-radius: 16px;
+  border-radius: 18px;
   background: var(--dp-panel);
-  color: var(--dp-text-muted);
+  color: var(--dp-text-soft);
 }
 
 @media (max-width: 1080px) {
-  .dp-hero-panel,
-  .dp-layout--split,
-  .dp-support-grid--essay,
-  .dp-support-grid--ledger,
-  .dp-ledger-row,
-  .dp-ledger-head {
+  .dp-masthead,
+  .dp-banner-grid,
+  .dp-support-row--banner,
+  .dp-support-row--index,
+  .dp-index-head,
+  .dp-index-row {
     grid-template-columns: 1fr;
-  }
-
-  .dp-sidebar {
-    position: static;
   }
 }
 
@@ -500,10 +527,10 @@
   }
 
   .dp-switcher__frame,
-  .dp-hero-panel,
+  .dp-masthead,
   .dp-featured-card,
   .dp-support-block,
-  .dp-sidebar {
+  .dp-banner-panel {
     padding: 16px;
   }
 
@@ -512,7 +539,10 @@
     flex: 1 1 100%;
   }
 
-  .dp-entry {
-    padding: 16px 0;
+  .dp-entry--monolith,
+  .dp-index-row,
+  .dp-index-row--featured {
+    padding-top: 16px;
+    padding-bottom: 16px;
   }
 }

--- a/apps/astro-blog/src/design-preview.css
+++ b/apps/astro-blog/src/design-preview.css
@@ -1,22 +1,16 @@
 .design-preview-shell {
-  --dp-bg: #101216;
-  --dp-bg-secondary: #171a20;
-  --dp-panel: rgb(18 22 28 / 82%);
-  --dp-panel-strong: rgb(23 28 34 / 92%);
-  --dp-text: #edf0f3;
-  --dp-text-muted: #96a0aa;
-  --dp-border: rgb(255 255 255 / 0.12);
-  --dp-grid: rgb(255 255 255 / 0.05);
-  --dp-accent: #e1a94b;
-  --dp-accent-strong: #f0c87d;
-  --dp-shadow: 0 24px 60px rgb(0 0 0 / 0.28);
-  --dp-font-display:
-    'Bahnschrift', 'DIN Alternate', 'Arial Narrow', 'Yu Gothic UI', 'Segoe UI', sans-serif;
+  --dp-bg: #f7f6f2;
+  --dp-panel: #ffffff;
+  --dp-panel-muted: #fbfbf9;
+  --dp-text: #141414;
+  --dp-text-muted: #66635f;
+  --dp-border: #dad6cf;
+  --dp-border-strong: #bdb7ae;
+  --dp-shadow: 0 14px 40px rgb(20 20 20 / 0.04);
+  --dp-font-display: Georgia, 'Times New Roman', 'Yu Mincho', serif;
   --dp-font-body: 'Aptos', 'Yu Gothic UI', 'Hiragino Sans', 'Segoe UI', sans-serif;
-  --dp-font-mono: 'IBM Plex Mono', 'Cascadia Mono', 'Cascadia Code', monospace;
-  background:
-    radial-gradient(circle at top, rgb(255 255 255 / 0.07), transparent 28%),
-    linear-gradient(180deg, var(--dp-bg), #090b0f 76%);
+  --dp-font-mono: 'IBM Plex Mono', 'Cascadia Code', 'Courier New', monospace;
+  background: var(--dp-bg);
   color: var(--dp-text);
   font-family: var(--dp-font-body);
   min-height: 100vh;
@@ -33,57 +27,22 @@
   text-decoration: none;
 }
 
-.design-preview-shell--archive-grid {
-  --dp-bg: #dce2e5;
-  --dp-bg-secondary: #eef2f3;
-  --dp-panel: rgb(249 250 250 / 0.82);
-  --dp-panel-strong: rgb(255 255 255 / 0.92);
-  --dp-text: #182126;
-  --dp-text-muted: #60717a;
-  --dp-border: rgb(24 33 38 / 0.18);
-  --dp-grid: rgb(24 33 38 / 0.07);
-  --dp-accent: #2f9fb3;
-  --dp-accent-strong: #256f80;
-  --dp-shadow: 0 20px 48px rgb(78 96 104 / 0.14);
-  background:
-    linear-gradient(180deg, rgb(255 255 255 / 0.45), transparent 18%),
-    linear-gradient(90deg, rgb(255 255 255 / 0.25) 1px, transparent 1px),
-    linear-gradient(rgb(255 255 255 / 0.25) 1px, transparent 1px),
-    linear-gradient(180deg, #d6dde0, #edf2f3 35%, #d8dfe2);
-  background-size:
-    auto,
-    28px 28px,
-    28px 28px,
-    auto;
-}
-
-.design-preview-shell--signal-frame {
-  --dp-bg: #0d1116;
-  --dp-bg-secondary: #141921;
-  --dp-panel: rgb(17 22 29 / 0.84);
-  --dp-panel-strong: rgb(18 23 31 / 0.94);
-  --dp-text: #ecf1ee;
-  --dp-text-muted: #8f9a93;
-  --dp-border: rgb(255 177 70 / 0.16);
-  --dp-grid: rgb(255 177 70 / 0.06);
-  --dp-accent: #c77733;
-  --dp-accent-strong: #ebbb64;
-  --dp-shadow: 0 28px 80px rgb(0 0 0 / 0.34);
-  background:
-    radial-gradient(circle at top right, rgb(199 119 51 / 0.12), transparent 24%),
-    radial-gradient(circle at left, rgb(255 255 255 / 0.04), transparent 18%),
-    linear-gradient(180deg, #131821, #090b10 78%);
-}
-
 .dp-shell {
-  padding: 24px;
+  padding: 24px 20px 48px;
 }
 
 .dp-switcher {
   position: sticky;
   top: 0;
   z-index: 30;
-  padding-bottom: 20px;
+  padding-bottom: 18px;
+}
+
+.dp-switcher__frame,
+.dp-featured-card,
+.dp-support-block,
+.dp-hero-panel {
+  border-radius: 16px;
 }
 
 .dp-switcher__frame {
@@ -93,34 +52,12 @@
   justify-content: space-between;
   gap: 16px;
   margin: 0 auto;
-  max-width: 1320px;
-  padding: 18px 22px;
+  max-width: 1180px;
+  padding: 16px 20px;
   border: 1px solid var(--dp-border);
-  background: color-mix(in srgb, var(--dp-panel-strong) 92%, transparent);
-  backdrop-filter: blur(18px);
+  background: rgb(255 255 255 / 0.9);
   box-shadow: var(--dp-shadow);
-}
-
-.design-preview-shell--industrial-slate .dp-switcher__frame {
-  border-radius: 22px 8px 22px 8px;
-}
-
-.design-preview-shell--archive-grid .dp-switcher__frame {
-  border-radius: 8px;
-}
-
-.design-preview-shell--signal-frame .dp-switcher__frame {
-  border-radius: 18px;
-  position: relative;
-  overflow: hidden;
-}
-
-.design-preview-shell--signal-frame .dp-switcher__frame::after {
-  content: '';
-  position: absolute;
-  inset: auto 18px 0 18px;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, var(--dp-accent), transparent);
+  backdrop-filter: blur(12px);
 }
 
 .dp-switcher__intro {
@@ -131,35 +68,35 @@
 .dp-switcher__eyebrow,
 .dp-hero-panel__eyebrow,
 .dp-section-heading__eyebrow,
-.dp-status-panel__label,
-.dp-note-block__title {
+.dp-support-block__label,
+.dp-ledger-row__label {
   margin: 0;
-  color: var(--dp-accent);
+  color: var(--dp-text-muted);
   font-family: var(--dp-font-mono);
   font-size: 0.72rem;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
 .dp-switcher__copy {
   margin: 0;
   color: var(--dp-text-muted);
-  font-size: 0.94rem;
+  font-size: 0.92rem;
 }
 
 .dp-switcher__nav {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 8px;
 }
 
 .dp-switcher__link {
   display: grid;
   gap: 4px;
   min-width: 184px;
-  padding: 12px 14px;
+  padding: 11px 13px;
   border: 1px solid var(--dp-border);
-  background: color-mix(in srgb, var(--dp-panel) 92%, transparent);
+  background: var(--dp-panel);
   transition:
     border-color 180ms ease,
     transform 180ms ease,
@@ -168,20 +105,18 @@
 
 .dp-switcher__link:hover {
   transform: translateY(-1px);
-  border-color: color-mix(in srgb, var(--dp-accent) 60%, var(--dp-border));
+  border-color: var(--dp-border-strong);
 }
 
 .dp-switcher__link.is-current {
-  border-color: color-mix(in srgb, var(--dp-accent) 80%, var(--dp-border));
-  background: color-mix(in srgb, var(--dp-accent) 14%, var(--dp-panel));
+  border-color: var(--dp-text);
 }
 
 .dp-switcher__link-name {
-  font-family: var(--dp-font-display);
-  font-size: 0.98rem;
+  font-family: var(--dp-font-body);
+  font-size: 0.96rem;
   font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  letter-spacing: 0.01em;
 }
 
 .dp-switcher__link-kicker {
@@ -194,144 +129,66 @@
 
 .dp-main {
   margin: 0 auto;
-  max-width: 1320px;
+  max-width: 1180px;
 }
 
 .design-preview {
   display: grid;
-  gap: 22px;
+  gap: 18px;
 }
 
-.dp-hero-panel,
-.dp-content-panel {
+.dp-hero-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(260px, 0.65fr);
+  gap: 18px;
+  padding: 28px 30px;
   border: 1px solid var(--dp-border);
   background: var(--dp-panel);
   box-shadow: var(--dp-shadow);
 }
 
-.dp-hero-panel {
+.dp-hero-panel__body {
   display: grid;
-  grid-template-columns: minmax(0, 1.4fr) minmax(280px, 0.8fr);
-  gap: 24px;
-  padding: 28px;
-}
-
-.dp-content-panel {
-  padding: 24px;
-}
-
-.design-preview-shell--industrial-slate .dp-content-panel,
-.design-preview-shell--industrial-slate .dp-hero-panel {
-  border-radius: 26px 12px 26px 12px;
-}
-
-.design-preview-shell--archive-grid .dp-content-panel,
-.design-preview-shell--archive-grid .dp-hero-panel {
-  border-radius: 10px;
-}
-
-.design-preview-shell--signal-frame .dp-content-panel,
-.design-preview-shell--signal-frame .dp-hero-panel {
-  border-radius: 20px;
-  position: relative;
-  overflow: hidden;
-}
-
-.design-preview-shell--signal-frame .dp-content-panel::before,
-.design-preview-shell--signal-frame .dp-hero-panel::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  border: 1px solid rgb(255 255 255 / 0.04);
-}
-
-.dp-hero-panel__lead {
-  display: grid;
-  gap: 16px;
+  gap: 10px;
 }
 
 .dp-hero-panel__title {
   margin: 0;
-  max-width: 12ch;
+  max-width: 16ch;
   font-family: var(--dp-font-display);
-  font-size: clamp(2.6rem, 6vw, 4.9rem);
+  font-size: clamp(2rem, 4vw, 3.35rem);
   font-weight: 700;
-  letter-spacing: 0.02em;
-  line-height: 0.95;
-  text-transform: uppercase;
+  letter-spacing: 0.01em;
+  line-height: 1.05;
 }
 
 .dp-hero-panel__description,
-.dp-status-panel__body,
 .dp-featured-card__description,
-.dp-post-card__description,
-.dp-note-block__body {
+.dp-entry__description,
+.dp-sidebar__body,
+.dp-hero-panel__summary {
   margin: 0;
   color: var(--dp-text-muted);
-  line-height: 1.7;
+  line-height: 1.75;
 }
 
-.dp-metric-list,
-.dp-chip-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin: 0;
-  padding: 0;
-  list-style: none;
+.dp-hero-panel__summary {
+  max-width: 60ch;
 }
 
-.dp-metric-list__item,
-.dp-chip-list__item {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  min-height: 36px;
-  padding: 0 14px;
-  border: 1px solid var(--dp-border);
-  background: color-mix(in srgb, var(--dp-panel-strong) 90%, transparent);
-  color: inherit;
-}
-
-.design-preview-shell--industrial-slate .dp-metric-list__item,
-.design-preview-shell--industrial-slate .dp-chip-list__item {
-  border-radius: 999px;
-}
-
-.design-preview-shell--archive-grid .dp-metric-list__item,
-.design-preview-shell--archive-grid .dp-chip-list__item {
-  border-radius: 4px;
-}
-
-.design-preview-shell--signal-frame .dp-metric-list__item,
-.design-preview-shell--signal-frame .dp-chip-list__item {
-  border-radius: 10px;
-}
-
-.dp-status-panel {
-  display: grid;
-  align-content: start;
-  gap: 16px;
-  padding: 18px;
-  border: 1px solid var(--dp-border);
-  background: color-mix(in srgb, var(--dp-panel-strong) 94%, transparent);
-}
-
-.dp-stat-grid {
+.dp-hero-meta {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 14px;
+  gap: 12px;
   margin: 0;
 }
 
-.dp-stat-grid__item {
-  padding: 12px 14px;
-  border: 1px solid var(--dp-border);
-  background: color-mix(in srgb, var(--dp-panel) 88%, transparent);
+.dp-hero-meta__item {
+  padding: 12px 0;
+  border-top: 1px solid var(--dp-border);
 }
 
-.dp-stat-grid__item dt {
+.dp-hero-meta__item dt {
   color: var(--dp-text-muted);
   font-family: var(--dp-font-mono);
   font-size: 0.72rem;
@@ -339,222 +196,301 @@
   text-transform: uppercase;
 }
 
-.dp-stat-grid__item dd {
+.dp-hero-meta__item dd {
   margin: 8px 0 0;
-  font-family: var(--dp-font-display);
-  font-size: 1.18rem;
-  font-weight: 700;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.dp-layout {
+  display: grid;
+  gap: 18px;
+}
+
+.dp-layout--essay {
+  max-width: 840px;
+  margin: 0 auto;
+}
+
+.dp-layout--split {
+  grid-template-columns: minmax(0, 1fr) 280px;
+  align-items: start;
+}
+
+.dp-layout--ledger {
+  gap: 0;
+  border-top: 1px solid var(--dp-border);
+}
+
+.dp-list-section {
+  display: grid;
+  gap: 14px;
 }
 
 .dp-section-heading {
   display: grid;
-  gap: 4px;
-  margin-bottom: 18px;
-}
-
-.dp-section-heading__title,
-.dp-subheading,
-.dp-featured-card__title,
-.dp-post-card__title {
-  margin: 0;
-  font-family: var(--dp-font-display);
-  font-weight: 700;
-  letter-spacing: 0.02em;
+  gap: 5px;
+  padding-top: 10px;
 }
 
 .dp-section-heading__title {
-  font-size: clamp(1.3rem, 2vw, 1.8rem);
-  text-transform: uppercase;
+  margin: 0;
+  font-family: var(--dp-font-display);
+  font-size: clamp(1.2rem, 2vw, 1.55rem);
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.dp-featured-card,
+.dp-entry,
+.dp-support-block,
+.dp-sidebar {
+  border: 1px solid var(--dp-border);
+  background: var(--dp-panel);
 }
 
 .dp-featured-card {
   display: grid;
-  grid-template-columns: minmax(0, 1.15fr) minmax(240px, 0.85fr);
-  gap: 18px;
-  min-height: 340px;
-  padding: 18px;
-  border: 1px solid var(--dp-border);
-  background: color-mix(in srgb, var(--dp-panel-strong) 94%, transparent);
+  gap: 12px;
+  padding: 22px 24px;
+  box-shadow: var(--dp-shadow);
 }
 
-.dp-featured-card__copy {
-  display: grid;
-  align-content: start;
-  gap: 18px;
+.dp-featured-card--essay,
+.dp-featured-card--split {
+  margin-bottom: 8px;
 }
 
-.dp-featured-card__title {
-  font-size: clamp(1.8rem, 3vw, 2.8rem);
-  line-height: 1;
-  text-transform: uppercase;
-}
-
-.dp-card-meta {
+.dp-card-meta,
+.dp-ledger-row__meta {
   display: flex;
   flex-wrap: wrap;
   gap: 8px 14px;
+  margin: 0;
   color: var(--dp-text-muted);
   font-family: var(--dp-font-mono);
-  font-size: 0.78rem;
+  font-size: 0.74rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-.dp-featured-card__media {
-  position: relative;
-  min-height: 220px;
-  overflow: hidden;
+.dp-featured-card__title,
+.dp-entry__title {
+  margin: 0;
+  font-family: var(--dp-font-display);
+  font-weight: 700;
+  line-height: 1.18;
+}
+
+.dp-featured-card__title {
+  font-size: clamp(1.7rem, 3vw, 2.35rem);
+}
+
+.dp-entry__title {
+  font-size: clamp(1.15rem, 2vw, 1.45rem);
+}
+
+.dp-list {
+  display: grid;
+}
+
+.dp-list--essay {
+  gap: 0;
+  border-top: 1px solid var(--dp-border);
+}
+
+.dp-list--split {
+  gap: 0;
+}
+
+.dp-entry {
+  display: grid;
+  gap: 10px;
+  padding: 20px 0;
+  border-top: 1px solid var(--dp-border);
+  background: transparent;
+}
+
+.dp-entry--essay,
+.dp-entry--split {
+  border-right: 0;
+  border-bottom: 0;
+  border-left: 0;
+  border-radius: 0;
+}
+
+.dp-entry--split {
+  padding-right: 6px;
+}
+
+.dp-chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.dp-chip-list__item {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0 10px;
   border: 1px solid var(--dp-border);
-  background:
-    linear-gradient(135deg, var(--dp-grid) 25%, transparent 25%),
-    linear-gradient(225deg, var(--dp-grid) 25%, transparent 25%),
-    linear-gradient(45deg, var(--dp-grid) 25%, transparent 25%),
-    linear-gradient(315deg, var(--dp-grid) 25%, var(--dp-bg-secondary) 25%);
-  background-position:
-    12px 0,
-    12px 0,
-    0 0,
-    0 0;
-  background-size: 24px 24px;
+  border-radius: 999px;
+  background: var(--dp-panel-muted);
+  color: var(--dp-text-muted);
+  font-size: 0.82rem;
 }
 
-.dp-featured-card__image {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
-  mix-blend-mode: luminosity;
-  opacity: 0.88;
-}
-
-.design-preview-shell--archive-grid .dp-featured-card__image {
-  mix-blend-mode: normal;
-  opacity: 0.96;
-}
-
-.design-preview-shell--signal-frame .dp-featured-card__image {
-  mix-blend-mode: screen;
-  opacity: 0.52;
-}
-
-.dp-featured-card__placeholder {
-  position: absolute;
-  inset: 0;
-  display: grid;
-  place-items: center;
-  color: var(--dp-accent);
-  font-family: var(--dp-font-mono);
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-}
-
-.dp-card-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 16px;
-}
-
-.dp-post-card {
-  display: grid;
-  align-content: start;
-  gap: 14px;
-  min-height: 250px;
-  padding: 18px;
-  border: 1px solid var(--dp-border);
-  background: color-mix(in srgb, var(--dp-panel-strong) 94%, transparent);
-  transition:
-    transform 180ms ease,
-    border-color 180ms ease;
-}
-
-.dp-post-card:hover,
-.dp-featured-card:hover {
-  transform: translateY(-2px);
-  border-color: color-mix(in srgb, var(--dp-accent) 72%, var(--dp-border));
-}
-
-.dp-post-card__title {
-  font-size: 1.28rem;
-  line-height: 1.1;
-}
-
-.dp-post-card__footer {
+.dp-support-grid {
   display: grid;
   gap: 12px;
-  margin-top: auto;
 }
 
-.dp-post-card__reading,
-.dp-subheading {
-  color: var(--dp-text-muted);
-  font-family: var(--dp-font-mono);
-  font-size: 0.74rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.dp-utility-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1.4fr) minmax(280px, 0.85fr);
-  gap: 22px;
-}
-
-.dp-taxonomy-columns {
-  display: grid;
+.dp-support-grid--essay {
   grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.dp-support-grid--ledger {
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
+  margin-top: 18px;
+}
+
+.dp-support-block,
+.dp-sidebar {
+  display: grid;
+  gap: 12px;
+  padding: 18px;
+}
+
+.dp-split-main {
+  display: grid;
   gap: 18px;
 }
 
-.dp-content-panel--support {
+.dp-sidebar {
+  position: sticky;
+  top: 84px;
+  gap: 14px;
+}
+
+.dp-sidebar-list {
   display: grid;
-  align-content: start;
-  gap: 18px;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.dp-sidebar-list a {
+  color: var(--dp-text);
+}
+
+.dp-sidebar-list a:hover {
+  text-decoration: underline;
 }
 
 .dp-pagination-sample {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 8px;
 }
 
 .dp-pagination-sample__button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 52px;
-  min-height: 44px;
-  padding: 0 16px;
+  min-width: 44px;
+  min-height: 36px;
+  padding: 0 12px;
   border: 1px solid var(--dp-border);
-  background: color-mix(in srgb, var(--dp-panel-strong) 92%, transparent);
+  border-radius: 999px;
+  background: var(--dp-panel-muted);
   font-family: var(--dp-font-mono);
-  font-size: 0.86rem;
+  font-size: 0.8rem;
 }
 
 .dp-pagination-sample__button.is-current {
-  border-color: color-mix(in srgb, var(--dp-accent) 72%, var(--dp-border));
-  background: color-mix(in srgb, var(--dp-accent) 14%, var(--dp-panel));
+  border-color: var(--dp-text);
+  color: var(--dp-text);
 }
 
-.dp-note-block {
+.dp-ledger-head {
   display: grid;
-  gap: 10px;
-  padding: 18px;
-  border: 1px solid var(--dp-border);
-  background: color-mix(in srgb, var(--dp-panel-strong) 92%, transparent);
+  grid-template-columns: minmax(0, 1fr) 140px 120px 100px;
+  gap: 16px;
+  padding: 0 0 10px;
+  color: var(--dp-text-muted);
+  font-family: var(--dp-font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.dp-ledger-list {
+  display: grid;
+}
+
+.dp-featured-card--ledger {
+  margin: 0 0 12px;
+  padding: 0;
+  border: 0;
+  box-shadow: none;
+}
+
+.dp-entry--ledger {
+  padding: 0;
+  border-right: 0;
+  border-bottom: 0;
+  border-left: 0;
+  border-radius: 0;
+}
+
+.dp-ledger-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 140px;
+  gap: 16px;
+  padding: 18px 0;
+  border-bottom: 1px solid var(--dp-border);
+}
+
+.dp-ledger-row__main {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+.dp-ledger-row__meta {
+  display: grid;
+  grid-auto-rows: min-content;
+  justify-items: start;
+  align-content: start;
+  gap: 8px;
+  min-width: 0;
 }
 
 .dp-empty-state {
   padding: 22px;
   border: 1px dashed var(--dp-border);
+  border-radius: 16px;
+  background: var(--dp-panel);
   color: var(--dp-text-muted);
 }
 
 @media (max-width: 1080px) {
   .dp-hero-panel,
-  .dp-utility-grid,
-  .dp-featured-card,
-  .dp-card-grid {
+  .dp-layout--split,
+  .dp-support-grid--essay,
+  .dp-support-grid--ledger,
+  .dp-ledger-row,
+  .dp-ledger-head {
     grid-template-columns: 1fr;
+  }
+
+  .dp-sidebar {
+    position: static;
   }
 }
 
@@ -565,16 +501,18 @@
 
   .dp-switcher__frame,
   .dp-hero-panel,
-  .dp-content-panel {
+  .dp-featured-card,
+  .dp-support-block,
+  .dp-sidebar {
     padding: 16px;
   }
 
-  .dp-taxonomy-columns,
-  .dp-stat-grid {
-    grid-template-columns: 1fr;
+  .dp-switcher__link {
+    min-width: 0;
+    flex: 1 1 100%;
   }
 
-  .dp-featured-card {
-    min-height: unset;
+  .dp-entry {
+    padding: 16px 0;
   }
 }

--- a/apps/astro-blog/src/layouts/DesignPreviewLayout.astro
+++ b/apps/astro-blog/src/layouts/DesignPreviewLayout.astro
@@ -52,7 +52,7 @@ const { title, description, canonical, variant, noIndex = true } = Astro.props;
         <div class="dp-switcher__frame">
           <div class="dp-switcher__intro">
             <p class="dp-switcher__eyebrow">Design sandbox</p>
-            <p class="dp-switcher__copy">White, text-first studies for a long-form blog.</p>
+            <p class="dp-switcher__copy">Top-page prototypes for a cold, text-first blog.</p>
           </div>
 
           <nav aria-label="Design preview variants" class="dp-switcher__nav">

--- a/apps/astro-blog/src/layouts/DesignPreviewLayout.astro
+++ b/apps/astro-blog/src/layouts/DesignPreviewLayout.astro
@@ -58,7 +58,8 @@ const activeTheme = DESIGN_PREVIEW_THEMES[variant];
           <div class="dp-switcher__intro">
             <p class="dp-switcher__eyebrow">Palette sandbox</p>
             <p class="dp-switcher__copy">
-              One index layout, four full-page color systems based on the reference palettes.
+              Theme 01 is the base direction. The other pages are full-page palette checks on the
+              same cold index structure.
             </p>
           </div>
 

--- a/apps/astro-blog/src/layouts/DesignPreviewLayout.astro
+++ b/apps/astro-blog/src/layouts/DesignPreviewLayout.astro
@@ -52,7 +52,7 @@ const { title, description, canonical, variant, noIndex = true } = Astro.props;
         <div class="dp-switcher__frame">
           <div class="dp-switcher__intro">
             <p class="dp-switcher__eyebrow">Design sandbox</p>
-            <p class="dp-switcher__copy">Isolated routes for material and layout comparison.</p>
+            <p class="dp-switcher__copy">White, text-first studies for a long-form blog.</p>
           </div>
 
           <nav aria-label="Design preview variants" class="dp-switcher__nav">

--- a/apps/astro-blog/src/layouts/DesignPreviewLayout.astro
+++ b/apps/astro-blog/src/layouts/DesignPreviewLayout.astro
@@ -3,6 +3,7 @@ import { SITE_AUTHOR, SITE_TITLE, SOCIAL_LINK_X } from '$constants';
 import {
   DESIGN_PREVIEW_THEMES,
   DESIGN_PREVIEW_VARIANTS,
+  getDesignPreviewStyle,
   getDesignPreviewHref,
   type DesignPreviewVariant,
 } from '$lib/design-preview';
@@ -17,6 +18,7 @@ interface Props {
 }
 
 const { title, description, canonical, variant, noIndex = true } = Astro.props;
+const activeTheme = DESIGN_PREVIEW_THEMES[variant];
 ---
 
 <!doctype html>
@@ -46,16 +48,21 @@ const { title, description, canonical, variant, noIndex = true } = Astro.props;
 
     <link rel="canonical" href={canonical} />
   </head>
-  <body class={`design-preview-shell design-preview-shell--${variant}`}>
+  <body
+    class={`design-preview-shell design-preview-shell--${variant}`}
+    style={getDesignPreviewStyle(activeTheme)}
+  >
     <div class="dp-shell">
       <header class="dp-switcher">
         <div class="dp-switcher__frame">
           <div class="dp-switcher__intro">
-            <p class="dp-switcher__eyebrow">Design sandbox</p>
-            <p class="dp-switcher__copy">Top-page prototypes for a cold, text-first blog.</p>
+            <p class="dp-switcher__eyebrow">Palette sandbox</p>
+            <p class="dp-switcher__copy">
+              One index layout, four full-page color systems based on the reference palettes.
+            </p>
           </div>
 
-          <nav aria-label="Design preview variants" class="dp-switcher__nav">
+          <nav aria-label="Design preview palettes" class="dp-switcher__nav">
             {
               DESIGN_PREVIEW_VARIANTS.map((entry) => {
                 const theme = DESIGN_PREVIEW_THEMES[entry];

--- a/apps/astro-blog/src/layouts/DesignPreviewLayout.astro
+++ b/apps/astro-blog/src/layouts/DesignPreviewLayout.astro
@@ -1,0 +1,85 @@
+---
+import { SITE_AUTHOR, SITE_TITLE, SOCIAL_LINK_X } from '$constants';
+import {
+  DESIGN_PREVIEW_THEMES,
+  DESIGN_PREVIEW_VARIANTS,
+  getDesignPreviewHref,
+  type DesignPreviewVariant,
+} from '$lib/design-preview';
+import '../design-preview.css';
+
+interface Props {
+  title: string;
+  description: string;
+  canonical: string;
+  variant: DesignPreviewVariant;
+  noIndex?: boolean;
+}
+
+const { title, description, canonical, variant, noIndex = true } = Astro.props;
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" href="/icon.svg" />
+
+    <title>{title}</title>
+    <meta name="description" content={description} />
+    <meta name="author" content={SITE_AUTHOR} />
+    {noIndex && <meta name="robots" content="noindex, nofollow" />}
+
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={canonical} />
+    <meta property="og:site_name" content={SITE_TITLE} />
+    <meta property="og:locale" content="ja_JP" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content={`@${SOCIAL_LINK_X}`} />
+    <meta name="twitter:creator" content={`@${SOCIAL_LINK_X}`} />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+
+    <link rel="canonical" href={canonical} />
+  </head>
+  <body class={`design-preview-shell design-preview-shell--${variant}`}>
+    <div class="dp-shell">
+      <header class="dp-switcher">
+        <div class="dp-switcher__frame">
+          <div class="dp-switcher__intro">
+            <p class="dp-switcher__eyebrow">Design sandbox</p>
+            <p class="dp-switcher__copy">Isolated routes for material and layout comparison.</p>
+          </div>
+
+          <nav aria-label="Design preview variants" class="dp-switcher__nav">
+            {
+              DESIGN_PREVIEW_VARIANTS.map((entry) => {
+                const theme = DESIGN_PREVIEW_THEMES[entry];
+                const isCurrent = entry === variant;
+
+                return (
+                  <a
+                    href={getDesignPreviewHref(entry)}
+                    class={`dp-switcher__link ${isCurrent ? 'is-current' : ''}`}
+                    aria-current={isCurrent ? 'page' : undefined}
+                  >
+                    <span class="dp-switcher__link-name">{theme.name}</span>
+                    <span class="dp-switcher__link-kicker">{theme.kicker}</span>
+                  </a>
+                );
+              })
+            }
+          </nav>
+        </div>
+      </header>
+
+      <main class="dp-main">
+        <slot />
+      </main>
+    </div>
+  </body>
+</html>

--- a/apps/astro-blog/src/layouts/TopPageLayout.astro
+++ b/apps/astro-blog/src/layouts/TopPageLayout.astro
@@ -58,12 +58,51 @@ const pathname = Astro.url.pathname;
     />
   </head>
   <body class="top-page-shell">
-    <TopPageHeader pathname={pathname} />
+    <TopPageHeader pathname={pathname} scrollReveal={true} />
 
     <main class="tp-main">
       <slot />
     </main>
 
     <TopPageFooter />
+
+    <script is:inline>
+      (() => {
+        const header = document.querySelector('[data-scroll-reveal-header]');
+        const trigger = document.querySelector('[data-header-trigger]');
+
+        if (!(header instanceof HTMLElement) || !(trigger instanceof HTMLElement)) {
+          return;
+        }
+
+        /** @param {boolean} isVisible */
+        const updateVisibility = (isVisible) => {
+          header.classList.toggle('is-visible', isVisible);
+        };
+
+        if ('IntersectionObserver' in window) {
+          const observer = new IntersectionObserver(
+            ([entry]) => {
+              updateVisibility(!entry.isIntersecting);
+            },
+            {
+              rootMargin: '-88px 0px 0px 0px',
+              threshold: 0,
+            },
+          );
+
+          observer.observe(trigger);
+          return;
+        }
+
+        const onScroll = () => {
+          const rect = trigger.getBoundingClientRect();
+          updateVisibility(rect.top <= 88);
+        };
+
+        onScroll();
+        globalThis.addEventListener('scroll', onScroll, { passive: true });
+      })();
+    </script>
   </body>
 </html>

--- a/apps/astro-blog/src/layouts/TopPageLayout.astro
+++ b/apps/astro-blog/src/layouts/TopPageLayout.astro
@@ -1,0 +1,69 @@
+---
+import TopPageFooter from '$components/TopPageFooter.astro';
+import TopPageHeader from '$components/TopPageHeader.astro';
+import { SITE_AUTHOR, SITE_TITLE, SOCIAL_LINK_X } from '$constants';
+import '../top-page.css';
+
+interface Props {
+  title: string;
+  description: string;
+  canonical: string;
+  prevUrl?: string;
+  nextUrl?: string;
+}
+
+const { title, description, canonical, prevUrl, nextUrl } = Astro.props;
+const pathname = Astro.url.pathname;
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" href="/icon.svg" />
+
+    <title>{title}</title>
+    <meta name="description" content={description} />
+    <meta name="author" content={SITE_AUTHOR} />
+
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={canonical} />
+    <meta property="og:site_name" content={SITE_TITLE} />
+    <meta property="og:locale" content="ja_JP" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content={`@${SOCIAL_LINK_X}`} />
+    <meta name="twitter:creator" content={`@${SOCIAL_LINK_X}`} />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+
+    <link rel="canonical" href={canonical} />
+    {prevUrl && <link rel="prev" href={prevUrl} />}
+    {nextUrl && <link rel="next" href={nextUrl} />}
+
+    <link
+      rel="alternate"
+      type="text/markdown"
+      href="/llms.txt"
+      title="LLM-friendly content guide"
+    />
+    <link
+      rel="alternate"
+      type="text/markdown"
+      href="/llms-full.txt"
+      title="Complete content archive"
+    />
+  </head>
+  <body class="top-page-shell">
+    <TopPageHeader pathname={pathname} />
+
+    <main class="tp-main">
+      <slot />
+    </main>
+
+    <TopPageFooter />
+  </body>
+</html>

--- a/apps/astro-blog/src/lib/design-preview.ts
+++ b/apps/astro-blog/src/lib/design-preview.ts
@@ -3,9 +3,10 @@ import { SITE_URL } from '$constants';
 import { getAllCategories, getPosts } from '$lib/content';
 
 export const DESIGN_PREVIEW_VARIANTS = [
-  'industrial-slate',
-  'archive-grid',
-  'signal-frame',
+  'blue-palette',
+  'luxury-01',
+  'luxury-04',
+  'luxury-07',
 ] as const;
 
 export type DesignPreviewVariant = (typeof DESIGN_PREVIEW_VARIANTS)[number];
@@ -17,20 +18,18 @@ export interface DesignPreviewTheme {
   title: string;
   description: string;
   summary: string;
-}
-
-export interface IndexFrameTheme {
-  id: 'blue-palette' | 'luxury-01' | 'luxury-04' | 'luxury-07';
-  name: string;
-  kicker: string;
-  note: string;
-  rail: string;
-  accent: string;
-  accentSoft: string;
-  surface: string;
-  border: string;
+  swatches: string[];
+  bgBase: string;
+  bgDeep: string;
+  bgAura: string;
+  panel: string;
+  panelAlt: string;
   text: string;
   textSoft: string;
+  border: string;
+  borderStrong: string;
+  rail: string;
+  accent: string;
 }
 
 export interface DesignPreviewStats {
@@ -49,92 +48,111 @@ export interface DesignPreviewModel {
 }
 
 export const DESIGN_PREVIEW_THEMES: Record<DesignPreviewVariant, DesignPreviewTheme> = {
-  'industrial-slate': {
-    variant: 'industrial-slate',
-    name: 'Monolith Column',
-    kicker: 'Design Preview 01',
-    title: 'A single reading axis, stripped to category, title, and text.',
+  'blue-palette': {
+    variant: 'blue-palette',
+    name: 'Blue Palette',
+    kicker: 'Palette Preview A',
+    title: 'A submerged blue archive with misted rails and cobalt lift.',
     description:
-      'This route treats the top page like a disciplined reading surface with one dominant column and almost no decorative interruption.',
+      'This route rebuilds the page around the first reference palette, using a dense navy field, pale dividers, and soft steel-blue highlights across the entire screen.',
     summary:
-      'The mood comes from proportion rather than ornament: hard rules, generous white space, and quiet category markers that organize the page without stealing focus.',
+      'The palette is the main event here: background, shell, switcher, and metadata all tune themselves to the same four blues so the page feels like one cooled surface.',
+    swatches: ['#1f2c5d', '#3a539f', '#c2ccdf', '#829fb6'],
+    bgBase: '#142a57',
+    bgDeep: '#08162d',
+    bgAura: 'rgb(58 83 159 / 0.42)',
+    panel: 'rgb(18 40 83 / 0.78)',
+    panelAlt: 'rgb(194 204 223 / 0.09)',
+    text: '#f3f6fc',
+    textSoft: '#c7d2e6',
+    border: 'rgb(194 204 223 / 0.22)',
+    borderStrong: 'rgb(194 204 223 / 0.42)',
+    rail: '#c2ccdf',
+    accent: '#829fb6',
   },
-  'archive-grid': {
-    variant: 'archive-grid',
-    name: 'Monument Banner',
-    kicker: 'Design Preview 02',
-    title: 'A bold site banner first, then a severe field of text.',
+  'luxury-01': {
+    variant: 'luxury-01',
+    name: 'Theme 01',
+    kicker: 'Palette Preview 01',
+    title: 'Ink navy, restrained brass, and smoked steel in one quiet system.',
     description:
-      'This route gives the blog a stronger front face with a large typographic banner before dropping into a text-led article field.',
+      'This route takes the 01 reference as a colder luxury palette: near-black blue, warm metallic accents, and a measured amount of brushed grey for supporting structure.',
     summary:
-      'It aims to feel architectural rather than editorially soft: the site name acts like a structure, while the article list remains restrained and readable.',
+      'Instead of a white reading surface, the page becomes a dark instrument panel where the brass category rail and subtle graphite fields carry the atmosphere.',
+    swatches: ['#09171f', '#cea17a', '#3e4e5a'],
+    bgBase: '#0c1921',
+    bgDeep: '#050c11',
+    bgAura: 'rgb(206 161 122 / 0.18)',
+    panel: 'rgb(10 23 31 / 0.84)',
+    panelAlt: 'rgb(206 161 122 / 0.07)',
+    text: '#f4eee6',
+    textSoft: '#dbc7b3',
+    border: 'rgb(206 161 122 / 0.18)',
+    borderStrong: 'rgb(206 161 122 / 0.36)',
+    rail: '#cea17a',
+    accent: '#93a2ad',
   },
-  'signal-frame': {
-    variant: 'signal-frame',
-    name: 'Index Frame',
-    kicker: 'Design Preview 03',
-    title: 'A cold index where category anchors the page before the title opens.',
+  'luxury-04': {
+    variant: 'luxury-04',
+    name: 'Theme 04',
+    kicker: 'Palette Preview 04',
+    title: 'Blue-grey metal, dark soot, and a sharp red fault line.',
     description:
-      'This route minimizes card behavior and uses a left-side metadata rail, hard rules, and quiet spacing to produce a sharper, more systematic landing page.',
+      'This route interprets 04 as an industrial control surface: cold slate structures, a darker underlayer, and a disciplined red signal used only where the page needs tension.',
     summary:
-      'The result should feel closest to a technical archive or mission index while still preserving enough summary text to invite reading.',
+      'The overall page stays calm and heavy, but the red accent gives the index a precise warning-light character that is closest to the harder Arknights-like direction.',
+    swatches: ['#303d49', '#5d020a', '#1a1e22'],
+    bgBase: '#293641',
+    bgDeep: '#11161b',
+    bgAura: 'rgb(93 2 10 / 0.24)',
+    panel: 'rgb(33 43 53 / 0.84)',
+    panelAlt: 'rgb(93 2 10 / 0.08)',
+    text: '#f2f4f7',
+    textSoft: '#cbd2da',
+    border: 'rgb(201 209 216 / 0.18)',
+    borderStrong: 'rgb(201 209 216 / 0.34)',
+    rail: '#d7dce1',
+    accent: '#8a0d18',
+  },
+  'luxury-07': {
+    variant: 'luxury-07',
+    name: 'Theme 07',
+    kicker: 'Palette Preview 07',
+    title: 'Night violet with silver rails and muted graphite pressure.',
+    description:
+      'This route uses the 07 palette to push the page toward a cooler, more nocturnal mood, where silver metadata and low-contrast violet panels carry the entire composition.',
+    summary:
+      'It is the quietest of the four palettes, relying on small changes in value more than bright accents, which makes the typography feel especially severe.',
+    swatches: ['#141424', '#b5b5b6', '#323240'],
+    bgBase: '#171828',
+    bgDeep: '#09090f',
+    bgAura: 'rgb(181 181 182 / 0.16)',
+    panel: 'rgb(20 20 36 / 0.86)',
+    panelAlt: 'rgb(181 181 182 / 0.08)',
+    text: '#f2f2f5',
+    textSoft: '#d3d4da',
+    border: 'rgb(181 181 182 / 0.18)',
+    borderStrong: 'rgb(181 181 182 / 0.34)',
+    rail: '#d9d9dc',
+    accent: '#727282',
   },
 };
 
-export const INDEX_FRAME_THEMES: IndexFrameTheme[] = [
-  {
-    id: 'blue-palette',
-    name: 'Blue Palette',
-    kicker: 'Palette Study A',
-    note: 'Based on the first image: deep navy, saturated cobalt, pale mist, and dusty blue.',
-    rail: '#1f2c5d',
-    accent: '#3a539f',
-    accentSoft: '#829fb6',
-    surface: '#eef2fa',
-    border: '#c2ccdf',
-    text: '#1f2c5d',
-    textSoft: '#50617f',
-  },
-  {
-    id: 'luxury-01',
-    name: 'Theme 01',
-    kicker: 'Palette Study 01',
-    note: 'Ink navy with warm brass restraint and smoked steel neutrals.',
-    rail: '#09171f',
-    accent: '#cea17a',
-    accentSoft: '#3e4e5a',
-    surface: '#edf1f3',
-    border: '#c8d0d5',
-    text: '#101b22',
-    textSoft: '#566571',
-  },
-  {
-    id: 'luxury-04',
-    name: 'Theme 04',
-    kicker: 'Palette Study 04',
-    note: 'Blue-grey metal with a precise red signal and nearly-black shadow tone.',
-    rail: '#303d49',
-    accent: '#5d020a',
-    accentSoft: '#1a1e22',
-    surface: '#eff2f5',
-    border: '#c9d1d8',
-    text: '#192027',
-    textSoft: '#5a6672',
-  },
-  {
-    id: 'luxury-07',
-    name: 'Theme 07',
-    kicker: 'Palette Study 07',
-    note: 'Night violet, brushed silver, and muted charcoal for the coolest version.',
-    rail: '#141424',
-    accent: '#b5b5b6',
-    accentSoft: '#323240',
-    surface: '#f1f1f4',
-    border: '#d4d5dc',
-    text: '#161824',
-    textSoft: '#5c5f6f',
-  },
-];
+export function getDesignPreviewStyle(theme: DesignPreviewTheme): string {
+  return [
+    `--dp-bg:${theme.bgBase}`,
+    `--dp-bg-deep:${theme.bgDeep}`,
+    `--dp-bg-aura:${theme.bgAura}`,
+    `--dp-panel:${theme.panel}`,
+    `--dp-panel-alt:${theme.panelAlt}`,
+    `--dp-text:${theme.text}`,
+    `--dp-text-soft:${theme.textSoft}`,
+    `--dp-border:${theme.border}`,
+    `--dp-border-strong:${theme.borderStrong}`,
+    `--dp-rail:${theme.rail}`,
+    `--dp-accent:${theme.accent}`,
+  ].join(';');
+}
 
 export function isDesignPreviewVariant(value: string): value is DesignPreviewVariant {
   return DESIGN_PREVIEW_VARIANTS.includes(value as DesignPreviewVariant);

--- a/apps/astro-blog/src/lib/design-preview.ts
+++ b/apps/astro-blog/src/lib/design-preview.ts
@@ -23,7 +23,7 @@ export interface DesignPreviewStats {
   totalPosts: number;
   categoryCount: number;
   averageReadingMinutes: number;
-  latestPublishedLabel: string;
+  leadCategoryLabel: string;
 }
 
 export interface DesignPreviewModel {
@@ -37,33 +37,33 @@ export interface DesignPreviewModel {
 export const DESIGN_PREVIEW_THEMES: Record<DesignPreviewVariant, DesignPreviewTheme> = {
   'industrial-slate': {
     variant: 'industrial-slate',
-    name: 'Essay Stack',
+    name: 'Monolith Column',
     kicker: 'Design Preview 01',
-    title: 'A quiet single-column index for slow reading.',
+    title: 'A single reading axis, stripped to category, title, and text.',
     description:
-      'A calm editorial stack that treats titles, summaries, and publishing metadata as the primary surface.',
+      'This route treats the top page like a disciplined reading surface with one dominant column and almost no decorative interruption.',
     summary:
-      'The focus is a gentle reading rhythm: one strong lead entry, restrained separators, and enough whitespace to feel like the opening spread of a literary journal.',
+      'The mood comes from proportion rather than ornament: hard rules, generous white space, and quiet category markers that organize the page without stealing focus.',
   },
   'archive-grid': {
     variant: 'archive-grid',
-    name: 'Editorial Split',
+    name: 'Monument Banner',
     kicker: 'Design Preview 02',
-    title: 'A text-led index with a narrow editorial sidebar.',
+    title: 'A bold site banner first, then a severe field of text.',
     description:
-      'A two-column composition where the article list stays central and supporting taxonomy moves into a slim companion rail.',
+      'This route gives the blog a stronger front face with a large typographic banner before dropping into a text-led article field.',
     summary:
-      'This option keeps the page airy, but improves browseability with a right-side context column for tags, categories, and site notes.',
+      'It aims to feel architectural rather than editorially soft: the site name acts like a structure, while the article list remains restrained and readable.',
   },
   'signal-frame': {
     variant: 'signal-frame',
-    name: 'Index Ledger',
+    name: 'Index Frame',
     kicker: 'Design Preview 03',
-    title: 'A ledger-like article list with structured metadata.',
+    title: 'A cold index where category leads and titles carry the weight.',
     description:
-      'A denser arrangement that reduces card styling and lets alignment, rules, and metadata columns define the experience.',
+      'This route minimizes card behavior and uses alignment, frames, and category columns to produce a sharper, more systematic landing page.',
     summary:
-      'This route leans closest to an index or bibliography while still giving each post enough summary text to feel readable.',
+      'The result should feel closest to a technical archive or mission index while still preserving enough summary text to invite reading.',
   },
 };
 
@@ -95,14 +95,6 @@ export async function getDesignPreviewModel(): Promise<DesignPreviewModel> {
     readingMinutes.length > 0 ?
       Math.round(readingMinutes.reduce((sum, value) => sum + value, 0) / readingMinutes.length)
     : 0;
-  const latestPublishedLabel =
-    featuredPost ?
-      new Intl.DateTimeFormat('ja-JP', {
-        year: 'numeric',
-        month: '2-digit',
-        day: '2-digit',
-      }).format(featuredPost.publishedAt)
-    : 'N/A';
 
   return {
     featuredPost: featuredPost ?? null,
@@ -111,7 +103,7 @@ export async function getDesignPreviewModel(): Promise<DesignPreviewModel> {
       totalPosts: total,
       categoryCount: categories.length,
       averageReadingMinutes,
-      latestPublishedLabel,
+      leadCategoryLabel: featuredPost?.category ?? 'N/A',
     },
     sampleTags,
     sampleCategories: categories.slice(0, 6),

--- a/apps/astro-blog/src/lib/design-preview.ts
+++ b/apps/astro-blog/src/lib/design-preview.ts
@@ -4,7 +4,7 @@ import { getAllCategories, getPosts } from '$lib/content';
 
 export const DESIGN_PREVIEW_VARIANTS = [
   'luxury-01',
-  'blue-palette',
+  'white-palette',
   'luxury-04',
   'luxury-07',
 ] as const;
@@ -48,27 +48,27 @@ export interface DesignPreviewModel {
 }
 
 export const DESIGN_PREVIEW_THEMES: Record<DesignPreviewVariant, DesignPreviewTheme> = {
-  'blue-palette': {
-    variant: 'blue-palette',
-    name: 'Blue Palette',
-    kicker: 'Palette Preview A',
-    title: 'A submerged blue archive with misted rails and cobalt lift.',
+  'white-palette': {
+    variant: 'white-palette',
+    name: 'White Palette',
+    kicker: 'Palette Preview White',
+    title: 'A pale mineral field with cold grey rails and one near-black anchor.',
     description:
-      'This route rebuilds the page around the first reference palette, using a dense navy field, pale dividers, and soft steel-blue highlights across the entire screen.',
+      'This route replaces the blue study with the attached white palette: chalk white, frosted grey, steel slate, and one deep graphite block used to stabilize the page.',
     summary:
-      'The palette is the main event here: background, shell, switcher, and metadata all tune themselves to the same four blues so the page feels like one cooled surface.',
-    swatches: ['#1f2c5d', '#3a539f', '#c2ccdf', '#829fb6'],
-    bgBase: '#142a57',
-    bgDeep: '#08162d',
-    bgAura: 'rgb(58 83 159 / 0.42)',
-    panel: 'rgb(18 40 83 / 0.78)',
-    panelAlt: 'rgb(194 204 223 / 0.09)',
-    text: '#f3f6fc',
-    textSoft: '#c7d2e6',
-    border: 'rgb(194 204 223 / 0.22)',
-    borderStrong: 'rgb(194 204 223 / 0.42)',
-    rail: '#c2ccdf',
-    accent: '#829fb6',
+      'The mood comes from pale industrial materials rather than brightness alone: matte white surfaces, cool grey rails, and sparse graphite accents keeping the layout severe.',
+    swatches: ['#e4e8e8', '#c8d0d1', '#6b757d', '#1a1d25'],
+    bgBase: '#e4e8e8',
+    bgDeep: '#c8d0d1',
+    bgAura: 'rgb(255 255 255 / 0.42)',
+    panel: 'rgb(246 248 248 / 0.78)',
+    panelAlt: 'rgb(107 117 125 / 0.09)',
+    text: '#1a1d25',
+    textSoft: '#59626a',
+    border: 'rgb(107 117 125 / 0.22)',
+    borderStrong: 'rgb(26 29 37 / 0.22)',
+    rail: '#1a1d25',
+    accent: '#6b757d',
   },
   'luxury-01': {
     variant: 'luxury-01',

--- a/apps/astro-blog/src/lib/design-preview.ts
+++ b/apps/astro-blog/src/lib/design-preview.ts
@@ -3,8 +3,8 @@ import { SITE_URL } from '$constants';
 import { getAllCategories, getPosts } from '$lib/content';
 
 export const DESIGN_PREVIEW_VARIANTS = [
-  'blue-palette',
   'luxury-01',
+  'blue-palette',
   'luxury-04',
   'luxury-07',
 ] as const;
@@ -73,12 +73,12 @@ export const DESIGN_PREVIEW_THEMES: Record<DesignPreviewVariant, DesignPreviewTh
   'luxury-01': {
     variant: 'luxury-01',
     name: 'Theme 01',
-    kicker: 'Palette Preview 01',
-    title: 'Ink navy, restrained brass, and smoked steel in one quiet system.',
+    kicker: 'Base Palette 01',
+    title: 'Ink navy, restrained brass, and smoked steel in a colder archive system.',
     description:
-      'This route takes the 01 reference as a colder luxury palette: near-black blue, warm metallic accents, and a measured amount of brushed grey for supporting structure.',
+      'This route becomes the base direction: near-black blue, restrained brass accents, and smoked steel neutrals arranged with harder rules and less decorative softness.',
     summary:
-      'Instead of a white reading surface, the page becomes a dark instrument panel where the brass category rail and subtle graphite fields carry the atmosphere.',
+      'The page should read like an austere mission ledger rather than a luxury editorial: strict rails, dry labels, and minimal effects over a dark instrument surface.',
     swatches: ['#09171f', '#cea17a', '#3e4e5a'],
     bgBase: '#0c1921',
     bgDeep: '#050c11',

--- a/apps/astro-blog/src/lib/design-preview.ts
+++ b/apps/astro-blog/src/lib/design-preview.ts
@@ -59,7 +59,7 @@ export const DESIGN_PREVIEW_THEMES: Record<DesignPreviewVariant, DesignPreviewTh
       'The mood comes from pale industrial materials rather than brightness alone: matte white surfaces, cool grey rails, and sparse graphite accents keeping the layout severe.',
     swatches: ['#e4e8e8', '#c8d0d1', '#6b757d', '#1a1d25'],
     bgBase: '#e4e8e8',
-    bgDeep: '#c8d0d1',
+    bgDeep: '#d7ddde',
     bgAura: 'rgb(255 255 255 / 0.42)',
     panel: 'rgb(246 248 248 / 0.78)',
     panelAlt: 'rgb(107 117 125 / 0.09)',

--- a/apps/astro-blog/src/lib/design-preview.ts
+++ b/apps/astro-blog/src/lib/design-preview.ts
@@ -1,0 +1,127 @@
+import type { PostMeta } from '@estrivault/content-processor';
+import { SITE_URL } from '$constants';
+import { getAllCategories, getPosts } from '$lib/content';
+
+export const DESIGN_PREVIEW_VARIANTS = [
+  'industrial-slate',
+  'archive-grid',
+  'signal-frame',
+] as const;
+
+export type DesignPreviewVariant = (typeof DESIGN_PREVIEW_VARIANTS)[number];
+
+export interface DesignPreviewTheme {
+  variant: DesignPreviewVariant;
+  name: string;
+  kicker: string;
+  title: string;
+  description: string;
+  panelTitle: string;
+  panelBody: string;
+  metrics: string[];
+}
+
+export interface DesignPreviewStats {
+  totalPosts: number;
+  categoryCount: number;
+  averageReadingMinutes: number;
+  latestPublishedLabel: string;
+}
+
+export interface DesignPreviewModel {
+  featuredPost: PostMeta | null;
+  posts: PostMeta[];
+  stats: DesignPreviewStats;
+  sampleTags: string[];
+  sampleCategories: string[];
+}
+
+export const DESIGN_PREVIEW_THEMES: Record<DesignPreviewVariant, DesignPreviewTheme> = {
+  'industrial-slate': {
+    variant: 'industrial-slate',
+    name: 'Industrial Slate',
+    kicker: 'Design Preview 01',
+    title: 'Matte graphite panels with a quiet amber signal.',
+    description:
+      'A denser, harder-tuned landing surface built from rigid cards, measured spacing, and restrained accent color.',
+    panelTitle: 'Direction note',
+    panelBody:
+      'This route studies a mechanical blog index: strong rails, muted materials, and enough contrast to feel precise without becoming noisy.',
+    metrics: ['Matte graphite', 'Mechanical rails', 'Amber restraint'],
+  },
+  'archive-grid': {
+    variant: 'archive-grid',
+    name: 'Archive Grid',
+    kicker: 'Design Preview 02',
+    title: 'Index-card order with cold, document-like clarity.',
+    description:
+      'A lighter concept that borrows from archive shelving and filing systems, using narrow rules and cyan-tinted utility highlights.',
+    panelTitle: 'Direction note',
+    panelBody:
+      'This route focuses on legibility and sorting. It should feel editorial and systematic rather than soft or lifestyle-oriented.',
+    metrics: ['Concrete light', 'Document rails', 'Cyan utility'],
+  },
+  'signal-frame': {
+    variant: 'signal-frame',
+    name: 'Signal Frame',
+    kicker: 'Design Preview 03',
+    title: 'A low-glow control frame with warning-color discipline.',
+    description:
+      'A darker proposal that frames the content like a monitoring surface, with restrained hazard accents and layered depth.',
+    panelTitle: 'Direction note',
+    panelBody:
+      'This route is the most theatrical of the three, but it keeps the content primary by limiting glow and keeping typography crisp.',
+    metrics: ['Steel depth', 'Layered frame', 'Hazard accent'],
+  },
+};
+
+export function isDesignPreviewVariant(value: string): value is DesignPreviewVariant {
+  return DESIGN_PREVIEW_VARIANTS.includes(value as DesignPreviewVariant);
+}
+
+export function getDesignPreviewHref(variant: DesignPreviewVariant): string {
+  return `/design-preview/${variant}`;
+}
+
+export function getDesignPreviewCanonical(variant: DesignPreviewVariant): string {
+  return `${SITE_URL.replace(/\/$/, '')}${getDesignPreviewHref(variant)}`;
+}
+
+export async function getDesignPreviewModel(): Promise<DesignPreviewModel> {
+  const [{ posts, total }, categories] = await Promise.all([
+    getPosts({ page: 1, perPage: 6 }),
+    getAllCategories(),
+  ]);
+
+  const [featuredPost, ...restPosts] = posts;
+  const visiblePosts = featuredPost ? restPosts : [];
+  const sampleTags = [...new Set(posts.flatMap((post) => post.tags))].slice(0, 8);
+  const readingMinutes = posts
+    .map((post) => Math.ceil(post.readingTime ?? 0))
+    .filter((value) => value > 0);
+  const averageReadingMinutes =
+    readingMinutes.length > 0 ?
+      Math.round(readingMinutes.reduce((sum, value) => sum + value, 0) / readingMinutes.length)
+    : 0;
+  const latestPublishedLabel =
+    featuredPost ?
+      new Intl.DateTimeFormat('ja-JP', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+      }).format(featuredPost.publishedAt)
+    : 'N/A';
+
+  return {
+    featuredPost: featuredPost ?? null,
+    posts: visiblePosts,
+    stats: {
+      totalPosts: total,
+      categoryCount: categories.length,
+      averageReadingMinutes,
+      latestPublishedLabel,
+    },
+    sampleTags,
+    sampleCategories: categories.slice(0, 6),
+  };
+}

--- a/apps/astro-blog/src/lib/design-preview.ts
+++ b/apps/astro-blog/src/lib/design-preview.ts
@@ -19,6 +19,20 @@ export interface DesignPreviewTheme {
   summary: string;
 }
 
+export interface IndexFrameTheme {
+  id: 'blue-palette' | 'luxury-01' | 'luxury-04' | 'luxury-07';
+  name: string;
+  kicker: string;
+  note: string;
+  rail: string;
+  accent: string;
+  accentSoft: string;
+  surface: string;
+  border: string;
+  text: string;
+  textSoft: string;
+}
+
 export interface DesignPreviewStats {
   totalPosts: number;
   categoryCount: number;
@@ -59,13 +73,68 @@ export const DESIGN_PREVIEW_THEMES: Record<DesignPreviewVariant, DesignPreviewTh
     variant: 'signal-frame',
     name: 'Index Frame',
     kicker: 'Design Preview 03',
-    title: 'A cold index where category leads and titles carry the weight.',
+    title: 'A cold index where category anchors the page before the title opens.',
     description:
-      'This route minimizes card behavior and uses alignment, frames, and category columns to produce a sharper, more systematic landing page.',
+      'This route minimizes card behavior and uses a left-side metadata rail, hard rules, and quiet spacing to produce a sharper, more systematic landing page.',
     summary:
       'The result should feel closest to a technical archive or mission index while still preserving enough summary text to invite reading.',
   },
 };
+
+export const INDEX_FRAME_THEMES: IndexFrameTheme[] = [
+  {
+    id: 'blue-palette',
+    name: 'Blue Palette',
+    kicker: 'Palette Study A',
+    note: 'Based on the first image: deep navy, saturated cobalt, pale mist, and dusty blue.',
+    rail: '#1f2c5d',
+    accent: '#3a539f',
+    accentSoft: '#829fb6',
+    surface: '#eef2fa',
+    border: '#c2ccdf',
+    text: '#1f2c5d',
+    textSoft: '#50617f',
+  },
+  {
+    id: 'luxury-01',
+    name: 'Theme 01',
+    kicker: 'Palette Study 01',
+    note: 'Ink navy with warm brass restraint and smoked steel neutrals.',
+    rail: '#09171f',
+    accent: '#cea17a',
+    accentSoft: '#3e4e5a',
+    surface: '#edf1f3',
+    border: '#c8d0d5',
+    text: '#101b22',
+    textSoft: '#566571',
+  },
+  {
+    id: 'luxury-04',
+    name: 'Theme 04',
+    kicker: 'Palette Study 04',
+    note: 'Blue-grey metal with a precise red signal and nearly-black shadow tone.',
+    rail: '#303d49',
+    accent: '#5d020a',
+    accentSoft: '#1a1e22',
+    surface: '#eff2f5',
+    border: '#c9d1d8',
+    text: '#192027',
+    textSoft: '#5a6672',
+  },
+  {
+    id: 'luxury-07',
+    name: 'Theme 07',
+    kicker: 'Palette Study 07',
+    note: 'Night violet, brushed silver, and muted charcoal for the coolest version.',
+    rail: '#141424',
+    accent: '#b5b5b6',
+    accentSoft: '#323240',
+    surface: '#f1f1f4',
+    border: '#d4d5dc',
+    text: '#161824',
+    textSoft: '#5c5f6f',
+  },
+];
 
 export function isDesignPreviewVariant(value: string): value is DesignPreviewVariant {
   return DESIGN_PREVIEW_VARIANTS.includes(value as DesignPreviewVariant);

--- a/apps/astro-blog/src/lib/design-preview.ts
+++ b/apps/astro-blog/src/lib/design-preview.ts
@@ -16,9 +16,7 @@ export interface DesignPreviewTheme {
   kicker: string;
   title: string;
   description: string;
-  panelTitle: string;
-  panelBody: string;
-  metrics: string[];
+  summary: string;
 }
 
 export interface DesignPreviewStats {
@@ -39,39 +37,33 @@ export interface DesignPreviewModel {
 export const DESIGN_PREVIEW_THEMES: Record<DesignPreviewVariant, DesignPreviewTheme> = {
   'industrial-slate': {
     variant: 'industrial-slate',
-    name: 'Industrial Slate',
+    name: 'Essay Stack',
     kicker: 'Design Preview 01',
-    title: 'Matte graphite panels with a quiet amber signal.',
+    title: 'A quiet single-column index for slow reading.',
     description:
-      'A denser, harder-tuned landing surface built from rigid cards, measured spacing, and restrained accent color.',
-    panelTitle: 'Direction note',
-    panelBody:
-      'This route studies a mechanical blog index: strong rails, muted materials, and enough contrast to feel precise without becoming noisy.',
-    metrics: ['Matte graphite', 'Mechanical rails', 'Amber restraint'],
+      'A calm editorial stack that treats titles, summaries, and publishing metadata as the primary surface.',
+    summary:
+      'The focus is a gentle reading rhythm: one strong lead entry, restrained separators, and enough whitespace to feel like the opening spread of a literary journal.',
   },
   'archive-grid': {
     variant: 'archive-grid',
-    name: 'Archive Grid',
+    name: 'Editorial Split',
     kicker: 'Design Preview 02',
-    title: 'Index-card order with cold, document-like clarity.',
+    title: 'A text-led index with a narrow editorial sidebar.',
     description:
-      'A lighter concept that borrows from archive shelving and filing systems, using narrow rules and cyan-tinted utility highlights.',
-    panelTitle: 'Direction note',
-    panelBody:
-      'This route focuses on legibility and sorting. It should feel editorial and systematic rather than soft or lifestyle-oriented.',
-    metrics: ['Concrete light', 'Document rails', 'Cyan utility'],
+      'A two-column composition where the article list stays central and supporting taxonomy moves into a slim companion rail.',
+    summary:
+      'This option keeps the page airy, but improves browseability with a right-side context column for tags, categories, and site notes.',
   },
   'signal-frame': {
     variant: 'signal-frame',
-    name: 'Signal Frame',
+    name: 'Index Ledger',
     kicker: 'Design Preview 03',
-    title: 'A low-glow control frame with warning-color discipline.',
+    title: 'A ledger-like article list with structured metadata.',
     description:
-      'A darker proposal that frames the content like a monitoring surface, with restrained hazard accents and layered depth.',
-    panelTitle: 'Direction note',
-    panelBody:
-      'This route is the most theatrical of the three, but it keeps the content primary by limiting glow and keeping typography crisp.',
-    metrics: ['Steel depth', 'Layered frame', 'Hazard accent'],
+      'A denser arrangement that reduces card styling and lets alignment, rules, and metadata columns define the experience.',
+    summary:
+      'This route leans closest to an index or bibliography while still giving each post enough summary text to feel readable.',
   },
 };
 

--- a/apps/astro-blog/src/lib/top-page.ts
+++ b/apps/astro-blog/src/lib/top-page.ts
@@ -1,0 +1,60 @@
+import type { PostMeta } from '@estrivault/content-processor';
+import { getAllCategories, getPosts } from '$lib/content';
+
+export interface TopPageStats {
+  totalPosts: number;
+  categoryCount: number;
+  averageReadingMinutes: number;
+  leadCategoryLabel: string;
+}
+
+export interface TopPageModel {
+  featuredPost: PostMeta | null;
+  posts: PostMeta[];
+  stats: TopPageStats;
+  sampleTags: string[];
+  sampleCategories: string[];
+  currentPage: number;
+  totalPages: number;
+}
+
+interface GetTopPageModelOptions {
+  page: number;
+  perPage: number;
+}
+
+export async function getTopPageModel({
+  page,
+  perPage,
+}: GetTopPageModelOptions): Promise<TopPageModel> {
+  const [{ posts, total, totalPages }, categories] = await Promise.all([
+    getPosts({ page, perPage }),
+    getAllCategories(),
+  ]);
+
+  const [featuredPost, ...restPosts] = posts;
+  const visiblePosts = featuredPost ? restPosts : [];
+  const sampleTags = [...new Set(posts.flatMap((post) => post.tags))].slice(0, 8);
+  const readingMinutes = posts
+    .map((post) => Math.ceil(post.readingTime ?? 0))
+    .filter((value) => value > 0);
+  const averageReadingMinutes =
+    readingMinutes.length > 0 ?
+      Math.round(readingMinutes.reduce((sum, value) => sum + value, 0) / readingMinutes.length)
+    : 0;
+
+  return {
+    featuredPost: featuredPost ?? null,
+    posts: visiblePosts,
+    stats: {
+      totalPosts: total,
+      categoryCount: categories.length,
+      averageReadingMinutes,
+      leadCategoryLabel: featuredPost?.category ?? 'N/A',
+    },
+    sampleTags,
+    sampleCategories: categories.slice(0, 6),
+    currentPage: page,
+    totalPages,
+  };
+}

--- a/apps/astro-blog/src/pages/[page].astro
+++ b/apps/astro-blog/src/pages/[page].astro
@@ -1,9 +1,9 @@
 ---
-import BaseLayout from '$layouts/BaseLayout.astro';
-import Pagination from '$components/Pagination.astro';
-import PostCard from '$components/PostCard.astro';
+import TopPageIndex from '$components/TopPageIndex.astro';
 import { POSTS_PER_PAGE, SITE_TITLE, SITE_URL } from '$constants';
+import TopPageLayout from '$layouts/TopPageLayout.astro';
 import { getPosts } from '$lib/content';
+import { getTopPageModel } from '$lib/top-page';
 
 export async function getStaticPaths() {
   const allPosts = await getPosts({ perPage: POSTS_PER_PAGE });
@@ -17,33 +17,23 @@ export async function getStaticPaths() {
 }
 
 const currentPage = Number(Astro.params.page);
-const result = await getPosts({ page: currentPage, perPage: POSTS_PER_PAGE });
+const model = await getTopPageModel({ page: currentPage, perPage: POSTS_PER_PAGE });
 
-const pageTitle = `記事一覧 - ページ${currentPage} | ${SITE_TITLE}`;
-const pageDescription = `${SITE_TITLE}の記事一覧ページ${currentPage}です。技術記事やプログラミング情報を探すことができます。`;
+const pageTitle = `Page ${currentPage} | ${SITE_TITLE}`;
+const pageDescription = `Browse page ${currentPage} of ${SITE_TITLE}.`;
 const siteBase = SITE_URL.replace(/\/$/, '');
 const pageUrl = `${siteBase}/${currentPage}`;
 const prevUrl =
   currentPage > 1 ? `${siteBase}${currentPage > 2 ? `/${currentPage - 1}` : ''}` : undefined;
-const nextUrl = currentPage < result.totalPages ? `${siteBase}/${currentPage + 1}` : undefined;
+const nextUrl = currentPage < model.totalPages ? `${siteBase}/${currentPage + 1}` : undefined;
 ---
 
-<BaseLayout
+<TopPageLayout
   title={pageTitle}
   description={pageDescription}
   canonical={pageUrl}
   prevUrl={prevUrl}
   nextUrl={nextUrl}
 >
-  <div class="grid gap-8 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
-    {result.posts.map((post) => <PostCard post={post} />)}
-  </div>
-
-  {
-    result.totalPages > 1 && (
-      <div class="mt-12">
-        <Pagination currentPage={result.page} totalPages={result.totalPages} baseUrl="/" />
-      </div>
-    )
-  }
-</BaseLayout>
+  <TopPageIndex model={model} />
+</TopPageLayout>

--- a/apps/astro-blog/src/pages/design-preview/[variant].astro
+++ b/apps/astro-blog/src/pages/design-preview/[variant].astro
@@ -1,0 +1,38 @@
+---
+import DesignPreviewPage from '$components/DesignPreviewPage.astro';
+import { SITE_TITLE } from '$constants';
+import DesignPreviewLayout from '$layouts/DesignPreviewLayout.astro';
+import {
+  DESIGN_PREVIEW_THEMES,
+  DESIGN_PREVIEW_VARIANTS,
+  getDesignPreviewCanonical,
+  getDesignPreviewModel,
+  isDesignPreviewVariant,
+} from '$lib/design-preview';
+
+export function getStaticPaths() {
+  return DESIGN_PREVIEW_VARIANTS.map((variant) => ({
+    params: { variant },
+  }));
+}
+
+const variantParam = Astro.params.variant;
+
+if (!variantParam || !isDesignPreviewVariant(variantParam)) {
+  throw new Error(`Invalid design preview variant: ${variantParam}`);
+}
+
+const theme = DESIGN_PREVIEW_THEMES[variantParam];
+const model = await getDesignPreviewModel();
+const canonical = getDesignPreviewCanonical(variantParam);
+const title = `${theme.name} | Design Preview | ${SITE_TITLE}`;
+---
+
+<DesignPreviewLayout
+  title={title}
+  description={theme.description}
+  canonical={canonical}
+  variant={variantParam}
+>
+  <DesignPreviewPage model={model} theme={theme} />
+</DesignPreviewLayout>

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -1,25 +1,12 @@
 ---
-import BaseLayout from '$layouts/BaseLayout.astro';
-import Pagination from '$components/Pagination.astro';
-import PostCard from '$components/PostCard.astro';
+import TopPageIndex from '$components/TopPageIndex.astro';
 import { POSTS_PER_PAGE, SITE_DESCRIPTION, SITE_TITLE, SITE_URL } from '$constants';
-import { getPosts } from '$lib/content';
+import TopPageLayout from '$layouts/TopPageLayout.astro';
+import { getTopPageModel } from '$lib/top-page';
 
-const pageData = await getPosts({ page: 1, perPage: POSTS_PER_PAGE });
+const model = await getTopPageModel({ page: 1, perPage: POSTS_PER_PAGE });
 ---
 
-<BaseLayout title={SITE_TITLE} description={SITE_DESCRIPTION} canonical={SITE_URL}>
-  <h1 class="sr-only">{SITE_TITLE}</h1>
-
-  <div class="grid gap-8 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
-    {pageData.posts.map((post) => <PostCard post={post} />)}
-  </div>
-
-  {
-    pageData.totalPages > 1 && (
-      <div class="mt-12">
-        <Pagination currentPage={pageData.page} totalPages={pageData.totalPages} baseUrl="/" />
-      </div>
-    )
-  }
-</BaseLayout>
+<TopPageLayout title={SITE_TITLE} description={SITE_DESCRIPTION} canonical={SITE_URL}>
+  <TopPageIndex model={model} />
+</TopPageLayout>

--- a/apps/astro-blog/src/top-page.css
+++ b/apps/astro-blog/src/top-page.css
@@ -1,0 +1,441 @@
+.top-page-shell {
+  --tp-bg: #e4e8e8;
+  --tp-bg-deep: #d7ddde;
+  --tp-panel: rgb(246 248 248 / 0.82);
+  --tp-panel-alt: rgb(107 117 125 / 0.08);
+  --tp-text: #1a1d25;
+  --tp-text-soft: #59626a;
+  --tp-border: rgb(107 117 125 / 0.18);
+  --tp-border-strong: rgb(26 29 37 / 0.18);
+  --tp-rail: #1a1d25;
+  --tp-accent: #6b757d;
+  --tp-shadow: 0 18px 44px rgb(26 29 37 / 0.08);
+  --tp-font-display:
+    'Aptos', 'Segoe UI', 'Yu Gothic UI', 'Hiragino Sans', 'Helvetica Neue', sans-serif;
+  --tp-font-body:
+    'Aptos', 'Segoe UI', 'Yu Gothic UI', 'Hiragino Sans', 'Helvetica Neue', sans-serif;
+  --tp-font-mono: 'IBM Plex Mono', 'Cascadia Code', 'Courier New', monospace;
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(circle at 14% 8%, rgb(255 255 255 / 0.42), transparent 22%),
+    radial-gradient(circle at 82% 0%, rgb(255 255 255 / 0.28), transparent 18%),
+    linear-gradient(180deg, var(--tp-bg) 0%, #dde2e2 55%, var(--tp-bg-deep) 100%);
+  color: var(--tp-text);
+  font-family: var(--tp-font-body);
+}
+
+.top-page-shell *,
+.top-page-shell *::before,
+.top-page-shell *::after {
+  box-sizing: border-box;
+}
+
+.top-page-shell a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.tp-main {
+  width: min(1280px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 0 0 28px;
+}
+
+.tp-header {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  padding: 22px 16px 16px;
+}
+
+.tp-header__frame {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  width: min(1280px, 100%);
+  margin: 0 auto;
+  padding: 15px 18px;
+  border: 1px solid var(--tp-border);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 0.04), transparent),
+    color-mix(in srgb, var(--tp-panel) 82%, var(--tp-bg-deep) 18%);
+  box-shadow: var(--tp-shadow);
+  backdrop-filter: blur(6px);
+}
+
+.tp-header__brand {
+  font-size: 1.1rem;
+  font-weight: 780;
+  letter-spacing: -0.02em;
+  text-transform: uppercase;
+}
+
+.tp-header__nav-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tp-header__nav-link {
+  display: block;
+  padding: 10px 12px;
+  border: 1px solid var(--tp-border);
+  border-radius: 4px;
+  background: rgb(255 255 255 / 0.03);
+  color: var(--tp-text-soft);
+  font-size: 0.88rem;
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease;
+}
+
+.tp-header__nav-link:hover,
+.tp-header__nav-link.is-current {
+  border-color: var(--tp-rail);
+  color: var(--tp-text);
+}
+
+.top-page {
+  display: grid;
+  gap: 14px;
+}
+
+.tp-shell {
+  display: grid;
+  gap: 0;
+  padding: 30px 30px 24px;
+  border: 1px solid var(--tp-border);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 0.03), transparent 16%),
+    linear-gradient(180deg, var(--tp-panel), rgb(255 255 255 / 0.35));
+  box-shadow: var(--tp-shadow);
+}
+
+.tp-kicker {
+  margin: 0;
+  color: var(--tp-text-soft);
+  font-family: var(--tp-font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.tp-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
+  gap: 22px;
+  padding: 0 0 26px;
+  margin-bottom: 18px;
+  border-bottom: 1px solid var(--tp-border-strong);
+}
+
+.tp-hero__copy {
+  display: grid;
+  gap: 10px;
+}
+
+.tp-hero__title {
+  margin: 0;
+  font-family: var(--tp-font-display);
+  font-size: clamp(2.6rem, 5.4vw, 4.5rem);
+  font-weight: 780;
+  letter-spacing: -0.04em;
+  line-height: 0.98;
+  text-transform: uppercase;
+}
+
+.tp-hero__statement {
+  margin: 0;
+  max-width: 24ch;
+  font-size: clamp(1.16rem, 2vw, 1.38rem);
+  line-height: 1.45;
+}
+
+.tp-hero__description,
+.tp-row__description,
+.tp-hero__summary p,
+.tp-global-footer__copy {
+  margin: 0;
+  color: var(--tp-text-soft);
+  line-height: 1.72;
+}
+
+.tp-hero__aside {
+  display: grid;
+  gap: 16px;
+  align-content: start;
+}
+
+.tp-hero__summary {
+  display: grid;
+  gap: 8px;
+  padding: 0 0 14px;
+  border-bottom: 1px solid var(--tp-border-strong);
+}
+
+.tp-hero__stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.tp-hero__stats div {
+  padding-top: 10px;
+  border-top: 1px solid var(--tp-border-strong);
+}
+
+.tp-hero__stats dt {
+  color: var(--tp-text-soft);
+  font-family: var(--tp-font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.tp-hero__stats dd {
+  margin: 7px 0 0;
+  font-size: 0.98rem;
+  font-weight: 700;
+}
+
+.tp-featured {
+  display: grid;
+  border-bottom: 1px solid var(--tp-border-strong);
+}
+
+.tp-list {
+  display: grid;
+}
+
+.tp-entry {
+  display: grid;
+  border-bottom: 1px solid var(--tp-border);
+}
+
+.tp-row {
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr);
+  gap: 18px;
+  padding: 18px 0;
+}
+
+.tp-row--featured {
+  padding-top: 0;
+  padding-bottom: 24px;
+}
+
+.tp-row__meta {
+  display: grid;
+  align-content: start;
+  gap: 10px;
+}
+
+.tp-row__category {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+}
+
+.tp-row__category strong {
+  color: var(--tp-rail);
+  font-size: 1.04rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.tp-row__secondary {
+  display: grid;
+  gap: 8px;
+  color: var(--tp-text-soft);
+  font-family: var(--tp-font-mono);
+  font-size: 0.76rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.tp-row__body {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+.tp-row__title {
+  margin: 0;
+  font-size: clamp(1.08rem, 1.8vw, 1.48rem);
+  font-weight: 740;
+  letter-spacing: -0.02em;
+  line-height: 1.22;
+}
+
+.tp-pagination-wrap {
+  display: grid;
+  gap: 10px;
+  margin-top: 22px;
+  padding-top: 16px;
+  border-top: 1px solid var(--tp-border);
+}
+
+.tp-pagination {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.tp-pagination__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tp-pagination__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 36px;
+  padding: 0 12px;
+  border: 1px solid var(--tp-border);
+  border-radius: 2px;
+  background: rgb(255 255 255 / 0.03);
+  color: var(--tp-text-soft);
+  font-family: var(--tp-font-mono);
+  font-size: 0.8rem;
+}
+
+.tp-pagination__button.is-current {
+  border-color: var(--tp-rail);
+  color: var(--tp-rail);
+}
+
+.tp-pagination__button.is-disabled {
+  opacity: 0.5;
+}
+
+.tp-pagination__ellipsis {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  min-height: 36px;
+  color: var(--tp-text-soft);
+}
+
+.tp-meta-footer {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.tp-meta-footer__block {
+  display: grid;
+  gap: 12px;
+  padding: 18px;
+  border: 1px solid var(--tp-border);
+  border-radius: 4px;
+  background: var(--tp-panel-alt);
+}
+
+.tp-meta-footer__list,
+.tp-meta-footer__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tp-meta-footer__list a,
+.tp-meta-footer__chips a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  padding: 0 10px;
+  border: 1px solid var(--tp-border);
+  border-radius: 2px;
+  background: rgb(255 255 255 / 0.03);
+  color: var(--tp-text-soft);
+  font-size: 0.8rem;
+}
+
+.tp-global-footer {
+  width: min(1280px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 0 0 32px;
+}
+
+.tp-global-footer__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.tp-global-footer__links a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  padding: 0 10px;
+  border: 1px solid var(--tp-border);
+  border-radius: 2px;
+  background: rgb(255 255 255 / 0.03);
+  color: var(--tp-text-soft);
+  font-size: 0.8rem;
+}
+
+.tp-empty-state {
+  padding: 22px;
+  border: 1px dashed var(--tp-border);
+  border-radius: 4px;
+  background: var(--tp-panel-alt);
+  color: var(--tp-text-soft);
+}
+
+@media (max-width: 1080px) {
+  .tp-hero,
+  .tp-row,
+  .tp-meta-footer {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 820px) {
+  .tp-header__frame {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 720px) {
+  .tp-main,
+  .tp-global-footer {
+    width: calc(100% - 28px);
+  }
+
+  .tp-shell {
+    padding: 16px;
+  }
+
+  .tp-header {
+    padding: 14px 14px 12px;
+  }
+
+  .tp-header__frame {
+    padding: 14px;
+  }
+
+  .tp-hero__stats {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/astro-blog/src/top-page.css
+++ b/apps/astro-blog/src/top-page.css
@@ -47,6 +47,21 @@
   top: 0;
   z-index: 30;
   padding: 22px 16px 16px;
+  transition:
+    opacity 180ms ease,
+    transform 180ms ease;
+}
+
+.tp-header.is-scroll-reveal {
+  opacity: 0;
+  transform: translateY(-10px);
+  pointer-events: none;
+}
+
+.tp-header.is-scroll-reveal.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
 }
 
 .tp-header__frame {
@@ -134,6 +149,10 @@
   padding: 0 0 26px;
   margin-bottom: 18px;
   border-bottom: 1px solid var(--tp-border-strong);
+}
+
+.tp-header-trigger {
+  height: 1px;
 }
 
 .tp-hero__copy {
@@ -341,9 +360,10 @@
   display: grid;
   gap: 12px;
   padding: 18px;
-  border: 1px solid var(--tp-border);
+  border: 1px solid rgb(107 117 125 / 0.24);
   border-radius: 4px;
-  background: var(--tp-panel-alt);
+  background: rgb(250 251 251 / 0.72);
+  box-shadow: 0 8px 20px rgb(26 29 37 / 0.04);
 }
 
 .tp-meta-footer__list,
@@ -362,10 +382,10 @@
   align-items: center;
   min-height: 30px;
   padding: 0 10px;
-  border: 1px solid var(--tp-border);
+  border: 1px solid rgb(107 117 125 / 0.22);
   border-radius: 2px;
-  background: rgb(255 255 255 / 0.03);
-  color: var(--tp-text-soft);
+  background: rgb(255 255 255 / 0.7);
+  color: rgb(60 67 75);
   font-size: 0.8rem;
 }
 
@@ -387,11 +407,15 @@
   align-items: center;
   min-height: 30px;
   padding: 0 10px;
-  border: 1px solid var(--tp-border);
+  border: 1px solid rgb(107 117 125 / 0.22);
   border-radius: 2px;
-  background: rgb(255 255 255 / 0.03);
-  color: var(--tp-text-soft);
+  background: rgb(255 255 255 / 0.58);
+  color: rgb(68 75 82);
   font-size: 0.8rem;
+}
+
+.tp-global-footer__copy {
+  color: rgb(68 75 82);
 }
 
 .tp-empty-state {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:fast": "pnpm -r --filter astro-blog... run build",
     "build:legacy": "pnpm run build:packages && pnpm --filter astro-blog run build",
     "build:packages": "pnpm --parallel --filter @estrivault/cloudinary-utils --filter @estrivault/content-processor --filter @estrivault/og-image-generator run build",
-    "build:packages:incremental": "tsc --build packages/cloudinary-utils packages/content-processor packages/og-image-generator",
+    "build:packages:incremental": "pnpm exec tsc --build packages/cloudinary-utils packages/content-processor packages/og-image-generator",
     "dev:packages": "pnpm --parallel --filter @estrivault/cloudinary-utils --filter @estrivault/og-image-generator run dev",
     "validate:workspace": "node scripts/validate-workspace.js",
     "preinstall": "node scripts/require-pnpm.js",

--- a/packages/cloudinary-utils/package.json
+++ b/packages/cloudinary-utils/package.json
@@ -9,11 +9,11 @@
   ],
   "scripts": {
     "clean": "rimraf dist",
-    "build:types": "pnpm exec tsc --build",
-    "build:bundle": "pnpm exec tsup",
+    "build:types": "node ../../node_modules/typescript/bin/tsc --build",
+    "build:bundle": "node ./node_modules/tsup/dist/cli-default.js",
     "build": "pnpm run build:types && pnpm run build:bundle",
     "rebuild": "pnpm run clean && pnpm run build",
-    "dev": "tsup --watch"
+    "dev": "node ./node_modules/tsup/dist/cli-default.js --watch"
   },
   "exports": {
     ".": {

--- a/packages/cloudinary-utils/package.json
+++ b/packages/cloudinary-utils/package.json
@@ -9,8 +9,8 @@
   ],
   "scripts": {
     "clean": "rimraf dist",
-    "build:types": "tsc --build",
-    "build:bundle": "tsup",
+    "build:types": "pnpm exec tsc --build",
+    "build:bundle": "pnpm exec tsup",
     "build": "pnpm run build:types && pnpm run build:bundle",
     "rebuild": "pnpm run clean && pnpm run build",
     "dev": "tsup --watch"

--- a/packages/content-processor/package.json
+++ b/packages/content-processor/package.json
@@ -15,8 +15,8 @@
   ],
   "scripts": {
     "clean": "rimraf dist",
-    "build:types": "tsc --build",
-    "build:bundle": "tsup",
+    "build:types": "pnpm exec tsc --build",
+    "build:bundle": "pnpm exec tsup",
     "build": "pnpm run build:types && pnpm run build:bundle",
     "rebuild": "pnpm run clean && pnpm run build"
   },

--- a/packages/content-processor/package.json
+++ b/packages/content-processor/package.json
@@ -15,8 +15,8 @@
   ],
   "scripts": {
     "clean": "rimraf dist",
-    "build:types": "pnpm exec tsc --build",
-    "build:bundle": "pnpm exec tsup",
+    "build:types": "node ../../node_modules/typescript/bin/tsc --build",
+    "build:bundle": "node ./node_modules/tsup/dist/cli-default.js",
     "build": "pnpm run build:types && pnpm run build:bundle",
     "rebuild": "pnpm run clean && pnpm run build"
   },

--- a/packages/og-image-generator/package.json
+++ b/packages/og-image-generator/package.json
@@ -9,8 +9,8 @@
   ],
   "scripts": {
     "clean": "rimraf dist",
-    "build:types": "tsc --build",
-    "build:bundle": "tsup",
+    "build:types": "pnpm exec tsc --build",
+    "build:bundle": "pnpm exec tsup",
     "build": "pnpm run build:types && pnpm run build:bundle",
     "rebuild": "pnpm run clean && pnpm run build",
     "dev": "tsup --watch",

--- a/packages/og-image-generator/package.json
+++ b/packages/og-image-generator/package.json
@@ -9,11 +9,11 @@
   ],
   "scripts": {
     "clean": "rimraf dist",
-    "build:types": "pnpm exec tsc --build",
-    "build:bundle": "pnpm exec tsup",
+    "build:types": "node ../../node_modules/typescript/bin/tsc --build",
+    "build:bundle": "node ./node_modules/tsup/dist/cli-default.js",
     "build": "pnpm run build:types && pnpm run build:bundle",
     "rebuild": "pnpm run clean && pnpm run build",
-    "dev": "tsup --watch",
+    "dev": "node ./node_modules/tsup/dist/cli-default.js --watch",
     "test": "node --test test/*.test.mjs"
   },
   "exports": {


### PR DESCRIPTION
## Summary
- add three isolated design preview routes for visual comparison only
- introduce a dedicated preview layout, shared preview data model, and preview-specific styling
- add a lightweight Playwright smoke test for the new preview routes

## Validation
- prettier --check apps/astro-blog/src/lib/design-preview.ts apps/astro-blog/src/layouts/DesignPreviewLayout.astro apps/astro-blog/src/components/DesignPreviewPage.astro apps/astro-blog/src/design-preview.css apps/astro-blog/src/pages/design-preview/[variant].astro apps/astro-blog/e2e/design-preview.test.ts
- stro check *(fails in existing code: cannot resolve @estrivault/og-image-generator from pps/astro-blog/src/pages/post/[slug]/og.png.ts)*
- stro build *(fails in existing code: cannot resolve @estrivault/og-image-generator from pps/astro-blog/src/pages/post/[slug]/og.png.ts)*

## Notes
- preview routes are intentionally not added to the production navigation
- each route sets 
oindex, nofollow so they stay comparison-only
