### PR TITLE
Fix Japanese OGP title wrapping

### DIFF
--- a/packages/og-image-generator/src/title-layout.ts
+++ b/packages/og-image-generator/src/title-layout.ts
@@ -64,7 +64,7 @@ function adjustLineLength(
     adjustedLength -= 1;
   }
 
-  if (
+  while (
     adjustedLength < maxLineLength &&
     PROHIBITED_LINE_START_CHARACTERS.has(characters[start + adjustedLength] ?? '')
   ) {

--- a/packages/og-image-generator/src/title-layout.ts
+++ b/packages/og-image-generator/src/title-layout.ts
@@ -14,8 +14,8 @@ interface TitlePreset {
 
 const TITLE_PRESETS: TitlePreset[] = [
   { fontSize: 76, lineHeight: 1.14, maxCharsPerLine: 12, maxLines: 3 },
-  { fontSize: 64, lineHeight: 1.16, maxCharsPerLine: 16, maxLines: 3 },
-  { fontSize: 56, lineHeight: 1.2, maxCharsPerLine: 20, maxLines: 3 },
+  { fontSize: 64, lineHeight: 1.16, maxCharsPerLine: 14, maxLines: 3 },
+  { fontSize: 56, lineHeight: 1.2, maxCharsPerLine: 17, maxLines: 3 },
 ];
 
 function normalizeTitle(title: string): string {
@@ -36,12 +36,64 @@ function truncateTitle(
   };
 }
 
-function wrapTitle(title: string, maxCharsPerLine: number): string[] {
+const PROHIBITED_LINE_START_CHARACTERS = new Set(
+  Array.from('、。，．・：；！？!?)]）｝」』】〉》ぁぃぅぇぉっゃゅょー…'),
+);
+const PROHIBITED_LINE_END_CHARACTERS = new Set(Array.from('([{（｛「『【〈《'));
+
+function adjustLineLength(
+  characters: string[],
+  start: number,
+  lineLength: number,
+  minLineLength: number,
+  maxLineLength: number,
+): number {
+  let adjustedLength = lineLength;
+
+  while (
+    adjustedLength > minLineLength &&
+    PROHIBITED_LINE_START_CHARACTERS.has(characters[start + adjustedLength] ?? '')
+  ) {
+    adjustedLength -= 1;
+  }
+
+  while (
+    adjustedLength > minLineLength &&
+    PROHIBITED_LINE_END_CHARACTERS.has(characters[start + adjustedLength - 1] ?? '')
+  ) {
+    adjustedLength -= 1;
+  }
+
+  if (
+    adjustedLength < maxLineLength &&
+    PROHIBITED_LINE_START_CHARACTERS.has(characters[start + adjustedLength] ?? '')
+  ) {
+    adjustedLength += 1;
+  }
+
+  return adjustedLength;
+}
+
+function wrapTitle(title: string, maxCharsPerLine: number, maxLines: number): string[] {
   const characters = Array.from(title);
   const lines: string[] = [];
+  const lineCount = Math.min(Math.ceil(characters.length / maxCharsPerLine), maxLines);
+  let index = 0;
 
-  for (let index = 0; index < characters.length; index += maxCharsPerLine) {
-    lines.push(characters.slice(index, index + maxCharsPerLine).join(''));
+  for (let lineIndex = 0; lineIndex < lineCount; lineIndex += 1) {
+    const remainingCharacters = characters.length - index;
+    const remainingLines = lineCount - lineIndex;
+    const minLineLength = Math.max(1, remainingCharacters - maxCharsPerLine * (remainingLines - 1));
+    const lineLength = adjustLineLength(
+      characters,
+      index,
+      Math.min(Math.ceil(remainingCharacters / remainingLines), maxCharsPerLine),
+      minLineLength,
+      Math.min(maxCharsPerLine + 1, remainingCharacters),
+    );
+
+    lines.push(characters.slice(index, index + lineLength).join(''));
+    index += lineLength;
   }
 
   return lines;
@@ -62,7 +114,7 @@ export function layoutPostOgpTitle(title: string): TitleLayout {
   return {
     fontSize: preset.fontSize,
     lineHeight: preset.lineHeight,
-    lines: wrapTitle(value, preset.maxCharsPerLine),
+    lines: wrapTitle(value, preset.maxCharsPerLine, preset.maxLines),
     truncated,
   };
 }

--- a/packages/og-image-generator/test/generate-post-ogp.test.mjs
+++ b/packages/og-image-generator/test/generate-post-ogp.test.mjs
@@ -41,6 +41,13 @@ test('supports long Japanese titles without exceeding three lines', async () => 
   assert.deepEqual(readPngSize(png), { width: 1200, height: 630 });
 });
 
+test('balances Japanese title lines to avoid orphaned kana', () => {
+  const layout = layoutPostOgpTitle('基本週2回しかトレーニング出来ない場合のメニュー案');
+
+  assert.deepEqual(layout.lines, ['基本週2回しかトレーニング', '出来ない場合のメニュー案']);
+  assert.equal(layout.truncated, false);
+});
+
 test('adds an ellipsis once the title exceeds the three-line budget', () => {
   const layout = layoutPostOgpTitle(
     'これは非常に長い記事タイトルであり、三行に収まりきらないケースをテストするためにさらに文字数を増やしています。最終的には省略記号が付与される必要があります。',
@@ -49,4 +56,7 @@ test('adds an ellipsis once the title exceeds the three-line budget', () => {
   assert.equal(layout.lines.length, 3);
   assert.equal(layout.truncated, true);
   assert.match(layout.lines.at(-1) ?? '', /…$/);
+  assert.ok(
+    layout.lines.every((line) => !/^[、。，．・：；！？!?\])）｝」』】〉》ぁぃぅぇぉっゃゅょー…]/.test(line)),
+  );
 });

--- a/packages/og-image-generator/test/generate-post-ogp.test.mjs
+++ b/packages/og-image-generator/test/generate-post-ogp.test.mjs
@@ -48,6 +48,14 @@ test('balances Japanese title lines to avoid orphaned kana', () => {
   assert.equal(layout.truncated, false);
 });
 
+test('consumes consecutive prohibited-start characters when adjusting line breaks', () => {
+  const layout = layoutPostOgpTitle('かてく）』?】、』】ちおおあちうせ');
+
+  assert.ok(
+    layout.lines.every((line) => !/^[、。，．・：；！？!?\])）｝」』】〉》ぁぃぅぇぉっゃゅょー…]/.test(line)),
+  );
+});
+
 test('adds an ellipsis once the title exceeds the three-line budget', () => {
   const layout = layoutPostOgpTitle(
     'これは非常に長い記事タイトルであり、三行に収まりきらないケースをテストするためにさらに文字数を増やしています。最終的には省略記号が付与される必要があります。',


### PR DESCRIPTION
## Summary
- balance OGP title lines instead of splitting only by fixed chunks
- reduce per-line title budgets so rendered Japanese titles fit the OGP text area
- add light Japanese line-start/end prohibition handling and a regression test for the training-menu title

## Validation
- Confirmed `layoutPostOgpTitle('基本週2回しかトレーニング出来ない場合のメニュー案')` returns `['基本週2回しかトレーニング', '出来ない場合のメニュー案']` using the bundled Node runtime
- Confirmed a long Japanese title still truncates to three lines with an ellipsis and avoids prohibited line-start punctuation

Note: full `pnpm --filter @estrivault/og-image-generator build/test` could not be run in this local worktree because `pnpm`/`node_modules` were unavailable from the Windows shell.