### PR TITLE
Encode fallback tag route delimiters

### DIFF
--- a/apps/astro-blog/src/lib/url-segments.ts
+++ b/apps/astro-blog/src/lib/url-segments.ts
@@ -1,5 +1,9 @@
 import { normalizeForSlug, normalizeForTagFilter } from '@estrivault/content-processor';
 
+function encodePathDelimiters(segment: string): string {
+  return segment.replace(/[/%?#\\]/g, (char) => encodeURIComponent(char));
+}
+
 export function getTagRouteSegment(tag: string): string {
   const cleaned = tag.trim();
   if (!cleaned) {
@@ -11,5 +15,5 @@ export function getTagRouteSegment(tag: string): string {
     return normalizedSlug;
   }
 
-  return normalizeForTagFilter(cleaned).replace(/\s+/g, '-');
+  return encodePathDelimiters(normalizeForTagFilter(cleaned).replace(/\s+/g, '-'));
 }


### PR DESCRIPTION
## Summary
- preserve raw Unicode fallback tag segments for Astro static path matching
- percent-encode path delimiters in fallback tag route segments so /, ?, #, %, and \\ cannot break tag routes

## Validation
- pnpm run type-check
- pnpm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- `encodePathDelimiters` ヘルパー関数を追加 / タグ ルート セグメント内の `/`、`%`、`?`、`#`、`\` などのパス デリミタ文字を percent-encode するため
- `getTagRouteSegment` 関数のフォールバック処理（`normalizeForTagFilter` 使用時）に `encodePathDelimiters` を適用 / 特殊文字がタグ ルートを破損するのを防ぐため
- Astro の静的パス マッチング時に、ユニコード タグを正規化しながらも予約文字をエスケープ / raw Unicode セグメントを保持しつつルート安全性を確保するため

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/big-mon/estrivault-blog-app/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->