### PR TITLE
Redesign editorial homepage

### DIFF
--- a/apps/astro-blog/src/components/ArchiveListing.astro
+++ b/apps/astro-blog/src/components/ArchiveListing.astro
@@ -90,8 +90,8 @@ const visibleTopTags = topTags.slice(0, 5);
 
   <section class="archive-index" aria-labelledby="archive-index-title">
     <div class="section-heading">
-      <h2 id="archive-index-title">INDEX / {total} ENTRIES</h2>
-      <p>{page} / {totalPages} PAGE</p>
+      <h2 id="archive-index-title">ARTICLES MATCHING YOUR SELECTION</h2>
+      <p>{total} RESULTS</p>
     </div>
 
     {
@@ -227,7 +227,14 @@ const visibleTopTags = topTags.slice(0, 5);
     padding: 1rem 0;
   }
   .kicker {
-    margin: 0 0 0.75rem;
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid #222;
+    margin: 0 0 1.2rem;
+    padding: 0.34rem 0.65rem 0.28rem;
+    color: #f1eee7;
+    background: #222;
+    line-height: 1.1;
     letter-spacing: 0.05em;
   }
   h1 {

--- a/apps/astro-blog/src/components/ArchiveListing.astro
+++ b/apps/astro-blog/src/components/ArchiveListing.astro
@@ -531,10 +531,7 @@ const visiblePaginationItems = getVisiblePaginationItems(page, totalPages);
       grid-template-columns: 1fr;
     }
     aside {
-      border-top: 1px solid #222;
-      border-left: 0;
-      margin: 0;
-      padding: 1rem 0 0;
+      display: none;
     }
     h1 {
       max-width: none;

--- a/apps/astro-blog/src/components/ArchiveListing.astro
+++ b/apps/astro-blog/src/components/ArchiveListing.astro
@@ -50,6 +50,47 @@ const formatDate = (date: Date) => dateFormatter.format(date).replace(/\//g, '.'
 const getPageUrl = (pageNumber: number) => `${routeBase}/${pageNumber}`;
 const startNumber = (page - 1) * perPage;
 const visibleTopTags = topTags.slice(0, 5);
+
+type PaginationItem =
+  | { type: 'page'; pageNumber: number }
+  | { type: 'ellipsis'; key: string };
+
+function getVisiblePaginationItems(currentPage: number, pageCount: number): PaginationItem[] {
+  if (pageCount <= 7) {
+    return Array.from({ length: pageCount }, (_, index) => ({
+      type: 'page',
+      pageNumber: index + 1,
+    }));
+  }
+
+  const pageNumbers = new Set([1, pageCount, currentPage - 1, currentPage, currentPage + 1]);
+
+  if (currentPage <= 4) {
+    [2, 3, 4, 5].forEach((pageNumber) => pageNumbers.add(pageNumber));
+  }
+
+  if (currentPage >= pageCount - 3) {
+    [pageCount - 4, pageCount - 3, pageCount - 2, pageCount - 1].forEach((pageNumber) =>
+      pageNumbers.add(pageNumber),
+    );
+  }
+
+  const sortedPages = [...pageNumbers]
+    .filter((pageNumber) => pageNumber >= 1 && pageNumber <= pageCount)
+    .sort((a, b) => a - b);
+
+  return sortedPages.flatMap((pageNumber, index): PaginationItem[] => {
+    const previousPage = sortedPages[index - 1];
+    const gap =
+      previousPage !== undefined && pageNumber - previousPage > 1 ?
+        [{ type: 'ellipsis' as const, key: `${previousPage}-${pageNumber}` }]
+      : [];
+
+    return [...gap, { type: 'page', pageNumber }];
+  });
+}
+
+const visiblePaginationItems = getVisiblePaginationItems(page, totalPages);
 ---
 
 <div class="archive-page">
@@ -141,11 +182,13 @@ const visibleTopTags = topTags.slice(0, 5);
           </a>
         : <span aria-disabled="true">← PREV</span>}
         <div>
-          {Array.from({ length: totalPages }, (_, index) => index + 1).map((pageNumber) =>
-            pageNumber === page ?
-              <span aria-current="page">{String(pageNumber).padStart(2, '0')}</span>
-            : <a href={getPageUrl(pageNumber)} aria-label={`${pageNumber}ページ目`}>
-                {String(pageNumber).padStart(2, '0')}
+          {visiblePaginationItems.map((item) =>
+            item.type === 'ellipsis' ?
+              <span class="pagination-ellipsis" aria-hidden="true">…</span>
+            : item.pageNumber === page ?
+              <span aria-current="page">{String(item.pageNumber).padStart(2, '0')}</span>
+            : <a href={getPageUrl(item.pageNumber)} aria-label={`${item.pageNumber}ページ目`}>
+                {String(item.pageNumber).padStart(2, '0')}
               </a>,
           )}
         </div>
@@ -218,12 +261,12 @@ const visibleTopTags = topTags.slice(0, 5);
   }
   .archive-hero {
     display: grid;
-    grid-template-columns: minmax(0, 1.55fr) minmax(300px, 0.85fr);
+    grid-template-columns: minmax(0, 1fr) 360px;
     gap: 1rem;
     min-height: 300px;
     border-top: 1px solid #222;
     border-bottom: 1px solid #222;
-    margin-top: 1rem;
+    margin-top: 0;
     padding: 1rem 0;
   }
   .kicker {
@@ -294,9 +337,10 @@ const visibleTopTags = topTags.slice(0, 5);
   }
   aside h2 {
     margin: 0;
-    font-family: var(--font-display);
-    font-size: clamp(1.35rem, 2.2vw, 2rem);
-    font-weight: 400;
+    font-family: var(--font-meta);
+    font-size: 1rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
     line-height: 1.2;
     white-space: nowrap;
   }

--- a/apps/astro-blog/src/components/ArchiveListing.astro
+++ b/apps/astro-blog/src/components/ArchiveListing.astro
@@ -140,29 +140,31 @@ const visiblePaginationItems = getVisiblePaginationItems(page, totalPages);
         <ol class="post-list">
           {posts.map((post, index) => (
             <li>
-              <a href={`/post/${post.slug}`} class="post-row">
-                <span class="post-number">{String(startNumber + index + 1).padStart(2, '0')}</span>
-                <span class="post-copy">
-                  <span class="post-date">
-                    <time datetime={post.publishedAt.toISOString()}>
-                      {formatDate(post.publishedAt)}
-                    </time>
-                    <span>{getCategoryLabel(post.category)}</span>
+              <article>
+                <a href={`/post/${post.slug}`} class="post-row">
+                  <span class="post-number">{String(startNumber + index + 1).padStart(2, '0')}</span>
+                  <span class="post-copy">
+                    <span class="post-date">
+                      <time datetime={post.publishedAt.toISOString()}>
+                        {formatDate(post.publishedAt)}
+                      </time>
+                      <span>{getCategoryLabel(post.category)}</span>
+                    </span>
+                    <span class="post-title">{post.title}</span>
+                    <span class="post-description">{post.description}</span>
+                    <span class="post-tags" aria-label="タグ">
+                      {post.tags.slice(0, 4).map((tag) => (
+                        <span>#{tag}</span>
+                      ))}
+                    </span>
                   </span>
-                  <span class="post-title">{post.title}</span>
-                  <span class="post-description">{post.description}</span>
-                  <span class="post-tags" aria-label="タグ">
-                    {post.tags.slice(0, 4).map((tag) => (
-                      <span>#{tag}</span>
-                    ))}
-                  </span>
-                </span>
-                {post.coverImage && (
-                  <span class="post-image" aria-hidden="true">
-                    <img src={post.coverImage} alt="" loading="lazy" />
-                  </span>
-                )}
-              </a>
+                  {post.coverImage && (
+                    <span class="post-image" aria-hidden="true">
+                      <img src={post.coverImage} alt="" loading="lazy" />
+                    </span>
+                  )}
+                </a>
+              </article>
             </li>
           ))}
         </ol>

--- a/apps/astro-blog/src/components/ArchiveListing.astro
+++ b/apps/astro-blog/src/components/ArchiveListing.astro
@@ -1,0 +1,508 @@
+---
+import type { PostMeta } from '@estrivault/content-processor';
+import EditorialFooter from '$components/EditorialFooter.astro';
+import EditorialMasthead from '$components/EditorialMasthead.astro';
+import { getCategoryLabel } from '$constants';
+import { getTagRouteSegment } from '$lib/url-segments';
+
+interface ArchiveMeta {
+  label: string;
+  value: string | number;
+}
+
+interface Props {
+  archiveType: string;
+  title: string;
+  description?: string;
+  posts: PostMeta[];
+  total: number;
+  page: number;
+  perPage: number;
+  totalPages: number;
+  routeBase: string;
+  sideMeta: ArchiveMeta[];
+  topTags?: string[];
+  emptyMessage: string;
+}
+
+const {
+  archiveType,
+  title,
+  description,
+  posts,
+  total,
+  page,
+  perPage,
+  totalPages,
+  routeBase,
+  sideMeta,
+  topTags = [],
+  emptyMessage,
+} = Astro.props;
+
+const dateFormatter = new Intl.DateTimeFormat('ja-JP', {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
+const formatDate = (date: Date) => dateFormatter.format(date).replace(/\//g, '.');
+const getPageUrl = (pageNumber: number) => `${routeBase}/${pageNumber}`;
+const startNumber = (page - 1) * perPage;
+const visibleTopTags = topTags.slice(0, 5);
+---
+
+<div class="archive-page">
+  <EditorialMasthead />
+
+  <section class="archive-hero">
+    <div>
+      <p class="kicker">{archiveType}</p>
+      <h1>{title}</h1>
+      {description && <p class="lead">{description}</p>}
+      {
+        visibleTopTags.length > 0 && (
+          <div class="tag-variants" aria-label="上位タグ">
+            <h2>TAG VARIANT</h2>
+            <div>
+              {visibleTopTags.map((tag) => (
+                <a class="tag-link" href={`/tag/${getTagRouteSegment(tag)}/1`}>#{tag}</a>
+              ))}
+            </div>
+          </div>
+        )
+      }
+    </div>
+    <aside>
+      <h2>ARCHIVE STATUS</h2>
+      <dl>
+        {
+          sideMeta.map((item) => (
+            <div>
+              <dt>{item.label}</dt>
+              <dd>{item.value}</dd>
+            </div>
+          ))
+        }
+      </dl>
+    </aside>
+  </section>
+
+  <section class="archive-index" aria-labelledby="archive-index-title">
+    <div class="section-heading">
+      <h2 id="archive-index-title">INDEX / {total} ENTRIES</h2>
+      <p>{page} / {totalPages} PAGE</p>
+    </div>
+
+    {
+      posts.length > 0 ?
+        <ol class="post-list">
+          {posts.map((post, index) => (
+            <li>
+              <a href={`/post/${post.slug}`} class="post-row">
+                <span class="post-number">{String(startNumber + index + 1).padStart(2, '0')}</span>
+                <span class="post-copy">
+                  <span class="post-date">
+                    <time datetime={post.publishedAt.toISOString()}>
+                      {formatDate(post.publishedAt)}
+                    </time>
+                    <span>{getCategoryLabel(post.category)}</span>
+                  </span>
+                  <span class="post-title">{post.title}</span>
+                  <span class="post-description">{post.description}</span>
+                  <span class="post-tags" aria-label="タグ">
+                    {post.tags.slice(0, 4).map((tag) => (
+                      <span>#{tag}</span>
+                    ))}
+                  </span>
+                </span>
+                {post.coverImage && (
+                  <span class="post-image" aria-hidden="true">
+                    <img src={post.coverImage} alt="" loading="lazy" />
+                  </span>
+                )}
+              </a>
+            </li>
+          ))}
+        </ol>
+      : <div class="empty-state">
+          <p>{emptyMessage}</p>
+        </div>
+    }
+  </section>
+
+  {
+    totalPages > 1 && (
+      <nav class="archive-pagination" aria-label="ページネーション">
+        <h2>PAGINATION</h2>
+        {page > 1 ?
+          <a href={getPageUrl(page - 1)} aria-label="前のページ">
+            ← PREV
+          </a>
+        : <span aria-disabled="true">← PREV</span>}
+        <div>
+          {Array.from({ length: totalPages }, (_, index) => index + 1).map((pageNumber) =>
+            pageNumber === page ?
+              <span aria-current="page">{String(pageNumber).padStart(2, '0')}</span>
+            : <a href={getPageUrl(pageNumber)} aria-label={`${pageNumber}ページ目`}>
+                {String(pageNumber).padStart(2, '0')}
+              </a>,
+          )}
+        </div>
+        {page < totalPages ?
+          <a href={getPageUrl(page + 1)} aria-label="次のページ">
+            NEXT →
+          </a>
+        : <span aria-disabled="true">NEXT →</span>}
+      </nav>
+    )
+  }
+
+  <EditorialFooter />
+</div>
+
+<style>
+  :global(.archive-editorial-page) {
+    background: #f1eee7;
+  }
+  :global(.archive-editorial-main) {
+    width: 100%;
+    max-width: none;
+    padding: 0;
+  }
+  .archive-page {
+    --font-display: 'Times New Roman', serif;
+    --font-body: 'Inter', 'Noto Sans JP', sans-serif;
+    --font-meta: 'SF Mono', Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+    min-height: 100vh;
+    color: #111;
+    background: #f1eee7;
+    font-family: var(--font-body);
+    padding: clamp(1rem, 2vw, 2rem);
+  }
+  .archive-page::before {
+    content: '';
+    display: block;
+    max-width: 1180px;
+    margin: 0 auto;
+    border-top: 2px solid #202020;
+  }
+  .archive-hero,
+  .archive-index,
+  .archive-pagination {
+    max-width: 1180px;
+    margin-right: auto;
+    margin-left: auto;
+  }
+  .post-row {
+    color: inherit;
+    text-decoration: none;
+  }
+  .kicker,
+  .section-heading h2,
+  .section-heading p,
+  .post-number,
+  .post-date,
+  .archive-pagination,
+  dl dt,
+  dl dd {
+    font-family: var(--font-meta);
+    font-style: normal;
+  }
+  .kicker,
+  .section-heading h2,
+  .post-number,
+  .post-date time,
+  dl dt {
+    color: #d6452a;
+  }
+  .archive-hero {
+    display: grid;
+    grid-template-columns: minmax(0, 1.55fr) minmax(300px, 0.85fr);
+    gap: 1rem;
+    min-height: 300px;
+    border-top: 1px solid #222;
+    border-bottom: 1px solid #222;
+    margin-top: 1rem;
+    padding: 1rem 0;
+  }
+  .kicker {
+    margin: 0 0 0.75rem;
+    letter-spacing: 0.05em;
+  }
+  h1 {
+    max-width: 24ch;
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: clamp(2.25rem, 4vw, 3.5rem);
+    font-weight: 700;
+    line-height: 1.18;
+  }
+  .lead {
+    max-width: 42rem;
+    margin-top: 1rem;
+    color: #555;
+    font-size: 1.14rem;
+    line-height: 1.8;
+  }
+  .tag-variants {
+    margin-top: 1.25rem;
+  }
+  .tag-variants h2 {
+    margin: 0 0 0.7rem;
+    color: #d6452a;
+    font-family: var(--font-meta);
+    font-size: 0.88rem;
+    font-style: normal;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+  }
+  .tag-variants div {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 0.75rem;
+  }
+  .tag-variants .tag-link {
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid #222;
+    padding: 0.34rem 0.55rem 0.28rem;
+    color: inherit;
+    font-family: var(--font-meta);
+    font-size: 0.9rem;
+    font-style: normal;
+    line-height: 1.1;
+    text-decoration: none;
+    transition: color 120ms ease, border-color 120ms ease;
+  }
+  .tag-variants .tag-link:hover {
+    border-color: #d6452a;
+    color: #d6452a;
+  }
+  aside {
+    border-left: 1px solid #222;
+    margin-top: -1rem;
+    margin-bottom: -1rem;
+    padding: 1rem 0 1rem 1rem;
+  }
+  aside h2 {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: clamp(1.35rem, 2.2vw, 2rem);
+    font-weight: 400;
+    line-height: 1.2;
+    white-space: nowrap;
+  }
+  dl {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    column-gap: 1.25rem;
+    border-top: 1px solid #d6452a;
+    margin: 1rem 0 0;
+    padding-top: 0.75rem;
+  }
+  dl div {
+    display: contents;
+  }
+  dl dt,
+  dl dd {
+    margin: 0;
+    line-height: 1.65;
+  }
+  dl dd {
+    text-align: right;
+  }
+  .archive-index {
+    margin-top: 2.5rem;
+  }
+  .section-heading {
+    display: flex;
+    gap: 1rem;
+    align-items: baseline;
+    justify-content: space-between;
+    border-bottom: 1px solid #222;
+    padding-bottom: 0.8rem;
+  }
+  .section-heading h2,
+  .section-heading p {
+    margin: 0;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+  }
+  .section-heading p {
+    color: #666;
+    font-size: 0.9rem;
+  }
+  .post-list {
+    border-bottom: 1px solid #222;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  .post-row {
+    display: grid;
+    grid-template-columns: 64px minmax(0, 1fr) 112px;
+    gap: 1rem;
+    align-items: center;
+    min-height: 156px;
+    border-top: 1px solid #aaa;
+    padding: 1.35rem 0;
+  }
+  .post-row:hover .post-title {
+    color: #d6452a;
+  }
+  .post-date,
+  .post-copy,
+  .post-tags {
+    display: flex;
+  }
+  .post-date {
+    flex-flow: row wrap;
+    gap: 0.35rem 0.75rem;
+    color: #222;
+    font-size: 0.86rem;
+  }
+  .post-number {
+    font-size: 1rem;
+    line-height: 1.2;
+  }
+  .post-copy {
+    flex-direction: column;
+    min-width: 0;
+    gap: 0.55rem;
+  }
+  .post-title {
+    font-family: var(--font-display);
+    font-size: 1.5rem;
+    font-weight: 700;
+    line-height: 1.12;
+    transition: color 120ms ease;
+  }
+  .post-description {
+    display: -webkit-box;
+    overflow: hidden;
+    color: #666;
+    line-height: 1.65;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+  .post-tags {
+    flex-flow: row wrap;
+    gap: 0.45rem;
+    color: #444;
+    font-family: var(--font-meta);
+    font-size: 0.78rem;
+  }
+  .post-tags span {
+    border: 1px solid #222;
+    padding: 0.26rem 0.45rem 0.2rem;
+    line-height: 1.1;
+  }
+  .post-image {
+    grid-column: 3;
+    display: block;
+    width: 112px;
+    aspect-ratio: 4/3;
+    overflow: hidden;
+    border: 1px solid #555;
+  }
+  .post-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+  .empty-state {
+    border-bottom: 1px solid #222;
+    padding: 3rem 0;
+    color: #666;
+    text-align: center;
+  }
+  .archive-pagination {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+    align-items: center;
+    justify-content: flex-start;
+    border-top: 0;
+    border-bottom: 0;
+    margin-top: 3.5rem;
+    padding: 0;
+  }
+  .archive-pagination h2 {
+    flex-basis: 100%;
+    border-bottom: 1px solid #222;
+    margin: 0 0 0.85rem;
+    padding-bottom: 0.8rem;
+    color: #d6452a;
+    font-family: var(--font-meta);
+    font-size: 0.88rem;
+    font-style: normal;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+  }
+  .archive-pagination > div {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    justify-content: flex-start;
+  }
+  .archive-pagination a,
+  .archive-pagination span {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2rem;
+    border: 1px solid #222;
+    padding: 0.34rem 0.65rem 0.28rem;
+    color: inherit;
+    line-height: 1.1;
+    text-decoration: none;
+    transition: color 120ms ease, border-color 120ms ease;
+  }
+  .archive-pagination a:hover {
+    border-color: #d6452a;
+    color: #d6452a;
+  }
+  .archive-pagination [aria-current='page'] {
+    border-color: #222;
+    color: #f1eee7;
+    background: #222;
+  }
+  .archive-pagination [aria-disabled='true'] {
+    border-color: #999;
+    color: #999;
+  }
+  @media (max-width: 900px) {
+    .archive-page {
+      padding: 1rem;
+    }
+    .archive-hero {
+      grid-template-columns: 1fr;
+    }
+    aside {
+      border-top: 1px solid #222;
+      border-left: 0;
+      margin: 0;
+      padding: 1rem 0 0;
+    }
+    h1 {
+      max-width: none;
+    }
+    .post-row {
+      grid-template-columns: 56px minmax(0, 1fr) 72px;
+      gap: 0.75rem;
+      min-height: 0;
+    }
+    .post-copy {
+      grid-column: 2;
+    }
+    .post-image {
+      grid-column: 3;
+      grid-row: 1 / span 3;
+      width: 72px;
+    }
+    .archive-pagination {
+      text-align: left;
+    }
+  }
+</style>

--- a/apps/astro-blog/src/components/EditorialFooter.astro
+++ b/apps/astro-blog/src/components/EditorialFooter.astro
@@ -1,0 +1,79 @@
+---
+import { SOCIAL_LINK_GITHUB, SOCIAL_LINK_X } from '$constants';
+---
+
+<footer class="editorial-footer">
+  <a class="footer-brand" href="/">Estrilda</a>
+  <span class="footer-links">
+    <a
+      href={`https://x.com/${SOCIAL_LINK_X}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="X"
+      title="X"
+    >
+      <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24">
+        <path
+          d="M18.9 2h3.3l-7.3 8.3 8.5 11.7h-6.7l-5.2-7.1L5.5 22H2.2l7.8-8.9L1.8 2h6.8l4.7 6.4L18.9 2Zm-1.2 17.9h1.8L7.6 4H5.7l12 15.9Z"
+        />
+      </svg>
+    </a>
+    <a
+      href={`https://github.com/${SOCIAL_LINK_GITHUB}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="GitHub"
+      title="GitHub"
+    >
+      <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24">
+        <path
+          d="M12 2a10 10 0 0 0-3.2 19.5c.5.1.7-.2.7-.5v-1.8c-2.9.6-3.5-1.2-3.5-1.2-.5-1.1-1.1-1.4-1.1-1.4-.9-.6.1-.6.1-.6 1 .1 1.6 1.1 1.6 1.1.9 1.5 2.4 1.1 3 .8.1-.7.4-1.1.7-1.3-2.3-.3-4.7-1.1-4.7-5A3.9 3.9 0 0 1 6.6 9c-.1-.3-.5-1.3.1-2.7 0 0 .9-.3 2.8 1a9.6 9.6 0 0 1 5.1 0c1.9-1.3 2.8-1 2.8-1 .6 1.4.2 2.4.1 2.7a3.9 3.9 0 0 1 1.1 2.7c0 3.9-2.4 4.7-4.7 5 .4.3.7 1 .7 2v2.3c0 .3.2.6.7.5A10 10 0 0 0 12 2Z"
+        />
+      </svg>
+    </a>
+  </span>
+</footer>
+
+<style>
+  .editorial-footer {
+    display: flex;
+    justify-content: space-between;
+    max-width: 1180px;
+    border-top: 2px solid #202020;
+    margin: 3.5rem auto 0;
+    padding-top: 0.75rem;
+    font-style: normal;
+  }
+  .footer-brand {
+    font-family: var(--font-display);
+    font-style: normal;
+    font-weight: 400;
+  }
+  .footer-links {
+    display: inline-flex;
+    gap: 0.75rem;
+    align-items: center;
+    font-family: var(--font-meta);
+  }
+  .footer-brand,
+  .footer-links a {
+    color: inherit;
+    text-decoration: none;
+  }
+  .footer-links a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.25rem;
+    height: 1.25rem;
+    transition: color 120ms ease;
+  }
+  .footer-links a:hover {
+    color: #d6452a;
+  }
+  .footer-links svg {
+    width: 1rem;
+    height: 1rem;
+    fill: currentColor;
+  }
+</style>

--- a/apps/astro-blog/src/components/EditorialMasthead.astro
+++ b/apps/astro-blog/src/components/EditorialMasthead.astro
@@ -1,0 +1,111 @@
+---
+interface Props {
+  homePage?: boolean;
+}
+
+const { homePage = false } = Astro.props;
+const localPath = (hash: string) => (homePage ? hash : `/${hash}`);
+---
+
+<section class="editorial-masthead">
+  <div class="brand"><a href="/">Estrilda</a></div>
+  <nav>
+    <a href={localPath('#categories')}>CATEGORIES</a>
+    <a href="/post/about">ABOUT</a>
+    <a href="/llms.txt" target="_blank" aria-label="LLMs" title="LLMs" class="icon-link">
+      <svg aria-hidden="true" width="22" height="22" viewBox="0 0 24 24">
+        <path
+          d="M11 2h2v3h3.5A3.5 3.5 0 0 1 20 8.5v6A3.5 3.5 0 0 1 16.5 18h-9A3.5 3.5 0 0 1 4 14.5v-6A3.5 3.5 0 0 1 7.5 5H11V2Zm-3.5 5A1.5 1.5 0 0 0 6 8.5v6A1.5 1.5 0 0 0 7.5 16h9a1.5 1.5 0 0 0 1.5-1.5v-6A1.5 1.5 0 0 0 16.5 7h-9ZM9 11a1.25 1.25 0 1 1 0-2.5A1.25 1.25 0 0 1 9 11Zm6 0a1.25 1.25 0 1 1 0-2.5A1.25 1.25 0 0 1 15 11Zm-5.5 2.5h5v1.5h-5v-1.5ZM2 10h2v3H2v-3Zm18 0h2v3h-2v-3Z"
+        />
+      </svg>
+    </a>
+  </nav>
+  <p class="tagline">
+    <span class="tagline-copy">株式投資・ソフトウェア・AI・ゲーム・ギアレビューを横断する個人アーカイブ</span>
+    <span class="tagline-meta">TEXT FIRST / IMAGE OPTIONAL</span>
+  </p>
+</section>
+
+<style>
+  .editorial-masthead {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.75rem;
+    align-items: center;
+    max-width: 1180px;
+    margin-right: auto;
+    margin-left: auto;
+    padding-top: 1rem;
+  }
+  .brand {
+    font-family: var(--font-display);
+    font-size: 1.35rem;
+    font-weight: 700;
+    line-height: 1;
+  }
+  .brand a,
+  nav a {
+    color: #222;
+    text-decoration: none;
+    transition: color 120ms ease;
+  }
+  .brand a {
+    font-family: var(--font-display);
+    font-style: normal;
+    font-weight: 700;
+  }
+  nav {
+    display: flex;
+    gap: 1rem;
+    font-family: var(--font-meta);
+    font-size: 0.95rem;
+    font-style: normal;
+  }
+  nav a:hover {
+    color: #d6452a;
+  }
+  .icon-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.8rem;
+    height: 1.8rem;
+    margin-left: 0.85rem;
+  }
+  .icon-link svg {
+    width: 1.65rem;
+    height: 1.65rem;
+    fill: currentColor;
+  }
+  .tagline {
+    grid-column: 1/-1;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem 1rem;
+    justify-content: space-between;
+    border-top: 1px solid #222;
+    color: #666;
+    padding-top: 0.75rem;
+  }
+  .tagline-copy {
+    font-family: var(--font-meta);
+    font-size: 0.82rem;
+    font-style: normal;
+  }
+  .tagline-meta {
+    font-family: var(--font-meta);
+    font-size: 0.82rem;
+    font-style: normal;
+  }
+  .tagline-meta {
+    color: #d6452a;
+  }
+  @media (max-width: 900px) {
+    .editorial-masthead {
+      grid-template-columns: 1fr;
+    }
+    nav {
+      flex-wrap: wrap;
+    }
+  }
+</style>

--- a/apps/astro-blog/src/components/EditorialMasthead.astro
+++ b/apps/astro-blog/src/components/EditorialMasthead.astro
@@ -34,6 +34,7 @@ const localPath = (hash: string) => (homePage ? hash : `/${hash}`);
     align-items: center;
     max-width: 1180px;
     margin-right: auto;
+    margin-bottom: 2rem;
     margin-left: auto;
     padding-top: 1rem;
   }

--- a/apps/astro-blog/src/components/EditorialMasthead.astro
+++ b/apps/astro-blog/src/components/EditorialMasthead.astro
@@ -103,10 +103,19 @@ const localPath = (hash: string) => (homePage ? hash : `/${hash}`);
   }
   @media (max-width: 900px) {
     .editorial-masthead {
-      grid-template-columns: 1fr;
+      grid-template-columns: minmax(0, 1fr) auto;
+      column-gap: 0.75rem;
     }
     nav {
-      flex-wrap: wrap;
+      flex-wrap: nowrap;
+      gap: 0.75rem;
+      white-space: nowrap;
+    }
+    .tagline-meta {
+      display: none;
+    }
+    .tagline {
+      display: none;
     }
   }
 </style>

--- a/apps/astro-blog/src/constants/index.ts
+++ b/apps/astro-blog/src/constants/index.ts
@@ -1,6 +1,6 @@
 export const SITE_TITLE = 'Estrilda';
 export const SITE_DESCRIPTION =
-  '株式投資やプログラミング情報をお届けするブログです。開発者向けの実践的な内容を発信しています。';
+  '投資分析、ソフトウェア開発、AI活用、ゲーム攻略、ギアレビュー、考察を蓄積する個人アーカイブです。';
 export const SITE_AUTHOR = 'Estrilda';
 export const SITE_URL = 'https://estrilda.damonge.com/';
 

--- a/apps/astro-blog/src/layouts/BaseLayout.astro
+++ b/apps/astro-blog/src/layouts/BaseLayout.astro
@@ -18,6 +18,10 @@ interface Props {
   modifiedTime?: string;
   section?: string;
   tags?: string[];
+  hideHeader?: boolean;
+  hideFooter?: boolean;
+  bodyClass?: string;
+  mainClass?: string;
 }
 
 const {
@@ -34,6 +38,10 @@ const {
   modifiedTime,
   section,
   tags = [],
+  hideHeader = false,
+  hideFooter = false,
+  bodyClass = '',
+  mainClass = 'mx-auto w-full max-w-6xl px-4 py-4',
 } = Astro.props;
 
 const pathname = Astro.url.pathname;
@@ -98,13 +106,13 @@ const pathname = Astro.url.pathname;
 
     {jsonLd && <script is:inline type="application/ld+json" set:html={JSON.stringify(jsonLd)} />}
   </head>
-  <body>
-    <Header pathname={pathname} />
+  <body class={bodyClass}>
+    {!hideHeader && <Header pathname={pathname} />}
 
-    <main class="mx-auto w-full max-w-6xl px-4 py-4">
+    <main class={mainClass}>
       <slot />
     </main>
 
-    <Footer />
+    {!hideFooter && <Footer />}
   </body>
 </html>

--- a/apps/astro-blog/src/lib/content.ts
+++ b/apps/astro-blog/src/lib/content.ts
@@ -24,6 +24,8 @@ interface PostMetaSource {
   meta: PostMeta | null;
 }
 
+let allPostsMetaPromise: Promise<PostMeta[]> | undefined;
+
 function getMarkdownFiles(): Record<string, string> {
   const modules = import.meta.glob('@content/blog/**/*.{md,mdx}', {
     query: '?raw',
@@ -103,6 +105,15 @@ async function extractFrontmatterOnly(
 export async function getAllPostsMeta(
   options: ProcessorOptions = defaultProcessorOptions,
 ): Promise<PostMeta[]> {
+  if (options === defaultProcessorOptions) {
+    allPostsMetaPromise ??= loadAllPostsMeta(options);
+    return allPostsMetaPromise;
+  }
+
+  return loadAllPostsMeta(options);
+}
+
+async function loadAllPostsMeta(options: ProcessorOptions): Promise<PostMeta[]> {
   const markdownFiles = getMarkdownFiles();
 
   const postMetaSources = await Promise.all(
@@ -125,16 +136,14 @@ export async function getAllPostsMeta(
     .sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());
 }
 
-export async function getPosts(options?: {
-  page?: number;
-  perPage?: number;
-  category?: string;
-  tag?: string;
-}): Promise<PaginatedPosts> {
-  const page = options?.page || 1;
-  const perPage = options?.perPage || 20;
-
-  let filteredPosts = await getAllPostsMeta();
+export function filterPosts(
+  posts: PostMeta[],
+  options?: {
+    category?: string;
+    tag?: string;
+  },
+): PostMeta[] {
+  let filteredPosts = posts;
 
   if (options?.category) {
     const normalizedCategory = normalizeForTagFilter(options.category);
@@ -150,18 +159,50 @@ export async function getPosts(options?: {
     );
   }
 
-  const total = filteredPosts.length;
+  return filteredPosts;
+}
+
+export function paginatePosts(
+  posts: PostMeta[],
+  options?: {
+    page?: number;
+    perPage?: number;
+  },
+): PaginatedPosts {
+  const page = options?.page || 1;
+  const perPage = options?.perPage || 20;
+  const total = posts.length;
   const totalPages = Math.ceil(total / perPage);
   const startIndex = (page - 1) * perPage;
-  const posts = filteredPosts.slice(startIndex, startIndex + perPage);
 
   return {
-    posts,
+    posts: posts.slice(startIndex, startIndex + perPage),
     total,
     page,
     perPage,
     totalPages,
   };
+}
+
+export function getPaginatedPosts(
+  posts: PostMeta[],
+  options?: {
+    page?: number;
+    perPage?: number;
+    category?: string;
+    tag?: string;
+  },
+): PaginatedPosts {
+  return paginatePosts(filterPosts(posts, options), options);
+}
+
+export async function getPosts(options?: {
+  page?: number;
+  perPage?: number;
+  category?: string;
+  tag?: string;
+}): Promise<PaginatedPosts> {
+  return getPaginatedPosts(await getAllPostsMeta(), options);
 }
 
 export async function getPostBySlug(

--- a/apps/astro-blog/src/pages/category/[category]/[page]/index.astro
+++ b/apps/astro-blog/src/pages/category/[category]/[page]/index.astro
@@ -1,12 +1,33 @@
 ---
+import type { PostMeta } from '@estrivault/content-processor';
 import BaseLayout from '$layouts/BaseLayout.astro';
-import Pagination from '$components/Pagination.astro';
-import PostCard from '$components/PostCard.astro';
+import ArchiveListing from '$components/ArchiveListing.astro';
 import { getCategoryMeta, POSTS_PER_PAGE, SITE_TITLE, SITE_URL } from '$constants';
 import { getAllCategories, getPosts } from '$lib/content';
 
 interface Props {
   category: string;
+}
+
+function getTopTags(posts: PostMeta[]): string[] {
+  const tagCounts = new Map<string, { tag: string; count: number }>();
+
+  for (const post of posts) {
+    for (const tag of post.tags) {
+      const current = tagCounts.get(tag) ?? { tag, count: 0 };
+      current.count += 1;
+      tagCounts.set(tag, current);
+    }
+  }
+
+  return [...tagCounts.values()]
+    .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
+    .slice(0, 5)
+    .map((item) => item.tag);
+}
+
+function getTagCount(posts: PostMeta[]): number {
+  return new Set(posts.flatMap((post) => post.tags)).size;
 }
 
 export async function getStaticPaths() {
@@ -40,6 +61,13 @@ const result = await getPosts({
   page: currentPage,
   perPage: POSTS_PER_PAGE,
 });
+const archivePosts = await getPosts({
+  category,
+  page: 1,
+  perPage: Number.MAX_SAFE_INTEGER,
+});
+const topTags = getTopTags(archivePosts.posts);
+const tagCount = getTagCount(archivePosts.posts);
 
 const siteBase = SITE_URL.replace(/\/$/, '');
 const pageUrl = `${siteBase}/category/${Astro.params.category}/${currentPage}`;
@@ -62,39 +90,28 @@ const nextUrl =
   canonical={pageUrl}
   prevUrl={prevUrl}
   nextUrl={nextUrl}
+  hideHeader
+  hideFooter
+  bodyClass="archive-editorial-page"
+  mainClass="archive-editorial-main"
 >
-  <div class="container mx-auto px-4 py-8">
-    <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold">{categoryMeta.label}</h1>
-      {categoryMeta.description && <p class="mb-2 text-gray-600">{categoryMeta.description}</p>}
-      <p class="text-sm text-gray-500">
-        全{result.total}件の記事（{result.page} / {result.totalPages}ページ）
-      </p>
-    </div>
-
-    {
-      result.posts.length > 0 ?
-        <div class="mb-8">
-          <div class="grid gap-8 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
-            {result.posts.map((post) => (
-              <PostCard post={post} />
-            ))}
-          </div>
-
-          {result.totalPages > 1 && (
-            <div class="mt-12">
-              <Pagination
-                currentPage={result.page}
-                totalPages={result.totalPages}
-                baseUrl={`/category/${Astro.params.category}`}
-                maxVisible={5}
-              />
-            </div>
-          )}
-        </div>
-      : <div class="rounded-lg bg-gray-50 p-8 text-center">
-          <p class="text-gray-500">このカテゴリーにはまだ記事がありません。</p>
-        </div>
-    }
-  </div>
+  <ArchiveListing
+    archiveType="CATEGORY ARCHIVE"
+    title={categoryMeta.label}
+    description={categoryMeta.description}
+    posts={result.posts}
+    total={result.total}
+    page={result.page}
+    perPage={result.perPage}
+    totalPages={result.totalPages}
+    routeBase={`/category/${Astro.params.category}`}
+    topTags={topTags}
+    sideMeta={[
+      { label: 'TYPE', value: 'CATEGORY' },
+      { label: 'SLUG', value: (Astro.params.category ?? category).toUpperCase() },
+      { label: 'NOTES', value: result.total },
+      { label: 'TAGS', value: tagCount },
+    ]}
+    emptyMessage="このカテゴリーにはまだ記事がありません。"
+  />
 </BaseLayout>

--- a/apps/astro-blog/src/pages/category/[category]/[page]/index.astro
+++ b/apps/astro-blog/src/pages/category/[category]/[page]/index.astro
@@ -96,7 +96,7 @@ const nextUrl =
   mainClass="archive-editorial-main"
 >
   <ArchiveListing
-    archiveType="CATEGORY ARCHIVE"
+    archiveType="CATEGORY"
     title={categoryMeta.label}
     description={categoryMeta.description}
     posts={result.posts}

--- a/apps/astro-blog/src/pages/category/[category]/[page]/index.astro
+++ b/apps/astro-blog/src/pages/category/[category]/[page]/index.astro
@@ -3,7 +3,7 @@ import type { PostMeta } from '@estrivault/content-processor';
 import BaseLayout from '$layouts/BaseLayout.astro';
 import ArchiveListing from '$components/ArchiveListing.astro';
 import { getCategoryMeta, POSTS_PER_PAGE, SITE_TITLE, SITE_URL } from '$constants';
-import { getAllCategories, getPosts } from '$lib/content';
+import { filterPosts, getAllPostsMeta, getPaginatedPosts } from '$lib/content';
 
 interface Props {
   category: string;
@@ -31,11 +31,14 @@ function getTagCount(posts: PostMeta[]): number {
 }
 
 export async function getStaticPaths() {
-  const categories = await getAllCategories();
+  const allPosts = await getAllPostsMeta();
+  const categories = [...new Set(allPosts.map((post) => post.category))].sort((a, b) =>
+    a.localeCompare(b),
+  );
   const paths = [];
 
   for (const category of categories) {
-    const categoryPosts = await getPosts({ category, perPage: POSTS_PER_PAGE });
+    const categoryPosts = getPaginatedPosts(allPosts, { category, perPage: POSTS_PER_PAGE });
 
     for (let page = 1; page <= categoryPosts.totalPages; page++) {
       paths.push({
@@ -56,18 +59,14 @@ export async function getStaticPaths() {
 const { category } = Astro.props as Props;
 const categoryMeta = getCategoryMeta(category);
 const currentPage = Number(Astro.params.page);
-const result = await getPosts({
-  category,
+const allPosts = await getAllPostsMeta();
+const archivePosts = filterPosts(allPosts, { category });
+const result = getPaginatedPosts(archivePosts, {
   page: currentPage,
   perPage: POSTS_PER_PAGE,
 });
-const archivePosts = await getPosts({
-  category,
-  page: 1,
-  perPage: Number.MAX_SAFE_INTEGER,
-});
-const topTags = getTopTags(archivePosts.posts);
-const tagCount = getTagCount(archivePosts.posts);
+const topTags = getTopTags(archivePosts);
+const tagCount = getTagCount(archivePosts);
 
 const siteBase = SITE_URL.replace(/\/$/, '');
 const pageUrl = `${siteBase}/category/${Astro.params.category}/${currentPage}`;

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -72,7 +72,7 @@ const fmtDate = (date: Date) =>
     <section class="hero-grid">
       <article>
         <h1>Estrilda</h1>
-        <h2>投資、開発、AI、<br />趣味の実践ログ。</h2>
+        <h2>投資、開発、AI、趣味の実践ログ。</h2>
         <p>
           米国株の企業分析、Web開発、生成AIツール、ゲーム攻略、ギアレビューまで。調べたこと・試したこと・考えたことを蓄積する、個人のための公開ノート。
         </p>
@@ -220,7 +220,7 @@ const fmtDate = (date: Date) =>
   }
   h1 {
     font-family: var(--font-display);
-    font-size: clamp(4rem, 9vw, 8.5rem);
+    font-size: clamp(4rem, 8vw, 6.8rem);
     font-weight: 400;
     line-height: 1;
     margin: 0;

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -175,8 +175,11 @@ const fmtDate = (date: Date) =>
     padding: 0;
   }
   .editorial-home {
+    --font-display: 'Times New Roman', serif;
+    --font-body: 'Inter', 'Noto Sans JP', sans-serif;
+    --font-meta: 'SF Mono', Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
     min-height: 100vh;
-    font-family: 'Inter', 'Noto Sans JP', sans-serif;
+    font-family: var(--font-body);
     color: #111;
     background: #f1eee7;
     border: 0;
@@ -211,12 +214,14 @@ const fmtDate = (date: Date) =>
     padding-top: 1rem;
   }
   .brand {
+    font-family: var(--font-meta);
     font-style: italic;
     letter-spacing: 0.06em;
   }
   nav {
     display: flex;
     gap: 1rem;
+    font-family: var(--font-meta);
     font-style: italic;
     font-size: 0.95rem;
   }
@@ -240,14 +245,14 @@ const fmtDate = (date: Date) =>
     padding-bottom: 1rem;
   }
   h1 {
-    font-family: 'Times New Roman', serif;
+    font-family: var(--font-display);
     font-size: clamp(4rem, 9vw, 8.5rem);
     font-weight: 400;
     line-height: 1;
     margin: 0;
   }
   h2 {
-    font-family: 'Times New Roman', serif;
+    font-family: var(--font-display);
     font-size: clamp(1.7rem, 3.1vw, 2.7rem);
     font-weight: 400;
     line-height: 1.25;
@@ -265,12 +270,13 @@ const fmtDate = (date: Date) =>
     padding: calc(1rem + 1px) 0 calc(1rem + 1px) 1rem;
   }
   aside h3 {
-    font-family: 'Times New Roman', serif;
+    font-family: var(--font-display);
     font-size: 3rem;
     font-weight: 400;
     line-height: 1.2;
   }
   .issue {
+    font-family: var(--font-meta);
     color: #d6452a;
     border-top: 1px solid #d6452a;
     margin-top: 0.75rem;
@@ -278,9 +284,11 @@ const fmtDate = (date: Date) =>
     font-style: italic;
   }
   .issue-sub {
+    font-family: var(--font-meta);
     font-style: italic;
   }
   .section-block > h3 {
+    font-family: var(--font-meta);
     font-style: italic;
     color: #d6452a;
     letter-spacing: 0.05em;
@@ -306,11 +314,12 @@ const fmtDate = (date: Date) =>
   }
   .no,
   .key {
+    font-family: var(--font-meta);
     font-style: italic;
     color: #d6452a;
   }
   .name {
-    font-family: 'Times New Roman', serif;
+    font-family: var(--font-display);
     font-size: 1.45rem;
     font-weight: 700;
   }
@@ -359,12 +368,13 @@ const fmtDate = (date: Date) =>
     border: 1px solid #555;
   }
   .cat {
+    font-family: var(--font-meta);
     color: #d6452a;
     font-style: italic;
   }
   .featured h4,
   .latest-item h4 {
-    font-family: 'Times New Roman', serif;
+    font-family: var(--font-display);
     font-weight: 400;
     line-height: 1.2;
   }
@@ -372,6 +382,7 @@ const fmtDate = (date: Date) =>
     font-size: 1.9rem;
   }
   .featured > span {
+    font-family: var(--font-meta);
     color: #d6452a;
     font-style: italic;
   }
@@ -406,6 +417,7 @@ const fmtDate = (date: Date) =>
     align-items: baseline;
   }
   .latest-meta time {
+    font-family: var(--font-meta);
     color: #d6452a;
     font-style: italic;
   }
@@ -425,13 +437,14 @@ const fmtDate = (date: Date) =>
     padding: 1rem;
   }
   .series-card h4 {
-    font-family: 'Times New Roman', serif;
+    font-family: var(--font-display);
     font-size: 2rem;
     font-weight: 400;
     line-height: 1.15;
     margin: 0.5rem 0;
   }
   .series-card p:first-child {
+    font-family: var(--font-meta);
     color: #d6452a;
     font-style: italic;
   }
@@ -439,6 +452,7 @@ const fmtDate = (date: Date) =>
     margin-top: 1rem;
     border-top: 2px solid #202020;
     display: flex;
+    font-family: var(--font-meta);
     justify-content: space-between;
     font-style: italic;
     padding-top: 0.75rem;

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -111,7 +111,7 @@ const fmtDate = (date: Date) =>
               )}
               <p class="cat">{getCategoryLabel(featuredPost.category)}</p>
               <h4>{featuredPost.title}</h4>
-              <p>{featuredPost.description}</p>
+              <p class="note-summary">{featuredPost.description}</p>
               <span>READ ARTICLE →</span>
             </a>
           )
@@ -125,7 +125,7 @@ const fmtDate = (date: Date) =>
                   <p class="cat">{getCategoryLabel(post.category)}</p>
                 </div>
                 <h4>{post.title}</h4>
-                <p>{post.description}</p>
+                <p class="note-summary">{post.description}</p>
               </a>
             ))
           }
@@ -133,7 +133,7 @@ const fmtDate = (date: Date) =>
       </div>
     </section>
 
-    <section class="section-block">
+    <section class="section-block series-section">
       <h3>DEEP DIVES / SERIES</h3>
       <div class="series-grid">
         {
@@ -227,6 +227,7 @@ const fmtDate = (date: Date) =>
   .tagline {
     grid-column: 1/-1;
     color: #666;
+    margin-bottom: 1lh;
   }
   .hero-grid {
     display: grid;
@@ -318,6 +319,10 @@ const fmtDate = (date: Date) =>
     color: #222;
     text-transform: uppercase;
   }
+  .latest-notes,
+  .series-section {
+    margin-top: 2.5rem;
+  }
   .latest-grid {
     display: grid;
     grid-template-columns: 1.1fr 1fr;
@@ -352,6 +357,12 @@ const fmtDate = (date: Date) =>
   .featured > span {
     color: #d6452a;
     font-style: italic;
+  }
+  .note-summary {
+    overflow: hidden;
+    color: #666;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .latest-item h4 {
     font-size: 1.5rem;

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -10,10 +10,11 @@ import {
   SITE_URL,
   getCategoryLabel,
 } from '$constants';
-import { getPosts } from '$lib/content';
+import { getAllPostsMeta, getPosts } from '$lib/content';
 import { getTagRouteSegment } from '$lib/url-segments';
 
 const pageData = await getPosts({ page: 1, perPage: POSTS_PER_PAGE });
+const allPosts = await getAllPostsMeta();
 const featuredPost = pageData.posts[0] ?? null;
 const latestPosts = featuredPost ? pageData.posts.slice(1, 5) : pageData.posts.slice(0, 4);
 
@@ -26,6 +27,14 @@ const categoryRows = Object.entries(CATEGORY_META)
     description: category.description,
     href: `/category/${slug}/1`,
   }));
+
+const oldestPost = allPosts.at(-1);
+const archiveStats = {
+  notes: pageData.total,
+  categories: categoryRows.length,
+  format: 'Markdown',
+  since: oldestPost?.publishedAt.getFullYear() ?? '----',
+};
 
 const seriesCards = [
   { id: '01', title: 'EDGAR / XBRL', desc: 'SEC書類とAPIを読み解く', tag: 'EDGAR' },
@@ -84,12 +93,29 @@ const fmtDate = (date: Date) =>
         </p>
       </article>
       <aside>
-        <h3>FIELD NOTES &amp; INDEX</h3>
-        <p class="issue">ISSUE 00</p>
-        <p class="issue-sub">Design direction</p>
-        <p>
-          Not a SaaS dashboard. Not a media template. A readable index for accumulated field notes.
-        </p>
+        <h3>ARCHIVE STATUS</h3>
+        <dl class="archive-stats">
+          <div>
+            <dt>NOTES</dt>
+            <dd>{archiveStats.notes}</dd>
+          </div>
+          <div>
+            <dt>CATEGORIES</dt>
+            <dd>{archiveStats.categories}</dd>
+          </div>
+          <div>
+            <dt>FORMAT</dt>
+            <dd>{archiveStats.format}</dd>
+          </div>
+          <div>
+            <dt>SINCE</dt>
+            <dd>{archiveStats.since}</dd>
+          </div>
+        </dl>
+        <div class="archive-format">
+          <p>TEXT FIRST</p>
+          <p>IMAGE OPTIONAL</p>
+        </div>
       </aside>
     </section>
 
@@ -286,17 +312,33 @@ const fmtDate = (date: Date) =>
     font-weight: 400;
     line-height: 1.2;
   }
-  .issue {
-    font-family: var(--font-meta);
-    color: #d6452a;
+  .archive-stats {
     border-top: 1px solid #d6452a;
-    margin-top: 0.75rem;
+    margin: 0.75rem 0 0;
     padding-top: 0.75rem;
-    font-style: italic;
   }
-  .issue-sub {
+  .archive-stats div {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 1rem;
     font-family: var(--font-meta);
-    font-style: italic;
+    line-height: 1.65;
+  }
+  .archive-stats dt,
+  .archive-stats dd {
+    margin: 0;
+  }
+  .archive-stats dt {
+    color: #d6452a;
+  }
+  .archive-format {
+    margin-top: 1.25rem;
+    font-family: var(--font-meta);
+    font-weight: 700;
+    line-height: 1.45;
+  }
+  .archive-format p {
+    margin: 0;
   }
   .section-block > h3 {
     font-family: var(--font-meta);

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -239,12 +239,14 @@ const fmtDate = (date: Date) =>
   h1 {
     font-family: 'Times New Roman', serif;
     font-size: clamp(4.5rem, 11vw, 10rem);
+    font-weight: 400;
     line-height: 1;
     margin: 0;
   }
   h2 {
     font-family: 'Times New Roman', serif;
     font-size: clamp(2rem, 4vw, 3.6rem);
+    font-weight: 400;
     line-height: 1.25;
     margin: 0.5rem 0;
   }
@@ -260,6 +262,7 @@ const fmtDate = (date: Date) =>
   aside h3 {
     font-family: 'Times New Roman', serif;
     font-size: 3rem;
+    font-weight: 400;
     line-height: 1.2;
   }
   .issue {
@@ -304,6 +307,7 @@ const fmtDate = (date: Date) =>
   .name {
     font-family: 'Times New Roman', serif;
     font-size: 1.45rem;
+    font-weight: 400;
   }
   .desc {
     color: #666;
@@ -321,7 +325,7 @@ const fmtDate = (date: Date) =>
   }
   .featured {
     display: block;
-    border: 1px solid #d6452a;
+    border: 1px solid #222;
     padding: 1rem;
     text-decoration: none;
     color: inherit;
@@ -330,7 +334,7 @@ const fmtDate = (date: Date) =>
     width: 100%;
     aspect-ratio: 16/9;
     object-fit: cover;
-    border: 1px solid #d6452a;
+    border: 1px solid #555;
   }
   .cat {
     color: #d6452a;
@@ -339,6 +343,7 @@ const fmtDate = (date: Date) =>
   .featured h4,
   .latest-item h4 {
     font-family: 'Times New Roman', serif;
+    font-weight: 400;
     line-height: 1.2;
   }
   .featured h4 {
@@ -385,6 +390,7 @@ const fmtDate = (date: Date) =>
   .series-card h4 {
     font-family: 'Times New Roman', serif;
     font-size: 2rem;
+    font-weight: 400;
     line-height: 1.15;
     margin: 0.5rem 0;
   }

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -113,10 +113,6 @@ const fmtDate = (date: Date) =>
             <dd>{archiveStats.since}</dd>
           </div>
         </dl>
-        <div class="archive-format">
-          <p>TEXT FIRST</p>
-          <p>IMAGE OPTIONAL</p>
-        </div>
       </aside>
     </section>
 
@@ -340,15 +336,6 @@ const fmtDate = (date: Date) =>
   }
   .archive-stats dt {
     color: #d6452a;
-  }
-  .archive-format {
-    margin-top: 1.25rem;
-    font-family: var(--font-meta);
-    font-weight: 700;
-    line-height: 1.45;
-  }
-  .archive-format p {
-    margin: 0;
   }
   .section-block > h3 {
     font-family: var(--font-meta);

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -226,27 +226,29 @@ const fmtDate = (date: Date) =>
   }
   .tagline {
     grid-column: 1/-1;
+    border-top: 1px solid #222;
     color: #666;
     margin-bottom: 1lh;
+    padding-top: 0.75rem;
   }
   .hero-grid {
     display: grid;
-    grid-template-columns: 2fr 1fr;
-    gap: 1rem;
+    grid-template-columns: minmax(0, 1.55fr) minmax(340px, 1fr);
+    gap: 0.75rem;
     min-height: 320px;
     border-bottom: 1px solid #222;
     padding-bottom: 1rem;
   }
   h1 {
     font-family: 'Times New Roman', serif;
-    font-size: clamp(4.5rem, 11vw, 10rem);
+    font-size: clamp(4rem, 9vw, 8.5rem);
     font-weight: 400;
     line-height: 1;
     margin: 0;
   }
   h2 {
     font-family: 'Times New Roman', serif;
-    font-size: clamp(2rem, 4vw, 3.6rem);
+    font-size: clamp(1.7rem, 3.1vw, 2.7rem);
     font-weight: 400;
     line-height: 1.25;
     margin: 0.5rem 0;
@@ -254,7 +256,7 @@ const fmtDate = (date: Date) =>
   .hero-grid p {
     font-size: 1.2rem;
     color: #555;
-    max-width: 42rem;
+    max-width: 44rem;
   }
   aside {
     border-left: 1px solid #222;
@@ -310,7 +312,7 @@ const fmtDate = (date: Date) =>
   .name {
     font-family: 'Times New Roman', serif;
     font-size: 1.45rem;
-    font-weight: 400;
+    font-weight: 700;
   }
   .desc {
     color: #666;
@@ -319,6 +321,7 @@ const fmtDate = (date: Date) =>
   .key {
     justify-self: end;
     color: #222;
+    font-weight: 700;
     text-transform: uppercase;
   }
   .latest-notes,
@@ -345,6 +348,9 @@ const fmtDate = (date: Date) =>
     padding: 1rem;
     text-decoration: none;
     color: inherit;
+  }
+  .featured > * + * {
+    margin-top: 0.75rem;
   }
   .featured img {
     width: 100%;
@@ -389,7 +395,10 @@ const fmtDate = (date: Date) =>
     text-decoration: none;
     color: inherit;
     border-top: 1px solid #aaa;
-    padding: 0.8rem 0;
+    padding: 1rem 0;
+  }
+  .latest-item > * + * {
+    margin-top: 0.55rem;
   }
   .latest-meta {
     display: flex;
@@ -428,7 +437,7 @@ const fmtDate = (date: Date) =>
   }
   .index-footer {
     margin-top: 1rem;
-    border-top: 1px solid #222;
+    border-top: 2px solid #202020;
     display: flex;
     justify-content: space-between;
     font-style: italic;

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -1,10 +1,10 @@
 ---
 import BaseLayout from '$layouts/BaseLayout.astro';
+import EditorialFooter from '$components/EditorialFooter.astro';
+import EditorialMasthead from '$components/EditorialMasthead.astro';
 import {
   CATEGORY_META,
   POSTS_PER_PAGE,
-  SOCIAL_LINK_GITHUB,
-  SOCIAL_LINK_X,
   SITE_DESCRIPTION,
   SITE_TITLE,
   SITE_URL,
@@ -67,23 +67,7 @@ const fmtDate = (date: Date) =>
   mainClass="editorial-main"
 >
   <div class="editorial-home">
-    <section class="masthead">
-      <div class="brand"><a href="/">ESTRILDA</a> / PRIVATE RESEARCH ARCHIVE</div>
-      <nav>
-        <a href="#latest">ARTICLES</a>
-        <a href="#categories">CATEGORIES</a>
-        <a href="/post/about">ABOUT</a>
-        <a
-          href="https://github.com/big-mon/estrivault-blog-app"
-          target="_blank"
-          rel="noopener noreferrer">GITHUB</a
-        >
-      </nav>
-      <p class="tagline">
-        <span>株式投資・ソフトウェア・AI・ゲーム・ギアレビューを横断する個人アーカイブ</span>
-        <span class="tagline-meta">TEXT FIRST / IMAGE OPTIONAL</span>
-      </p>
-    </section>
+    <EditorialMasthead homePage />
 
     <section class="hero-grid">
       <article>
@@ -180,20 +164,7 @@ const fmtDate = (date: Date) =>
       </div>
     </section>
 
-    <footer class="index-footer">
-      <a class="footer-brand" href="/">Estrilda</a>
-      <span class="footer-links">
-        <a href={`https://x.com/${SOCIAL_LINK_X}`} target="_blank" rel="noopener noreferrer">X</a>
-        <span>/</span>
-        <a
-          href={`https://github.com/${SOCIAL_LINK_GITHUB}`}
-          target="_blank"
-          rel="noopener noreferrer">GITHUB</a
-        >
-        <span>/</span>
-        <a href="/llms.txt">LLMs</a>
-      </span>
-    </footer>
+    <EditorialFooter />
   </div>
 </BaseLayout>
 
@@ -224,10 +195,8 @@ const fmtDate = (date: Date) =>
     margin: 0 auto;
     border-top: 2px solid #202020;
   }
-  .masthead,
   .hero-grid,
-  .section-block,
-  .index-footer {
+  .section-block {
     max-width: 1180px;
     margin-right: auto;
     margin-left: auto;
@@ -238,52 +207,10 @@ const fmtDate = (date: Date) =>
     padding-top: 1rem;
     margin-top: 1rem;
   }
-  .masthead {
-    display: grid;
-    grid-template-columns: 1fr auto;
-    gap: 0.75rem;
-    align-items: center;
-    padding-top: 1rem;
-  }
-  .brand {
-    font-family: var(--font-display);
-    font-style: italic;
-    font-weight: 700;
-    letter-spacing: 0.06em;
-  }
-  nav {
-    display: flex;
-    gap: 1rem;
-    font-family: var(--font-meta);
-    font-style: italic;
-    font-size: 0.95rem;
-  }
-  .brand a,
-  nav a {
-    text-decoration: none;
-    color: #222;
-  }
-  .tagline {
-    grid-column: 1/-1;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem 1rem;
-    justify-content: space-between;
-    border-top: 1px solid #222;
-    color: #666;
-    margin-bottom: 1lh;
-    padding-top: 0.75rem;
-  }
-  .tagline-meta {
-    font-family: var(--font-meta);
-    color: #d6452a;
-    font-size: 0.82rem;
-    font-style: italic;
-  }
   .hero-grid {
     display: grid;
-    grid-template-columns: minmax(0, 1.55fr) minmax(340px, 1fr);
-    gap: 0.75rem;
+    grid-template-columns: minmax(0, 1.55fr) minmax(300px, 0.85fr);
+    gap: 1rem;
     min-height: 320px;
     border-bottom: 1px solid #222;
     padding-bottom: 1rem;
@@ -345,7 +272,8 @@ const fmtDate = (date: Date) =>
   }
   .section-block > h3 {
     font-family: var(--font-meta);
-    font-style: italic;
+    font-style: normal;
+    font-weight: 700;
     color: #d6452a;
     letter-spacing: 0.05em;
     margin-bottom: 0.75rem;
@@ -371,16 +299,23 @@ const fmtDate = (date: Date) =>
     color: inherit;
     text-decoration: none;
   }
+  .table-row:hover .name,
+  .featured:hover h4,
+  .latest-item:hover h4,
+  .series-card:hover h4 {
+    color: #d6452a;
+  }
   .no,
   .key {
     font-family: var(--font-meta);
-    font-style: italic;
+    font-style: normal;
     color: #d6452a;
   }
   .name {
     font-family: var(--font-display);
     font-size: 1.45rem;
     font-weight: 700;
+    transition: color 120ms ease;
   }
   .desc {
     color: #666;
@@ -432,13 +367,14 @@ const fmtDate = (date: Date) =>
   .cat {
     font-family: var(--font-meta);
     color: #d6452a;
-    font-style: italic;
+    font-style: normal;
   }
   .featured h4,
   .latest-item h4 {
     font-family: var(--font-display);
     font-weight: 400;
     line-height: 1.2;
+    transition: color 120ms ease;
   }
   .featured h4 {
     font-size: 1.9rem;
@@ -446,7 +382,7 @@ const fmtDate = (date: Date) =>
   .featured > span {
     font-family: var(--font-meta);
     color: #d6452a;
-    font-style: italic;
+    font-style: normal;
   }
   .note-summary {
     display: block;
@@ -489,7 +425,7 @@ const fmtDate = (date: Date) =>
   .latest-meta time {
     font-family: var(--font-meta);
     color: #d6452a;
-    font-style: italic;
+    font-style: normal;
   }
   .latest-meta .cat {
     color: #222;
@@ -516,44 +452,16 @@ const fmtDate = (date: Date) =>
     font-weight: 400;
     line-height: 1.15;
     margin: 0.5rem 0;
+    transition: color 120ms ease;
   }
   .series-card p:first-child {
     font-family: var(--font-meta);
     color: #d6452a;
-    font-style: italic;
-  }
-  .index-footer {
-    margin-top: 1rem;
-    border-top: 2px solid #202020;
-    display: flex;
-    justify-content: space-between;
-    font-style: italic;
-    padding-top: 0.75rem;
-  }
-  .footer-brand {
-    font-family: var(--font-display);
-  }
-  .footer-links {
-    font-family: var(--font-meta);
-  }
-  .footer-brand,
-  .footer-links a {
-    color: inherit;
-    text-decoration: none;
-  }
-  .footer-links {
-    display: inline-flex;
-    gap: 0.45rem;
+    font-style: normal;
   }
   @media (max-width: 900px) {
     .editorial-home {
       padding: 1rem;
-    }
-    .masthead {
-      grid-template-columns: 1fr;
-    }
-    nav {
-      flex-wrap: wrap;
     }
     .hero-grid,
     .latest-grid {

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -410,6 +410,9 @@ const fmtDate = (date: Date) =>
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+  .latest-item .note-summary {
+    max-width: calc(100% - 3ch);
+  }
   .latest-item h4 {
     font-size: 1.5rem;
   }

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -1,7 +1,6 @@
 ---
 import BaseLayout from '$layouts/BaseLayout.astro';
 import {
-  NAVIGATION_LINKS,
   POSTS_PER_PAGE,
   SOCIAL_LINK_GITHUB,
   SOCIAL_LINK_X,
@@ -9,7 +8,7 @@ import {
   SITE_TITLE,
   SITE_URL,
 } from '$constants';
-import { getPosts } from '$lib/content';
+import { getAllCategories, getPosts } from '$lib/content';
 
 const pageData = await getPosts({ page: 1, perPage: POSTS_PER_PAGE });
 const featuredPost = pageData.posts[0] ?? null;
@@ -22,22 +21,22 @@ const categoryDescriptions: Record<string, string> = {
   opinions: '考察、レビュー、個人的な視点のメモ',
 };
 
-const categoryRows = NAVIGATION_LINKS.filter((link) => link.href.startsWith('/category/')).map(
-  (link, index) => {
-    const category = link.href.split('/')[2] ?? link.label.toLowerCase();
+const categories = await getAllCategories();
 
-    return {
-      id: String(index + 1).padStart(2, '0'),
-      key: category.toUpperCase(),
-      label: link.label,
-      description: categoryDescriptions[category] ?? `${link.label}カテゴリーの記事一覧`,
-      href: link.href,
-    };
-  },
-);
+const categoryRows = categories.map((category, index) => {
+  const slug = category.toLowerCase();
+
+  return {
+    id: String(index + 1).padStart(2, '0'),
+    slug,
+    label: category,
+    description: categoryDescriptions[slug] ?? `${category}カテゴリーの記事一覧`,
+    href: `/category/${slug}/1`,
+  };
+});
 
 const categoryLabelByKey = Object.fromEntries(
-  categoryRows.map((category) => [category.key.toLowerCase(), category.label]),
+  categoryRows.map((category) => [category.slug, category.label]),
 );
 
 const getPostCategoryLabel = (category: string) =>
@@ -110,7 +109,7 @@ const fmtDate = (date: Date) =>
               <span class="no">{category.id}</span>
               <span class="name">{category.label}</span>
               <span class="desc">{category.description}</span>
-              <span class="key">{category.key}</span>
+              <span class="key">{category.slug}</span>
             </a>
           ))
         }

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -1,25 +1,361 @@
 ---
 import BaseLayout from '$layouts/BaseLayout.astro';
-import Pagination from '$components/Pagination.astro';
-import PostCard from '$components/PostCard.astro';
-import { POSTS_PER_PAGE, SITE_DESCRIPTION, SITE_TITLE, SITE_URL } from '$constants';
+import {
+  NAVIGATION_LINKS,
+  POSTS_PER_PAGE,
+  SITE_DESCRIPTION,
+  SITE_TITLE,
+  SITE_URL,
+} from '$constants';
 import { getPosts } from '$lib/content';
 
 const pageData = await getPosts({ page: 1, perPage: POSTS_PER_PAGE });
+const latestPosts = pageData.posts.slice(0, 4);
+const featuredPost = pageData.posts[0] ?? null;
+
+const categoryDescriptions: Record<string, string> = {
+  tech: '開発、AI、Web、ツール運用の記録',
+  finance: '米国株、企業分析、決算資料の読み解き',
+  hobbies: 'ゲーム、ガジェット、日々の試行錯誤',
+  opinions: '考察、レビュー、個人的な視点のメモ',
+};
+
+const categoryRows = NAVIGATION_LINKS.filter((link) => link.href.startsWith('/category/')).map(
+  (link, index) => {
+    const category = link.href.split('/')[2] ?? link.label.toLowerCase();
+
+    return {
+      id: String(index + 1).padStart(2, '0'),
+      key: category.toUpperCase(),
+      label: link.label,
+      description: categoryDescriptions[category] ?? `${link.label}カテゴリーの記事一覧`,
+      href: link.href,
+    };
+  },
+);
+
+const categoryLabelByKey = Object.fromEntries(
+  categoryRows.map((category) => [category.key.toLowerCase(), category.label]),
+);
+
+const getPostCategoryLabel = (category: string) =>
+  categoryLabelByKey[category.toLowerCase()] ?? category;
+
+const seriesCards = [
+  { id: '01', title: 'EDGAR / XBRL', desc: 'SEC書類とAPIを読み解く' },
+  { id: '02', title: 'Stable Diffusion', desc: '生成画像とモデル運用' },
+  { id: '03', title: 'Stock Analysis', desc: '個別銘柄と業界の深掘り' },
+  { id: '04', title: 'Gear Reviews', desc: '装備・機材の使用感レビュー' },
+];
+
+const fmtDate = (date: Date) =>
+  new Intl.DateTimeFormat('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit' })
+    .format(date)
+    .replace(/\//g, '.');
 ---
 
 <BaseLayout title={SITE_TITLE} description={SITE_DESCRIPTION} canonical={SITE_URL}>
-  <h1 class="sr-only">{SITE_TITLE}</h1>
+  <div class="editorial-home">
+    <section class="masthead">
+      <div class="brand">ESTRILDA / PRIVATE RESEARCH ARCHIVE</div>
+      <nav>
+        <a href="#latest">ARTICLES</a>
+        <a href="#categories">CATEGORIES</a>
+        <a href="/post/about">ABOUT</a>
+        <a href="https://github.com/big-mon/estrivault-blog-app" target="_blank">GITHUB</a>
+      </nav>
+      <p class="tagline">
+        株式投資・ソフトウェア・AI・ゲーム・ギアレビューを横断する個人アーカイブ
+      </p>
+    </section>
 
-  <div class="grid gap-8 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
-    {pageData.posts.map((post) => <PostCard post={post} />)}
-  </div>
+    <section class="hero-grid">
+      <article>
+        <h1>Estrilda</h1>
+        <h2>投資、開発、AI、<br />趣味の実践ログ。</h2>
+        <p>
+          米国株の企業分析、Web開発、生成AIツール、ゲーム攻略、ギアレビューまで。調べたこと・試したこと・考えたことを蓄積する、個人のための公開ノート。
+        </p>
+      </article>
+      <aside>
+        <h3>FIELD NOTES &amp; INDEX</h3>
+        <p class="issue">ISSUE 00</p>
+        <p class="issue-sub">Design direction</p>
+        <p>
+          Not a SaaS dashboard. Not a media template. A readable index for accumulated field notes.
+        </p>
+      </aside>
+    </section>
 
-  {
-    pageData.totalPages > 1 && (
-      <div class="mt-12">
-        <Pagination currentPage={pageData.page} totalPages={pageData.totalPages} baseUrl="/" />
+    <section id="categories" class="section-block">
+      <h3>CATEGORY INDEX</h3>
+      <div class="table-like">
+        {
+          categoryRows.map((category) => (
+            <a class="table-row" href={category.href}>
+              <span class="no">{category.id}</span>
+              <span class="name">{category.label}</span>
+              <span class="desc">{category.description}</span>
+              <span class="key">{category.key}</span>
+            </a>
+          ))
+        }
       </div>
-    )
-  }
+    </section>
+
+    <section id="latest" class="section-block latest-notes">
+      <h3>LATEST NOTES</h3>
+      <div class="latest-grid">
+        {
+          featuredPost && (
+            <a href={`/post/${featuredPost.slug}`} class="featured">
+              {featuredPost.coverImage && (
+                <img src={featuredPost.coverImage} alt={featuredPost.title} loading="lazy" />
+              )}
+              <p class="cat">{getPostCategoryLabel(featuredPost.category)}</p>
+              <h4>{featuredPost.title}</h4>
+              <p>{featuredPost.description}</p>
+              <span>READ ARTICLE →</span>
+            </a>
+          )
+        }
+        <div class="latest-list">
+          {
+            latestPosts.map((post) => (
+              <a href={`/post/${post.slug}`} class="latest-item">
+                <time>{fmtDate(post.publishedAt)}</time>
+                <p class="cat">{getPostCategoryLabel(post.category)}</p>
+                <h4>{post.title}</h4>
+                <p>{post.description}</p>
+              </a>
+            ))
+          }
+        </div>
+      </div>
+    </section>
+
+    <section class="section-block">
+      <h3>DEEP DIVES / SERIES</h3>
+      <div class="series-grid">
+        {
+          seriesCards.map((card) => (
+            <article class="series-card">
+              <p>{card.id}</p>
+              <h4>{card.title}</h4>
+              <p>{card.desc}</p>
+            </article>
+          ))
+        }
+      </div>
+    </section>
+
+    <footer class="index-footer">
+      <span>Estrilda</span>
+      <span>X / GITHUB / LLMs</span>
+    </footer>
+  </div>
 </BaseLayout>
+
+<style>
+  .editorial-home {
+    font-family: 'Inter', 'Noto Sans JP', sans-serif;
+    color: #111;
+    background: #f6f4ef;
+    border: 1px solid #202020;
+    padding: 1.5rem;
+  }
+  .masthead,
+  .hero-grid,
+  .section-block {
+    border-top: 1px solid #222;
+    padding-top: 1rem;
+    margin-top: 1rem;
+  }
+  .masthead {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.75rem;
+    align-items: center;
+  }
+  .brand {
+    font-style: italic;
+    letter-spacing: 0.06em;
+  }
+  nav {
+    display: flex;
+    gap: 1rem;
+    font-style: italic;
+    font-size: 0.95rem;
+  }
+  nav a {
+    text-decoration: none;
+    color: #222;
+  }
+  .tagline {
+    grid-column: 1/-1;
+    color: #666;
+  }
+  .hero-grid {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 1rem;
+    min-height: 360px;
+    border-bottom: 1px solid #222;
+    padding-bottom: 1rem;
+  }
+  h1 {
+    font-family: 'Times New Roman', serif;
+    font-size: clamp(3rem, 10vw, 7rem);
+    line-height: 1;
+    margin: 0;
+  }
+  h2 {
+    font-family: 'Times New Roman', serif;
+    font-size: clamp(2rem, 4vw, 3.6rem);
+    line-height: 1.25;
+    margin: 0.5rem 0;
+  }
+  .hero-grid p {
+    font-size: 1.2rem;
+    color: #555;
+    max-width: 42rem;
+  }
+  aside {
+    border-left: 1px solid #222;
+    padding-left: 1rem;
+  }
+  aside h3 {
+    font-family: 'Times New Roman', serif;
+    font-size: 3rem;
+    line-height: 1.2;
+  }
+  .issue {
+    color: #d6452a;
+    border-top: 1px solid #d6452a;
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
+    font-style: italic;
+  }
+  .issue-sub {
+    font-style: italic;
+  }
+  .section-block > h3 {
+    font-style: italic;
+    color: #d6452a;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.75rem;
+  }
+  .table-row {
+    display: grid;
+    grid-template-columns: 64px 300px 1fr 120px;
+    padding: 1rem 0;
+    border-top: 1px solid #aaa;
+    color: inherit;
+    text-decoration: none;
+  }
+  .no,
+  .key {
+    font-style: italic;
+    color: #d6452a;
+  }
+  .name {
+    font-family: 'Times New Roman', serif;
+    font-size: 2rem;
+  }
+  .desc {
+    color: #666;
+    align-self: center;
+  }
+  .key {
+    justify-self: end;
+    color: #222;
+  }
+  .latest-grid {
+    display: grid;
+    grid-template-columns: 1.1fr 1fr;
+    gap: 1.5rem;
+  }
+  .featured {
+    display: block;
+    border: 1px solid #222;
+    padding: 1rem;
+    text-decoration: none;
+    color: inherit;
+  }
+  .featured img {
+    width: 100%;
+    aspect-ratio: 16/9;
+    object-fit: cover;
+    border: 1px solid #555;
+  }
+  .cat {
+    color: #d6452a;
+    font-style: italic;
+  }
+  .featured h4,
+  .latest-item h4 {
+    font-family: 'Times New Roman', serif;
+    font-size: 2.25rem;
+    line-height: 1.2;
+  }
+  .latest-item {
+    display: block;
+    text-decoration: none;
+    color: inherit;
+    border-top: 1px solid #aaa;
+    padding: 0.8rem 0;
+  }
+  .latest-item time {
+    color: #d6452a;
+    font-style: italic;
+  }
+  .series-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    border-top: 1px solid #222;
+    border-left: 1px solid #222;
+  }
+  .series-card {
+    border-right: 1px solid #222;
+    border-bottom: 1px solid #222;
+    padding: 1rem;
+  }
+  .series-card h4 {
+    font-family: 'Times New Roman', serif;
+    font-size: 2rem;
+    line-height: 1.15;
+    margin: 0.5rem 0;
+  }
+  .series-card p:first-child {
+    color: #d6452a;
+    font-style: italic;
+  }
+  .index-footer {
+    margin-top: 1rem;
+    border-top: 1px solid #222;
+    display: flex;
+    justify-content: space-between;
+    font-style: italic;
+    padding-top: 0.75rem;
+  }
+  @media (max-width: 900px) {
+    .hero-grid,
+    .latest-grid {
+      grid-template-columns: 1fr;
+    }
+    .table-row {
+      grid-template-columns: 56px 1fr;
+      gap: 0.5rem;
+    }
+    .desc,
+    .key {
+      grid-column: 2;
+    }
+    .name {
+      font-size: 1.6rem;
+    }
+    .series-grid {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+</style>

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -10,8 +10,8 @@ import {
 import { getPosts } from '$lib/content';
 
 const pageData = await getPosts({ page: 1, perPage: POSTS_PER_PAGE });
-const latestPosts = pageData.posts.slice(0, 4);
 const featuredPost = pageData.posts[0] ?? null;
+const latestPosts = featuredPost ? pageData.posts.slice(1, 5) : pageData.posts.slice(0, 4);
 
 const categoryDescriptions: Record<string, string> = {
   tech: '開発、AI、Web、ツール運用の記録',

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -321,9 +321,8 @@ const fmtDate = (date: Date) =>
   }
   .archive-stats {
     display: grid;
-    grid-template-columns: max-content max-content;
+    grid-template-columns: max-content 1fr;
     column-gap: 1.25rem;
-    justify-content: start;
     width: 100%;
     border-top: 1px solid #d6452a;
     margin: 0.75rem 0 0;

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -258,7 +258,9 @@ const fmtDate = (date: Date) =>
   }
   aside {
     border-left: 1px solid #222;
-    padding-left: 1rem;
+    margin-top: calc(-1rem - 1px);
+    margin-bottom: calc(-1rem - 1px);
+    padding: calc(1rem + 1px) 0 calc(1rem + 1px) 1rem;
   }
   aside h3 {
     font-family: 'Times New Roman', serif;
@@ -321,15 +323,24 @@ const fmtDate = (date: Date) =>
   }
   .latest-notes,
   .series-section {
+    border-top: 0;
     margin-top: 2.5rem;
+    padding-top: 0;
+  }
+  .latest-notes > h3,
+  .series-section > h3 {
+    border-bottom: 1px solid #222;
+    margin-bottom: 0.75rem;
+    padding-bottom: 0.8rem;
   }
   .latest-grid {
     display: grid;
-    grid-template-columns: 1.1fr 1fr;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     gap: 1.5rem;
   }
   .featured {
     display: block;
+    min-width: 0;
     border: 1px solid #222;
     padding: 1rem;
     text-decoration: none;
@@ -359,6 +370,8 @@ const fmtDate = (date: Date) =>
     font-style: italic;
   }
   .note-summary {
+    display: block;
+    max-width: 100%;
     overflow: hidden;
     color: #666;
     text-overflow: ellipsis;
@@ -366,6 +379,10 @@ const fmtDate = (date: Date) =>
   }
   .latest-item h4 {
     font-size: 1.5rem;
+  }
+  .latest-list,
+  .latest-item {
+    min-width: 0;
   }
   .latest-item {
     display: block;

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -50,7 +50,7 @@ const fmtDate = (date: Date) =>
 >
   <div class="editorial-home">
     <section class="masthead">
-      <div class="brand">ESTRILDA / PRIVATE RESEARCH ARCHIVE</div>
+      <div class="brand"><a href="/">ESTRILDA</a> / PRIVATE RESEARCH ARCHIVE</div>
       <nav>
         <a href="#latest">ARTICLES</a>
         <a href="#categories">CATEGORIES</a>
@@ -149,7 +149,7 @@ const fmtDate = (date: Date) =>
     </section>
 
     <footer class="index-footer">
-      <span>Estrilda</span>
+      <a class="footer-brand" href="/">Estrilda</a>
       <span class="footer-links">
         <a href={`https://x.com/${SOCIAL_LINK_X}`} target="_blank" rel="noopener noreferrer">X</a>
         <span>/</span>
@@ -225,6 +225,7 @@ const fmtDate = (date: Date) =>
     font-style: italic;
     font-size: 0.95rem;
   }
+  .brand a,
   nav a {
     text-decoration: none;
     color: #222;
@@ -345,6 +346,9 @@ const fmtDate = (date: Date) =>
     margin-bottom: 0.75rem;
     padding-bottom: 0.8rem;
   }
+  .latest-notes > h3 {
+    margin-bottom: 1.5rem;
+  }
   .latest-grid {
     display: grid;
     grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
@@ -400,6 +404,9 @@ const fmtDate = (date: Date) =>
   .latest-list,
   .latest-item {
     min-width: 0;
+  }
+  .latest-list {
+    border-bottom: 1px solid #aaa;
   }
   .latest-item {
     display: block;
@@ -457,13 +464,14 @@ const fmtDate = (date: Date) =>
     font-style: italic;
     padding-top: 0.75rem;
   }
-  .footer-links {
-    display: inline-flex;
-    gap: 0.45rem;
-  }
+  .footer-brand,
   .footer-links a {
     color: inherit;
     text-decoration: none;
+  }
+  .footer-links {
+    display: inline-flex;
+    gap: 0.45rem;
   }
   @media (max-width: 900px) {
     .editorial-home {

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -277,6 +277,7 @@ const fmtDate = (date: Date) =>
   .tagline-meta {
     font-family: var(--font-meta);
     color: #d6452a;
+    font-size: 0.82rem;
     font-style: italic;
   }
   .hero-grid {

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -10,11 +10,11 @@ import {
   SITE_URL,
   getCategoryLabel,
 } from '$constants';
-import { getAllPostsMeta, getPosts } from '$lib/content';
+import { getAllPostsMeta, getPaginatedPosts } from '$lib/content';
 import { getTagRouteSegment } from '$lib/url-segments';
 
-const pageData = await getPosts({ page: 1, perPage: POSTS_PER_PAGE });
 const allPosts = await getAllPostsMeta();
+const pageData = getPaginatedPosts(allPosts, { page: 1, perPage: POSTS_PER_PAGE });
 const featuredPost = pageData.posts[0] ?? null;
 const latestPosts = featuredPost ? pageData.posts.slice(1, 5) : pageData.posts.slice(0, 4);
 
@@ -208,8 +208,11 @@ const fmtDate = (date: Date) =>
     margin-top: 1rem;
   }
   .hero-grid {
+    margin-top: 0;
+  }
+  .hero-grid {
     display: grid;
-    grid-template-columns: minmax(0, 1.55fr) minmax(300px, 0.85fr);
+    grid-template-columns: minmax(0, 1fr) 360px;
     gap: 1rem;
     min-height: 320px;
     border-bottom: 1px solid #222;
@@ -241,9 +244,10 @@ const fmtDate = (date: Date) =>
     padding: calc(1rem + 1px) 0 calc(1rem + 1px) 1rem;
   }
   aside h3 {
-    font-family: var(--font-display);
-    font-size: 2rem;
-    font-weight: 400;
+    font-family: var(--font-meta);
+    font-size: 1rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
     line-height: 1.2;
   }
   .archive-stats {

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -483,6 +483,8 @@ const fmtDate = (date: Date) =>
     display: flex;
     gap: 0.8rem;
     align-items: baseline;
+    font-size: 0.9rem;
+    line-height: 1.2;
   }
   .latest-meta time {
     font-family: var(--font-meta);
@@ -491,6 +493,8 @@ const fmtDate = (date: Date) =>
   }
   .latest-meta .cat {
     color: #222;
+    font-size: inherit;
+    line-height: inherit;
     margin: 0;
   }
   .series-grid {

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -54,7 +54,15 @@ const fmtDate = (date: Date) =>
     .replace(/\//g, '.');
 ---
 
-<BaseLayout title={SITE_TITLE} description={SITE_DESCRIPTION} canonical={SITE_URL}>
+<BaseLayout
+  title={SITE_TITLE}
+  description={SITE_DESCRIPTION}
+  canonical={SITE_URL}
+  hideHeader
+  hideFooter
+  bodyClass="editorial-page"
+  mainClass="editorial-main"
+>
   <div class="editorial-home">
     <section class="masthead">
       <div class="brand">ESTRILDA / PRIVATE RESEARCH ARCHIVE</div>
@@ -157,12 +165,34 @@ const fmtDate = (date: Date) =>
 </BaseLayout>
 
 <style>
+  :global(.editorial-page) {
+    background: #f1eee7;
+  }
+  :global(.editorial-main) {
+    width: 100%;
+    max-width: none;
+    padding: 0;
+  }
   .editorial-home {
+    min-height: 100vh;
     font-family: 'Inter', 'Noto Sans JP', sans-serif;
     color: #111;
-    background: #f6f4ef;
-    border: 1px solid #202020;
-    padding: 1.5rem;
+    background: #f1eee7;
+    border: 0;
+    padding: clamp(1rem, 2vw, 2rem);
+  }
+  .editorial-home::before {
+    content: '';
+    display: block;
+    border-top: 1px solid #202020;
+  }
+  .masthead,
+  .hero-grid,
+  .section-block,
+  .index-footer {
+    max-width: 1180px;
+    margin-right: auto;
+    margin-left: auto;
   }
   .masthead,
   .hero-grid,
@@ -199,13 +229,13 @@ const fmtDate = (date: Date) =>
     display: grid;
     grid-template-columns: 2fr 1fr;
     gap: 1rem;
-    min-height: 360px;
+    min-height: 320px;
     border-bottom: 1px solid #222;
     padding-bottom: 1rem;
   }
   h1 {
     font-family: 'Times New Roman', serif;
-    font-size: clamp(3rem, 10vw, 7rem);
+    font-size: clamp(4.5rem, 11vw, 10rem);
     line-height: 1;
     margin: 0;
   }
@@ -339,6 +369,15 @@ const fmtDate = (date: Date) =>
     padding-top: 0.75rem;
   }
   @media (max-width: 900px) {
+    .editorial-home {
+      padding: 1rem;
+    }
+    .masthead {
+      grid-template-columns: 1fr;
+    }
+    nav {
+      flex-wrap: wrap;
+    }
     .hero-grid,
     .latest-grid {
       grid-template-columns: 1fr;

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -80,7 +80,8 @@ const fmtDate = (date: Date) =>
         >
       </nav>
       <p class="tagline">
-        株式投資・ソフトウェア・AI・ゲーム・ギアレビューを横断する個人アーカイブ
+        <span>株式投資・ソフトウェア・AI・ゲーム・ギアレビューを横断する個人アーカイブ</span>
+        <span class="tagline-meta">TEXT FIRST / IMAGE OPTIONAL</span>
       </p>
     </section>
 
@@ -268,10 +269,19 @@ const fmtDate = (date: Date) =>
   }
   .tagline {
     grid-column: 1/-1;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem 1rem;
+    justify-content: space-between;
     border-top: 1px solid #222;
     color: #666;
     margin-bottom: 1lh;
     padding-top: 0.75rem;
+  }
+  .tagline-meta {
+    font-family: var(--font-meta);
+    color: #d6452a;
+    font-style: italic;
   }
   .hero-grid {
     display: grid;

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -95,7 +95,7 @@ const fmtDate = (date: Date) =>
       </aside>
     </section>
 
-    <section id="categories" class="section-block">
+    <section id="categories" class="section-block category-index">
       <h3>CATEGORY INDEX</h3>
       <div class="table-like">
         {
@@ -184,7 +184,9 @@ const fmtDate = (date: Date) =>
   .editorial-home::before {
     content: '';
     display: block;
-    border-top: 1px solid #202020;
+    max-width: 1180px;
+    margin: 0 auto;
+    border-top: 2px solid #202020;
   }
   .masthead,
   .hero-grid,
@@ -275,6 +277,16 @@ const fmtDate = (date: Date) =>
     letter-spacing: 0.05em;
     margin-bottom: 0.75rem;
   }
+  .category-index {
+    border-top: 0;
+    margin-top: 2.5rem;
+    padding-top: 0;
+  }
+  .category-index > h3 {
+    border-bottom: 1px solid #222;
+    margin-bottom: 0;
+    padding-bottom: 0.8rem;
+  }
   .table-row {
     display: grid;
     grid-template-columns: 64px 300px 1fr 120px;
@@ -325,8 +337,13 @@ const fmtDate = (date: Date) =>
   .featured h4,
   .latest-item h4 {
     font-family: 'Times New Roman', serif;
-    font-size: 2.25rem;
     line-height: 1.2;
+  }
+  .featured h4 {
+    font-size: 1.9rem;
+  }
+  .latest-item h4 {
+    font-size: 1.5rem;
   }
   .latest-item {
     display: block;

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -120,8 +120,10 @@ const fmtDate = (date: Date) =>
           {
             latestPosts.map((post) => (
               <a href={`/post/${post.slug}`} class="latest-item">
-                <time>{fmtDate(post.publishedAt)}</time>
-                <p class="cat">{getCategoryLabel(post.category)}</p>
+                <div class="latest-meta">
+                  <time>{fmtDate(post.publishedAt)}</time>
+                  <p class="cat">{getCategoryLabel(post.category)}</p>
+                </div>
                 <h4>{post.title}</h4>
                 <p>{post.description}</p>
               </a>
@@ -301,7 +303,7 @@ const fmtDate = (date: Date) =>
   }
   .name {
     font-family: 'Times New Roman', serif;
-    font-size: 2rem;
+    font-size: 1.45rem;
   }
   .desc {
     color: #666;
@@ -310,6 +312,7 @@ const fmtDate = (date: Date) =>
   .key {
     justify-self: end;
     color: #222;
+    text-transform: uppercase;
   }
   .latest-grid {
     display: grid;
@@ -318,7 +321,7 @@ const fmtDate = (date: Date) =>
   }
   .featured {
     display: block;
-    border: 1px solid #222;
+    border: 1px solid #d6452a;
     padding: 1rem;
     text-decoration: none;
     color: inherit;
@@ -327,7 +330,7 @@ const fmtDate = (date: Date) =>
     width: 100%;
     aspect-ratio: 16/9;
     object-fit: cover;
-    border: 1px solid #555;
+    border: 1px solid #d6452a;
   }
   .cat {
     color: #d6452a;
@@ -341,6 +344,10 @@ const fmtDate = (date: Date) =>
   .featured h4 {
     font-size: 1.9rem;
   }
+  .featured > span {
+    color: #d6452a;
+    font-style: italic;
+  }
   .latest-item h4 {
     font-size: 1.5rem;
   }
@@ -351,9 +358,18 @@ const fmtDate = (date: Date) =>
     border-top: 1px solid #aaa;
     padding: 0.8rem 0;
   }
-  .latest-item time {
+  .latest-meta {
+    display: flex;
+    gap: 0.8rem;
+    align-items: baseline;
+  }
+  .latest-meta time {
     color: #d6452a;
     font-style: italic;
+  }
+  .latest-meta .cat {
+    color: #222;
+    margin: 0;
   }
   .series-grid {
     display: grid;

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -70,7 +70,11 @@ const fmtDate = (date: Date) =>
         <a href="#latest">ARTICLES</a>
         <a href="#categories">CATEGORIES</a>
         <a href="/post/about">ABOUT</a>
-        <a href="https://github.com/big-mon/estrivault-blog-app" target="_blank">GITHUB</a>
+        <a
+          href="https://github.com/big-mon/estrivault-blog-app"
+          target="_blank"
+          rel="noopener noreferrer">GITHUB</a
+        >
       </nav>
       <p class="tagline">
         株式投資・ソフトウェア・AI・ゲーム・ギアレビューを横断する個人アーカイブ

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -315,7 +315,7 @@ const fmtDate = (date: Date) =>
   }
   aside h3 {
     font-family: var(--font-display);
-    font-size: 2.35rem;
+    font-size: 2rem;
     font-weight: 400;
     line-height: 1.2;
   }

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -11,6 +11,7 @@ import {
   getCategoryLabel,
 } from '$constants';
 import { getPosts } from '$lib/content';
+import { getTagRouteSegment } from '$lib/url-segments';
 
 const pageData = await getPosts({ page: 1, perPage: POSTS_PER_PAGE });
 const featuredPost = pageData.posts[0] ?? null;
@@ -27,11 +28,19 @@ const categoryRows = Object.entries(CATEGORY_META)
   }));
 
 const seriesCards = [
-  { id: '01', title: 'EDGAR / XBRL', desc: 'SEC書類とAPIを読み解く' },
-  { id: '02', title: 'Stable Diffusion', desc: '生成画像とモデル運用' },
-  { id: '03', title: 'Stock Analysis', desc: '個別銘柄と業界の深掘り' },
-  { id: '04', title: 'Gear Reviews', desc: '装備・機材の使用感レビュー' },
-];
+  { id: '01', title: 'EDGAR / XBRL', desc: 'SEC書類とAPIを読み解く', tag: 'EDGAR' },
+  {
+    id: '02',
+    title: 'Stable Diffusion',
+    desc: '生成画像とモデル運用',
+    tag: 'Stable Diffusion',
+  },
+  { id: '03', title: 'Stock Analysis', desc: '個別銘柄と業界の深掘り', tag: '銘柄分析' },
+  { id: '04', title: 'Gear Reviews', desc: '装備・機材の使用感レビュー', tag: 'レビュー' },
+].map((card) => ({
+  ...card,
+  href: `/tag/${getTagRouteSegment(card.tag)}/1`,
+}));
 
 const fmtDate = (date: Date) =>
   new Intl.DateTimeFormat('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit' })
@@ -138,11 +147,11 @@ const fmtDate = (date: Date) =>
       <div class="series-grid">
         {
           seriesCards.map((card) => (
-            <article class="series-card">
+            <a class="series-card" href={card.href}>
               <p>{card.id}</p>
               <h4>{card.title}</h4>
               <p>{card.desc}</p>
-            </article>
+            </a>
           ))
         }
       </div>
@@ -305,6 +314,9 @@ const fmtDate = (date: Date) =>
     margin-bottom: 0;
     padding-bottom: 0.8rem;
   }
+  .table-like {
+    border-bottom: 1px solid #222;
+  }
   .table-row {
     display: grid;
     grid-template-columns: 64px 300px 1fr 120px;
@@ -351,8 +363,8 @@ const fmtDate = (date: Date) =>
   }
   .latest-grid {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-    gap: 1.5rem;
+    grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+    gap: 2rem;
   }
   .featured {
     display: block;
@@ -442,6 +454,8 @@ const fmtDate = (date: Date) =>
     border-right: 1px solid #222;
     border-bottom: 1px solid #222;
     padding: 1rem;
+    color: inherit;
+    text-decoration: none;
   }
   .series-card h4 {
     font-family: var(--font-display);

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -315,28 +315,34 @@ const fmtDate = (date: Date) =>
   }
   aside h3 {
     font-family: var(--font-display);
-    font-size: 3rem;
+    font-size: 2.35rem;
     font-weight: 400;
     line-height: 1.2;
   }
   .archive-stats {
+    display: grid;
+    grid-template-columns: max-content max-content;
+    column-gap: 1.25rem;
+    justify-content: start;
+    width: 100%;
     border-top: 1px solid #d6452a;
     margin: 0.75rem 0 0;
     padding-top: 0.75rem;
   }
   .archive-stats div {
-    display: grid;
-    grid-template-columns: 1fr auto;
-    gap: 1rem;
-    font-family: var(--font-meta);
-    line-height: 1.65;
+    display: contents;
   }
   .archive-stats dt,
   .archive-stats dd {
     margin: 0;
+    font-family: var(--font-meta);
+    line-height: 1.65;
   }
   .archive-stats dt {
     color: #d6452a;
+  }
+  .archive-stats dd {
+    text-align: right;
   }
   .section-block > h3 {
     font-family: var(--font-meta);

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -223,8 +223,9 @@ const fmtDate = (date: Date) =>
     padding-top: 1rem;
   }
   .brand {
-    font-family: var(--font-meta);
+    font-family: var(--font-display);
     font-style: italic;
+    font-weight: 700;
     letter-spacing: 0.06em;
   }
   nav {
@@ -476,10 +477,15 @@ const fmtDate = (date: Date) =>
     margin-top: 1rem;
     border-top: 2px solid #202020;
     display: flex;
-    font-family: var(--font-meta);
     justify-content: space-between;
     font-style: italic;
     padding-top: 0.75rem;
+  }
+  .footer-brand {
+    font-family: var(--font-display);
+  }
+  .footer-links {
+    font-family: var(--font-meta);
   }
   .footer-brand,
   .footer-links a {

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -1,46 +1,30 @@
 ---
 import BaseLayout from '$layouts/BaseLayout.astro';
 import {
+  CATEGORY_META,
   POSTS_PER_PAGE,
   SOCIAL_LINK_GITHUB,
   SOCIAL_LINK_X,
   SITE_DESCRIPTION,
   SITE_TITLE,
   SITE_URL,
+  getCategoryLabel,
 } from '$constants';
-import { getAllCategories, getPosts } from '$lib/content';
+import { getPosts } from '$lib/content';
 
 const pageData = await getPosts({ page: 1, perPage: POSTS_PER_PAGE });
 const featuredPost = pageData.posts[0] ?? null;
 const latestPosts = featuredPost ? pageData.posts.slice(1, 5) : pageData.posts.slice(0, 4);
 
-const categoryDescriptions: Record<string, string> = {
-  tech: '開発、AI、Web、ツール運用の記録',
-  finance: '米国株、企業分析、決算資料の読み解き',
-  hobbies: 'ゲーム、ガジェット、日々の試行錯誤',
-  opinions: '考察、レビュー、個人的な視点のメモ',
-};
-
-const categories = await getAllCategories();
-
-const categoryRows = categories.map((category, index) => {
-  const slug = category.toLowerCase();
-
-  return {
+const categoryRows = Object.entries(CATEGORY_META)
+  .filter(([slug]) => slug !== 'meta')
+  .map(([slug, category], index) => ({
     id: String(index + 1).padStart(2, '0'),
     slug,
-    label: category,
-    description: categoryDescriptions[slug] ?? `${category}カテゴリーの記事一覧`,
+    label: category.label,
+    description: category.description,
     href: `/category/${slug}/1`,
-  };
-});
-
-const categoryLabelByKey = Object.fromEntries(
-  categoryRows.map((category) => [category.slug, category.label]),
-);
-
-const getPostCategoryLabel = (category: string) =>
-  categoryLabelByKey[category.toLowerCase()] ?? category;
+  }));
 
 const seriesCards = [
   { id: '01', title: 'EDGAR / XBRL', desc: 'SEC書類とAPIを読み解く' },
@@ -125,7 +109,7 @@ const fmtDate = (date: Date) =>
               {featuredPost.coverImage && (
                 <img src={featuredPost.coverImage} alt={featuredPost.title} loading="lazy" />
               )}
-              <p class="cat">{getPostCategoryLabel(featuredPost.category)}</p>
+              <p class="cat">{getCategoryLabel(featuredPost.category)}</p>
               <h4>{featuredPost.title}</h4>
               <p>{featuredPost.description}</p>
               <span>READ ARTICLE →</span>
@@ -137,7 +121,7 @@ const fmtDate = (date: Date) =>
             latestPosts.map((post) => (
               <a href={`/post/${post.slug}`} class="latest-item">
                 <time>{fmtDate(post.publishedAt)}</time>
-                <p class="cat">{getPostCategoryLabel(post.category)}</p>
+                <p class="cat">{getCategoryLabel(post.category)}</p>
                 <h4>{post.title}</h4>
                 <p>{post.description}</p>
               </a>

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -3,6 +3,8 @@ import BaseLayout from '$layouts/BaseLayout.astro';
 import {
   NAVIGATION_LINKS,
   POSTS_PER_PAGE,
+  SOCIAL_LINK_GITHUB,
+  SOCIAL_LINK_X,
   SITE_DESCRIPTION,
   SITE_TITLE,
   SITE_URL,
@@ -163,7 +165,17 @@ const fmtDate = (date: Date) =>
 
     <footer class="index-footer">
       <span>Estrilda</span>
-      <span>X / GITHUB / LLMs</span>
+      <span class="footer-links">
+        <a href={`https://x.com/${SOCIAL_LINK_X}`} target="_blank" rel="noopener noreferrer">X</a>
+        <span>/</span>
+        <a
+          href={`https://github.com/${SOCIAL_LINK_GITHUB}`}
+          target="_blank"
+          rel="noopener noreferrer">GITHUB</a
+        >
+        <span>/</span>
+        <a href="/llms.txt">LLMs</a>
+      </span>
     </footer>
   </div>
 </BaseLayout>
@@ -388,6 +400,14 @@ const fmtDate = (date: Date) =>
     justify-content: space-between;
     font-style: italic;
     padding-top: 0.75rem;
+  }
+  .footer-links {
+    display: inline-flex;
+    gap: 0.45rem;
+  }
+  .footer-links a {
+    color: inherit;
+    text-decoration: none;
   }
   @media (max-width: 900px) {
     .editorial-home {

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -197,7 +197,6 @@ const fmtDate = (date: Date) =>
     margin-right: auto;
     margin-left: auto;
   }
-  .masthead,
   .hero-grid,
   .section-block {
     border-top: 1px solid #222;
@@ -209,6 +208,7 @@ const fmtDate = (date: Date) =>
     grid-template-columns: 1fr auto;
     gap: 0.75rem;
     align-items: center;
+    padding-top: 1rem;
   }
   .brand {
     font-style: italic;

--- a/apps/astro-blog/src/pages/index.astro
+++ b/apps/astro-blog/src/pages/index.astro
@@ -467,6 +467,9 @@ const fmtDate = (date: Date) =>
     .editorial-home {
       padding: 1rem;
     }
+    .hero-grid {
+      display: none;
+    }
     .hero-grid,
     .latest-grid {
       grid-template-columns: 1fr;

--- a/apps/astro-blog/src/pages/post/[slug]/index.astro
+++ b/apps/astro-blog/src/pages/post/[slug]/index.astro
@@ -1,12 +1,11 @@
 ---
 import BaseLayout from '$layouts/BaseLayout.astro';
-import EditOnGitHub from '$components/EditOnGitHub.astro';
-import PostBody from '$components/PostBody.astro';
-import PostHeader from '$components/PostHeader.astro';
-import TableOfContents from '$components/TableOfContents.astro';
+import EditorialFooter from '$components/EditorialFooter.astro';
+import EditorialMasthead from '$components/EditorialMasthead.astro';
 import { getCategoryLabel, SITE_TITLE, SITE_URL, SOCIAL_LINK_X } from '$constants';
 import { getAllPostsMeta, getPostBySlug } from '$lib/content';
 import { getPostOgpImageUrl } from '$lib/og';
+import { getTagRouteSegment } from '$lib/url-segments';
 
 export async function getStaticPaths() {
   const allPosts = await getAllPostsMeta();
@@ -33,9 +32,39 @@ if (!post) {
 const siteBase = SITE_URL.replace(/\/$/, '');
 const canonical = `${siteBase}/post/${post.meta.slug}`;
 const title = `${post.meta.title} | ${SITE_TITLE}`;
-const description = post.meta.description || `${post.meta.title}�ɂ��Ă̋L���ł��B`;
+const description = post.meta.description || `${post.meta.title}についての記事です。`;
 const categoryLabel = getCategoryLabel(post.meta.category);
 const ogImage = getPostOgpImageUrl(post.meta.slug);
+const dateFormatter = new Intl.DateTimeFormat('ja-JP', {
+  timeZone: 'Asia/Tokyo',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+const publishedDate = dateFormatter.format(post.meta.publishedAt).replace(/\//g, '.');
+const updatedDate = post.meta.updatedAt ?
+  dateFormatter.format(post.meta.updatedAt).replace(/\//g, '.')
+: undefined;
+const readingTime = post.meta.readingTime ? `${Math.ceil(post.meta.readingTime)} min` : 'FIELD NOTE';
+const articleMeta = [
+  { label: 'PUBLISHED', value: publishedDate },
+  ...(updatedDate && updatedDate !== publishedDate ? [{ label: 'UPDATED', value: updatedDate }] : []),
+  { label: 'CATEGORY', value: categoryLabel },
+  { label: 'READING', value: readingTime },
+];
+const bodyClasses = [
+  'article-body',
+  post.hasTwitterEmbeds ? 'has-twitter-embeds' : '',
+  post.hasAmazonEmbeds ? 'has-amazon-embeds' : '',
+  post.hasCodeBlocks ? 'has-code-blocks' : '',
+  post.hasDirectiveBoxes ? 'has-directive-boxes' : '',
+]
+  .filter(Boolean)
+  .join(' ');
+const shouldShowArticleThumbnail =
+  post.meta.showArticleThumbnail !== false && Boolean(post.meta.coverImage);
+const tocHeadings =
+  post.headings.length > 10 ? post.headings.filter((heading) => heading.level === 2) : post.headings;
 
 const schemaData = {
   '@context': 'https://schema.org',
@@ -83,29 +112,638 @@ const schemaData = {
   modifiedTime={(post.meta.updatedAt || post.meta.publishedAt).toISOString()}
   section={categoryLabel}
   tags={post.meta.tags}
+  hideHeader
+  hideFooter
+  bodyClass="article-editorial-page"
+  mainClass="article-editorial-main"
 >
-  <article class="container mx-auto px-2 sm:px-4 xl:max-w-6xl">
-    <PostHeader meta={post.meta} />
-    <div class="xl:flex xl:gap-8">
-      <div class="xl:max-w-4xl xl:flex-1">
-        <div class="xl:hidden">
-          <TableOfContents headings={post.headings} />
+  <article class="article-page">
+    <EditorialMasthead />
+
+    <header class="article-hero">
+      <div class="article-heading">
+        <div class="article-badges">
+          <a
+            class="article-category"
+            href={`/category/${encodeURIComponent(post.meta.category.toLowerCase())}/1`}
+          >
+            {categoryLabel}
+          </a>
         </div>
-
-        <PostBody post={post} />
-
-        {
-          post.originalPath && (
-            <div class="post-footer mt-12 rounded-2xl border border-slate-200 bg-gradient-to-br from-slate-50 to-slate-100 p-8">
-              <EditOnGitHub originalPath={post.originalPath} />
-            </div>
-          )
-        }
+        <h1>{post.meta.title}</h1>
+        {post.meta.description && <p class="article-lead">{post.meta.description}</p>}
+        <div class="article-tags">
+          {post.meta.tags.slice(0, 4).map((tag) => (
+            <a href={`/tag/${getTagRouteSegment(tag)}/1`}>#{tag}</a>
+          ))}
+        </div>
       </div>
 
-      <aside class="hidden xl:block xl:w-64 xl:flex-shrink-0">
-        <TableOfContents headings={post.headings} />
+      <aside class="article-meta">
+        <h2>ARTICLE META</h2>
+        <dl>
+          {
+            articleMeta.map((item) => (
+              <div>
+                <dt>{item.label}</dt>
+                <dd>{item.value}</dd>
+              </div>
+            ))
+          }
+        </dl>
+        {
+          shouldShowArticleThumbnail && post.meta.coverImage && (
+            <figure class="article-thumbnail">
+              <img src={post.meta.coverImage} alt="" loading="lazy" />
+            </figure>
+          )
+        }
+      </aside>
+    </header>
+
+    <div class="article-layout">
+      <div class="article-content">
+        <div class={bodyClasses} set:html={post.html || 'コンテンツがありません'} />
+
+        <nav class="article-return" aria-label="記事ナビゲーション">
+          <a href="/">← ARTICLES INDEX</a>
+          {post.originalPath && (
+            <a
+              href={`https://github.com/big-mon/estrivault-blog-app/edit/main/${post.originalPath}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              EDIT SOURCE
+            </a>
+          )}
+        </nav>
+      </div>
+
+      <aside class="article-sidebar">
+        {
+          tocHeadings.length > 0 && (
+            <nav class="article-toc" aria-label="Table of contents">
+              <h2>TABLE OF CONTENTS</h2>
+              <ol>
+                {tocHeadings.map((heading) => (
+                  <li class={`toc-level-${heading.level}`}>
+                    <a href={`#${heading.id}`} data-toc-link={heading.id}>
+                      {heading.text}
+                    </a>
+                  </li>
+                ))}
+              </ol>
+            </nav>
+          )
+        }
       </aside>
     </div>
+
+    <EditorialFooter />
   </article>
 </BaseLayout>
+
+<script>
+  const tocLinks = [...document.querySelectorAll<HTMLAnchorElement>('[data-toc-link]')];
+  const articleHeadings = tocLinks
+    .map((link) => {
+      const headingId = link.dataset.tocLink;
+      return headingId ? document.getElementById(headingId) : null;
+    })
+    .filter((heading): heading is HTMLElement => heading !== null);
+
+  const setActiveTocLink = (headingId: string) => {
+    for (const link of tocLinks) {
+      const isActive = link.dataset.tocLink === headingId;
+      link.classList.toggle('is-active', isActive);
+      if (isActive) {
+        link.setAttribute('aria-current', 'location');
+      } else {
+        link.removeAttribute('aria-current');
+      }
+    }
+  };
+
+  const getCurrentHeadingId = () => {
+    const offset = window.innerHeight * 0.28;
+    let currentHeading = articleHeadings[0];
+
+    for (const heading of articleHeadings) {
+      if (heading.getBoundingClientRect().top <= offset) {
+        currentHeading = heading;
+      } else {
+        break;
+      }
+    }
+
+    return currentHeading?.id;
+  };
+
+  const updateActiveTocLink = () => {
+    const currentHeadingId = getCurrentHeadingId();
+    if (currentHeadingId) {
+      setActiveTocLink(currentHeadingId);
+    }
+  };
+
+  if (tocLinks.length > 0 && articleHeadings.length > 0) {
+    updateActiveTocLink();
+    window.addEventListener('scroll', updateActiveTocLink, { passive: true });
+    window.addEventListener('resize', updateActiveTocLink);
+  }
+</script>
+
+<style>
+  :global(.article-editorial-page) {
+    background: #f1eee7;
+  }
+  :global(.article-editorial-main) {
+    width: 100%;
+    max-width: none;
+    padding: 0;
+  }
+  .article-page {
+    --font-display: 'Times New Roman', serif;
+    --font-body: 'Inter', 'Noto Sans JP', sans-serif;
+    --font-meta: 'SF Mono', Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+    min-height: 100vh;
+    padding: clamp(1rem, 2vw, 2rem);
+    color: #111;
+    background: #f1eee7;
+    font-family: var(--font-body);
+  }
+  .article-page::before {
+    content: '';
+    display: block;
+    max-width: 1180px;
+    margin: 0 auto;
+    border-top: 2px solid #202020;
+  }
+  .article-hero,
+  .article-layout {
+    max-width: 1180px;
+    margin-right: auto;
+    margin-left: auto;
+  }
+  .article-hero {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 360px;
+    gap: 1rem;
+    min-height: 330px;
+    margin-top: 0;
+    border-top: 1px solid #222;
+    border-bottom: 2px solid #222;
+  }
+  .article-heading {
+    padding: 1rem 2rem 1.4rem 0;
+  }
+  .article-badges,
+  .article-tags,
+  .article-meta,
+  .article-toc,
+  .article-return {
+    font-family: var(--font-meta);
+    font-style: normal;
+  }
+  .article-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem 0.75rem;
+    margin-bottom: 2rem;
+  }
+  .article-badges a,
+  .article-tags a {
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid #222;
+    padding: 0.34rem 0.55rem 0.28rem;
+    color: #111;
+    font-size: 0.86rem;
+    line-height: 1.1;
+    text-decoration: none;
+    transition:
+      color 120ms ease,
+      border-color 120ms ease;
+  }
+  .article-badges .article-category {
+    color: #f1eee7;
+    background: #222;
+  }
+  .article-badges .article-category:hover {
+    border-color: #d6452a;
+    color: #f1eee7;
+    background: #d6452a;
+  }
+  .article-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem 0.75rem;
+    margin-top: 1.25rem;
+  }
+  .article-tags a:hover {
+    border-color: #d6452a;
+    color: #d6452a;
+  }
+  h1 {
+    max-width: 22ch;
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: clamp(2rem, 4vw, 3.6rem);
+    font-weight: 700;
+    line-height: 1.14;
+    letter-spacing: 0;
+  }
+  .article-lead {
+    max-width: 46rem;
+    margin: 1.25rem 0 0;
+    color: #666;
+    font-size: 1.08rem;
+    line-height: 1.85;
+  }
+  .article-meta {
+    border-left: 1px solid #222;
+    padding: 1.55rem 0 1.4rem 1.35rem;
+  }
+  .article-meta h2,
+  .article-toc h2 {
+    margin: 0;
+    color: #d6452a;
+    font-size: 0.92rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+  }
+  .article-meta h2 {
+    color: #d6452a;
+    font-family: var(--font-meta);
+    font-size: 1rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    line-height: 1.1;
+  }
+  .article-meta dl {
+    margin: 0.7rem 0 0;
+  }
+  .article-thumbnail {
+    margin: 1.5rem 0 0;
+    border-top: 1px solid #222;
+    padding: 1.2rem 2rem 0;
+  }
+  .article-thumbnail img {
+    display: block;
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    border: 1px solid #222;
+    object-fit: cover;
+    background: #ddd6c8;
+  }
+  .article-meta div {
+    display: grid;
+    grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.2fr);
+    gap: 1rem;
+    border-top: 1px solid #b9b2a4;
+    padding: 0.95rem 0;
+  }
+  .article-meta div:last-child {
+    border-bottom: 1px solid #b9b2a4;
+  }
+  .article-meta dt {
+    color: #d6452a;
+    font-size: 0.74rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+  }
+  .article-meta dd {
+    margin: 0;
+    color: #222;
+    font-size: 0.88rem;
+    font-weight: 700;
+    line-height: 1.45;
+    text-align: right;
+    overflow-wrap: anywhere;
+  }
+  .article-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 360px;
+    gap: 1rem;
+    padding-top: 3rem;
+  }
+  .article-content {
+    min-width: 0;
+    padding-right: 2rem;
+  }
+  .article-sidebar {
+    min-width: 0;
+    border-left: 1px solid #222;
+    padding-left: 1.35rem;
+  }
+  .article-toc {
+    position: sticky;
+    top: 1.5rem;
+  }
+  .article-toc h2 {
+    border-bottom: 2px solid #222;
+    padding-bottom: 0.9rem;
+  }
+  .article-toc ol {
+    display: grid;
+    gap: 0;
+    margin: 0.6rem 0 0;
+    padding: 0;
+    list-style: none;
+  }
+  .article-toc li {
+    border-bottom: 1px solid #b9b2a4;
+  }
+  .article-toc a {
+    display: block;
+    padding: 0.8rem 0.55rem;
+    color: #333;
+    font-size: 0.82rem;
+    font-weight: 700;
+    line-height: 1.45;
+    text-decoration: none;
+    transition:
+      color 120ms ease,
+      background-color 120ms ease;
+  }
+  .article-toc a:hover {
+    color: #d6452a;
+  }
+  :global(.article-toc a.is-active) {
+    color: #d6452a !important;
+    background: transparent;
+  }
+  .article-toc .toc-level-2 a {
+    padding-left: 0;
+  }
+  .article-toc .toc-level-3 a {
+    padding-left: 1.55rem;
+  }
+  .article-toc .toc-level-4 a,
+  .article-toc .toc-level-5 a,
+  .article-toc .toc-level-6 a {
+    padding-left: 2.55rem;
+    font-size: 0.78rem;
+  }
+  .article-return {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 3rem;
+    border-top: 2px solid #222;
+    padding-top: 1rem;
+  }
+  .article-return a {
+    border: 1px solid #222;
+    padding: 0.45rem 0.65rem 0.38rem;
+    color: #111;
+    font-size: 0.82rem;
+    font-weight: 700;
+    text-decoration: none;
+    transition:
+      color 120ms ease,
+      border-color 120ms ease;
+  }
+  .article-return a:hover {
+    border-color: #d6452a;
+    color: #d6452a;
+  }
+  :global(.article-body) {
+    counter-reset: article-section;
+    color: #222;
+    font-family: var(--font-body);
+    font-size: 1.03rem;
+    line-height: 2.05;
+    overflow-wrap: anywhere;
+  }
+  :global(.article-body > *:first-child) {
+    margin-top: 0;
+  }
+  :global(.article-body h2) {
+    display: grid;
+    grid-template-columns: 2.8rem minmax(0, 1fr);
+    gap: 0.35rem;
+    align-items: baseline;
+    margin: 4rem 0 1.35rem;
+    border-bottom: 1px solid #222;
+    padding-bottom: 0.95rem;
+    color: #111;
+    font-family: var(--font-display);
+    font-size: clamp(1.55rem, 2.4vw, 2.05rem);
+    line-height: 1.22;
+  }
+  :global(.article-body h2::before) {
+    content: counter(article-section, decimal-leading-zero);
+    counter-increment: article-section;
+    color: #d6452a;
+    font-family: var(--font-meta);
+    font-size: clamp(1.05rem, 1.6vw, 1.35rem);
+    font-weight: 700;
+    font-style: normal;
+    line-height: 1;
+  }
+  :global(.article-body h3) {
+    margin: 3rem 0 1.1rem;
+    border-bottom: 1px solid #8f897e;
+    padding-bottom: 0.55rem;
+    color: #d6452a;
+    font-family: var(--font-meta);
+    font-size: 1rem;
+    font-style: normal;
+    font-weight: 700;
+  }
+  :global(.article-body p) {
+    margin: 1.35rem 0;
+  }
+  :global(.article-body h2 + p),
+  :global(.article-body h3 + p) {
+    margin-top: 1rem;
+  }
+  :global(.article-body a:not(.heading-anchor)) {
+    color: #111;
+    text-decoration: underline;
+    text-decoration-color: #d6452a;
+    text-underline-offset: 0.18em;
+    transition: color 120ms ease;
+  }
+  :global(.article-body a:not(.heading-anchor):hover) {
+    color: #d6452a;
+  }
+  :global(.article-body .heading-anchor) {
+    display: none;
+  }
+  :global(.article-body ul),
+  :global(.article-body ol) {
+    margin: 1.6rem 0;
+    padding-left: 1.7rem;
+  }
+  :global(.article-body ul) {
+    list-style: none;
+  }
+  :global(.article-body ol) {
+    list-style: none;
+    counter-reset: note-list;
+  }
+  :global(.article-body ul > li) {
+    position: relative;
+  }
+  :global(.article-body ol > li) {
+    position: relative;
+  }
+  :global(.article-body ul > li::before) {
+    content: '';
+    position: absolute;
+    top: 0.78em;
+    left: -1.25rem;
+    width: 0.42rem;
+    height: 0.42rem;
+    border: 1px solid #222;
+    background: #222;
+  }
+  :global(.article-body ul ul > li::before) {
+    top: 0.9em;
+    width: 0.65rem;
+    height: 1px;
+    border: 0;
+    background: #8f897e;
+  }
+  :global(.article-body ol > li::before) {
+    content: counter(note-list, decimal-leading-zero);
+    counter-increment: note-list;
+    position: absolute;
+    top: 0.95em;
+    left: -1.75rem;
+    transform: translateY(-50%);
+    color: #d6452a;
+    font-family: var(--font-meta);
+    font-size: 0.78rem;
+    font-weight: 700;
+    line-height: 1;
+  }
+  :global(.article-body li) {
+    padding-left: 0.25rem;
+    line-height: 1.9;
+  }
+  :global(.article-body li + li) {
+    margin-top: 0.65rem;
+  }
+  :global(.article-body li > ul),
+  :global(.article-body li > ol) {
+    margin: 0.65rem 0 0.2rem;
+  }
+  :global(.article-body blockquote) {
+    margin: 2.4rem 0;
+    border-left: 2px solid #d6452a;
+    padding: 0.9rem 0 0.9rem 1.3rem;
+    color: #555;
+    line-height: 1.95;
+  }
+  :global(.article-body blockquote p) {
+    margin: 0.75rem 0;
+  }
+  :global(.article-body table) {
+    width: 100%;
+    margin: 2.4rem 0;
+    border-collapse: collapse;
+    font-size: 0.95rem;
+    line-height: 1.75;
+  }
+  :global(.article-body th),
+  :global(.article-body td) {
+    border-bottom: 1px solid #b9b2a4;
+    padding: 0.85rem 0.65rem;
+    text-align: left;
+  }
+  :global(.article-body th) {
+    color: #d6452a;
+    font-family: var(--font-meta);
+    font-size: 0.86rem;
+  }
+  :global(.article-body :not(pre) > code) {
+    border: 1px solid #222;
+    padding: 0.12rem 0.35rem;
+    background: transparent;
+    color: #111;
+    font-family: var(--font-meta);
+    font-size: 0.88em;
+  }
+  :global(.article-body pre) {
+    overflow-x: auto;
+    margin: 2.4rem 0;
+    padding: 1.25rem;
+    background: #161616;
+    color: #f1eee7;
+    font-family: var(--font-meta);
+    font-size: 0.9rem;
+    line-height: 1.7;
+  }
+  :global(.article-body figure) {
+    margin: 2.4rem 0;
+  }
+  :global(.article-body img) {
+    max-width: 100%;
+    height: auto;
+    border: 1px solid #222;
+  }
+  :global(.article-body figcaption) {
+    margin-top: 0.55rem;
+    color: #666;
+    font-family: var(--font-meta);
+    font-size: 0.78rem;
+    font-style: normal;
+    text-align: left;
+  }
+  :global(.article-body .directive-box) {
+    margin: 2.4rem 0;
+    border: 1px solid #d6452a;
+    padding: 1.1rem 1.25rem;
+    background: transparent;
+    line-height: 1.9;
+  }
+  :global(.article-body .amazon-card) {
+    border: 1px solid #222;
+    border-radius: 0;
+    box-shadow: none;
+    background: transparent;
+  }
+
+  @media (max-width: 900px) {
+    .article-hero,
+    .article-layout {
+      grid-template-columns: 1fr;
+    }
+    .article-heading {
+      padding-right: 0;
+    }
+    .article-meta {
+      border-top: 1px solid #222;
+      border-left: 0;
+      padding: 1.25rem 0;
+    }
+    .article-content {
+      padding-right: 0;
+    }
+    .article-sidebar {
+      border-top: 1px solid #222;
+      border-left: 0;
+      padding-left: 0;
+      padding-top: 2rem;
+    }
+    .article-toc {
+      position: static;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .article-page {
+      padding: 1rem;
+    }
+    h1 {
+      font-size: 2rem;
+    }
+    :global(.article-body h2) {
+      grid-template-columns: 2.35rem minmax(0, 1fr);
+      font-size: 1.55rem;
+    }
+  }
+</style>

--- a/apps/astro-blog/src/pages/post/[slug]/index.astro
+++ b/apps/astro-blog/src/pages/post/[slug]/index.astro
@@ -46,10 +46,19 @@ const updatedDate = post.meta.updatedAt ?
   dateFormatter.format(post.meta.updatedAt).replace(/\//g, '.')
 : undefined;
 const readingTime = post.meta.readingTime ? `${Math.ceil(post.meta.readingTime)} min` : 'FIELD NOTE';
+const articleSourcePath = post.originalPath ?? '';
+const editSourceUrl = articleSourcePath ?
+  `https://github.com/big-mon/estrivault-blog-app/edit/main/${articleSourcePath}`
+: undefined;
+const sourceHistoryUrl = articleSourcePath ?
+  `https://github.com/big-mon/estrivault-blog-app/commits/main/${articleSourcePath}`
+: undefined;
+const contributorsApiUrl = articleSourcePath ?
+  `https://api.github.com/repos/big-mon/estrivault-blog-app/commits?path=${encodeURIComponent(articleSourcePath)}&per_page=100`
+: undefined;
 const articleMeta = [
   { label: 'PUBLISHED', value: publishedDate },
   ...(updatedDate && updatedDate !== publishedDate ? [{ label: 'UPDATED', value: updatedDate }] : []),
-  { label: 'CATEGORY', value: categoryLabel },
   { label: 'READING', value: readingTime },
 ];
 const bodyClasses = [
@@ -167,16 +176,45 @@ const schemaData = {
 
         <nav class="article-return" aria-label="記事ナビゲーション">
           <a href="/">← ARTICLES INDEX</a>
-          {post.originalPath && (
-            <a
-              href={`https://github.com/big-mon/estrivault-blog-app/edit/main/${post.originalPath}`}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              EDIT SOURCE
-            </a>
-          )}
         </nav>
+
+        {
+          articleSourcePath && editSourceUrl && sourceHistoryUrl && contributorsApiUrl && (
+            <section
+              class="article-contributors"
+              data-contributors-api={contributorsApiUrl}
+              data-edit-url={editSourceUrl}
+              data-history-url={sourceHistoryUrl}
+            >
+              <div class="contributors-heading">
+                <h2>ARTICLE CONTRIBUTORS</h2>
+              </div>
+              <div class="contributors-body">
+                <div class="contributors-list" aria-live="polite">
+                  <span>Loading contributors</span>
+                </div>
+                <div class="contributors-actions">
+                  <a
+                    class="edit-source-link"
+                    href={editSourceUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24">
+                      <path
+                        d="M12 2C6.48 2 2 6.58 2 12.25c0 4.52 2.87 8.35 6.84 9.7.5.1.68-.22.68-.49v-1.9c-2.78.62-3.37-1.22-3.37-1.22-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.63.07-.63 1 .07 1.53 1.06 1.53 1.06.9 1.57 2.35 1.12 2.92.86.09-.67.35-1.12.63-1.38-2.22-.26-4.55-1.14-4.55-5.07 0-1.12.39-2.04 1.03-2.76-.1-.26-.45-1.31.1-2.72 0 0 .84-.28 2.75 1.05A9.3 9.3 0 0 1 12 6.91c.85 0 1.7.12 2.5.34 1.9-1.33 2.74-1.05 2.74-1.05.55 1.41.2 2.46.1 2.72.64.72 1.03 1.64 1.03 2.76 0 3.94-2.34 4.8-4.57 5.06.36.32.68.94.68 1.9v2.82c0 .27.18.59.69.49A10.08 10.08 0 0 0 22 12.25C22 6.58 17.52 2 12 2Z"
+                      />
+                    </svg>
+                    GitHubで編集を提案する
+                  </a>
+                  <a href={sourceHistoryUrl} target="_blank" rel="noopener noreferrer">
+                    VIEW HISTORY
+                  </a>
+                </div>
+              </div>
+            </section>
+          )
+        }
       </div>
 
       <aside class="article-sidebar">
@@ -250,6 +288,111 @@ const schemaData = {
     updateActiveTocLink();
     window.addEventListener('scroll', updateActiveTocLink, { passive: true });
     window.addEventListener('resize', updateActiveTocLink);
+  }
+
+  const contributorsSection = document.querySelector<HTMLElement>('.article-contributors');
+  const contributorsList = contributorsSection?.querySelector<HTMLElement>('.contributors-list');
+
+  if (contributorsSection && contributorsList) {
+    const apiUrl = contributorsSection.dataset.contributorsApi;
+
+    const renderFallback = () => {
+      contributorsList.innerHTML = '<span>Contributor data unavailable</span>';
+    };
+
+    const escapeHtml = (value: string) =>
+      value.replace(/[&<>"']/g, (char) => {
+        const entities: Record<string, string> = {
+          '&': '&amp;',
+          '<': '&lt;',
+          '>': '&gt;',
+          '"': '&quot;',
+          "'": '&#39;',
+        };
+
+        return entities[char] ?? char;
+      });
+
+    const renderContributors = async () => {
+      if (!apiUrl) {
+        renderFallback();
+        return;
+      }
+
+      try {
+        const response = await fetch(apiUrl, {
+          headers: { Accept: 'application/vnd.github+json' },
+        });
+
+        if (!response.ok) {
+          renderFallback();
+          return;
+        }
+
+        const commits = (await response.json()) as Array<{
+          author?: {
+            login?: string;
+            avatar_url?: string;
+            html_url?: string;
+          } | null;
+          commit?: {
+            author?: {
+              name?: string;
+            } | null;
+          } | null;
+        }>;
+        const contributors = new Map<
+          string,
+          { name: string; avatarUrl?: string; profileUrl?: string; count: number }
+        >();
+
+        for (const commit of commits) {
+          const key = commit.author?.login ?? commit.commit?.author?.name;
+          if (!key) {
+            continue;
+          }
+
+          const current = contributors.get(key) ?? {
+            name: key,
+            avatarUrl: commit.author?.avatar_url,
+            profileUrl: commit.author?.html_url,
+            count: 0,
+          };
+
+          current.count += 1;
+          contributors.set(key, current);
+        }
+
+        if (contributors.size === 0) {
+          renderFallback();
+          return;
+        }
+
+        contributorsList.innerHTML = [...contributors.values()]
+          .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
+          .slice(0, 6)
+          .map((contributor) => {
+            const label = `${contributor.name} (${contributor.count})`;
+            const safeLabel = escapeHtml(label);
+            const safeName = escapeHtml(contributor.name);
+            const safeAvatarUrl = contributor.avatarUrl ? escapeHtml(contributor.avatarUrl) : '';
+            const safeProfileUrl = contributor.profileUrl ? escapeHtml(contributor.profileUrl) : '';
+            const image =
+              contributor.avatarUrl ?
+                `<img src="${safeAvatarUrl}" alt="${safeName}" loading="lazy" />`
+              : '<span class="contributor-initial" aria-hidden="true"></span>';
+
+            return contributor.profileUrl ?
+                `<a href="${safeProfileUrl}" target="_blank" rel="noopener noreferrer" title="${safeLabel}" aria-label="${safeLabel}">${image}</a>`
+              : `<span title="${safeLabel}" aria-label="${safeLabel}">${image}</span>`;
+          })
+          .join('');
+      } catch {
+        renderFallback();
+      }
+    };
+
+    void renderContributors();
   }
 </script>
 
@@ -385,7 +528,6 @@ const schemaData = {
   }
   .article-thumbnail {
     margin: 1.5rem 0 0;
-    border-top: 1px solid #222;
     padding: 1.2rem 2rem 0;
   }
   .article-thumbnail img {
@@ -508,6 +650,108 @@ const schemaData = {
     border-color: #d6452a;
     color: #d6452a;
   }
+  .article-contributors {
+    margin-top: 5rem;
+    padding: 0 0 1.25rem;
+    font-family: var(--font-meta);
+    font-style: normal;
+  }
+  .contributors-heading {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1rem;
+    align-items: baseline;
+    justify-content: space-between;
+    border-bottom: 1px solid #222;
+    margin-bottom: 0.9rem;
+    padding-bottom: 0.75rem;
+  }
+  .contributors-heading h2 {
+    margin: 0;
+    color: #d6452a;
+    font-size: 0.9rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+  }
+  .contributors-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+    align-items: center;
+    color: #666;
+    font-size: 0.78rem;
+  }
+  .contributors-body {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    justify-content: space-between;
+  }
+  :global(.contributors-list a),
+  :global(.contributors-list > span) {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0;
+    color: #111;
+    text-decoration: none;
+    transition:
+      color 120ms ease,
+      opacity 120ms ease;
+  }
+  :global(.contributors-list a:hover) {
+    opacity: 0.72;
+  }
+  :global(.contributors-list img),
+  :global(.contributor-initial) {
+    width: 1.6rem;
+    height: 1.6rem;
+    border-radius: 50%;
+  }
+  :global(.contributors-list img) {
+    object-fit: cover;
+  }
+  .contributors-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+    align-items: stretch;
+    justify-content: flex-end;
+  }
+  .contributors-actions a {
+    border: 1px solid #222;
+    padding: 0.34rem 0.55rem 0.28rem;
+    color: #111;
+    font-size: 0.78rem;
+    font-weight: 700;
+    line-height: 1.1;
+    text-align: center;
+    text-decoration: none;
+    transition:
+      color 120ms ease,
+      border-color 120ms ease;
+  }
+  .contributors-actions .edit-source-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    color: #f1eee7;
+    background: #222;
+  }
+  .contributors-actions .edit-source-link svg {
+    width: 1rem;
+    height: 1rem;
+    fill: currentColor;
+  }
+  .contributors-actions .edit-source-link:hover {
+    border-color: #d6452a;
+    color: #f1eee7;
+    background: #d6452a;
+  }
+  .contributors-actions a:hover {
+    border-color: #d6452a;
+    color: #d6452a;
+  }
   :global(.article-body) {
     counter-reset: article-section;
     color: #222;
@@ -561,13 +805,14 @@ const schemaData = {
   }
   :global(.article-body a:not(.heading-anchor)) {
     color: #111;
-    text-decoration: underline;
-    text-decoration-color: #d6452a;
+    text-decoration: none;
+    text-decoration-color: currentColor;
     text-underline-offset: 0.18em;
     transition: color 120ms ease;
   }
   :global(.article-body a:not(.heading-anchor):hover) {
     color: #d6452a;
+    text-decoration: underline;
   }
   :global(.article-body .heading-anchor) {
     display: none;
@@ -701,10 +946,87 @@ const schemaData = {
     line-height: 1.9;
   }
   :global(.article-body .amazon-card) {
+    display: grid;
+    grid-template-columns: 120px minmax(0, 1fr);
+    gap: 1.2rem;
+    align-items: center;
+    margin: 2.8rem 0;
+    border-top: 1px solid #222;
+    border-right: 0;
+    border-bottom: 1px solid #222;
+    border-left: 0;
+    border-radius: 0;
+    box-shadow: none;
+    background:
+      repeating-linear-gradient(
+        135deg,
+        rgba(34, 34, 34, 0.12) 0,
+        rgba(34, 34, 34, 0.12) 1px,
+        transparent 1px,
+        transparent 9px
+      ),
+      transparent;
+    padding: 1rem 0;
+  }
+  :global(.article-body .amazon-card__image) {
+    display: block;
+    padding: 0;
+    background: transparent;
+  }
+  :global(.article-body .amazon-card__image img) {
+    display: block;
+    width: 100%;
+    max-height: 120px;
     border: 1px solid #222;
     border-radius: 0;
     box-shadow: none;
-    background: transparent;
+    object-fit: contain;
+    background: #f1eee7;
+    transition: opacity 120ms ease;
+  }
+  :global(.article-body .amazon-card__image img:hover) {
+    transform: none;
+    box-shadow: none;
+    opacity: 0.82;
+  }
+  :global(.article-body .amazon-card__content) {
+    gap: 0.8rem;
+  }
+  :global(.article-body .amazon-card__title) {
+    margin: 0;
+    color: #111;
+    font-family: var(--font-body);
+    font-size: 1rem;
+    font-weight: 700;
+    line-height: 1.7;
+    text-decoration: none;
+    transition: color 120ms ease;
+  }
+  :global(.article-body .amazon-card__title:hover) {
+    color: #d6452a;
+    text-decoration: none;
+  }
+  :global(.article-body .amazon-card__cta) {
+    width: fit-content;
+    border: 1px solid #b7791f;
+    border-radius: 0;
+    padding: 0.36rem 0.6rem 0.3rem;
+    background: #f3a847;
+    color: #111;
+    font-family: var(--font-meta);
+    font-size: 0.82rem;
+    font-weight: 700;
+    line-height: 1.1;
+    text-decoration: none;
+    transition:
+      background-color 120ms ease,
+      border-color 120ms ease;
+  }
+  :global(.article-body .amazon-card__cta:hover) {
+    transform: none;
+    border-color: #9c5f12;
+    background: #e99632;
+    color: #111;
   }
 
   @media (max-width: 900px) {
@@ -715,6 +1037,9 @@ const schemaData = {
     .article-heading {
       padding-right: 0;
     }
+    h1 {
+      max-width: none;
+    }
     .article-meta {
       border-top: 1px solid #222;
       border-left: 0;
@@ -722,15 +1047,32 @@ const schemaData = {
     }
     .article-content {
       padding-right: 0;
+      order: 2;
     }
     .article-sidebar {
       border-top: 1px solid #222;
       border-left: 0;
+      order: 1;
       padding-left: 0;
       padding-top: 2rem;
+      padding-bottom: 3rem;
     }
     .article-toc {
       position: static;
+    }
+    .contributors-body {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+    .contributors-actions {
+      justify-content: flex-start;
+    }
+    :global(.article-body .amazon-card) {
+      grid-template-columns: 96px minmax(0, 1fr);
+      gap: 1rem;
+    }
+    :global(.article-body .amazon-card__image img) {
+      max-height: 96px;
     }
   }
 
@@ -739,6 +1081,7 @@ const schemaData = {
       padding: 1rem;
     }
     h1 {
+      max-width: none;
       font-size: 2rem;
     }
     :global(.article-body h2) {

--- a/apps/astro-blog/src/pages/post/[slug]/index.astro
+++ b/apps/astro-blog/src/pages/post/[slug]/index.astro
@@ -223,9 +223,9 @@ const schemaData = {
             <nav class="article-toc" aria-label="Table of contents">
               <h2>TABLE OF CONTENTS</h2>
               <ol>
-                {tocHeadings.map((heading) => (
+                {tocHeadings.map((heading, index) => (
                   <li class={`toc-level-${heading.level}`}>
-                    <a href={`#${heading.id}`} data-toc-link={heading.id}>
+                    <a href={`#${heading.id}`} data-toc-index={String(index)}>
                       {heading.text}
                     </a>
                   </li>
@@ -242,17 +242,19 @@ const schemaData = {
 </BaseLayout>
 
 <script>
-  const tocLinks = [...document.querySelectorAll<HTMLAnchorElement>('[data-toc-link]')];
-  const articleHeadings = tocLinks
-    .map((link) => {
-      const headingId = link.dataset.tocLink;
-      return headingId ? document.getElementById(headingId) : null;
-    })
-    .filter((heading): heading is HTMLElement => heading !== null);
+  const tocLinks = [...document.querySelectorAll<HTMLAnchorElement>('[data-toc-index]')];
+  const tocLevels = new Set(
+    tocLinks
+      .map((link) => link.closest('li')?.className.match(/toc-level-(\d)/)?.[1])
+      .filter((level): level is string => Boolean(level)),
+  );
+  const articleHeadings = [
+    ...document.querySelectorAll<HTMLElement>('.article-body h2, .article-body h3, .article-body h4, .article-body h5, .article-body h6'),
+  ].filter((heading) => tocLevels.has(heading.tagName.replace('H', '')));
 
-  const setActiveTocLink = (headingId: string) => {
+  const setActiveTocLink = (activeIndex: number) => {
     for (const link of tocLinks) {
-      const isActive = link.dataset.tocLink === headingId;
+      const isActive = Number(link.dataset.tocIndex) === activeIndex;
       link.classList.toggle('is-active', isActive);
       if (isActive) {
         link.setAttribute('aria-current', 'location');
@@ -262,26 +264,23 @@ const schemaData = {
     }
   };
 
-  const getCurrentHeadingId = () => {
+  const getCurrentHeadingIndex = () => {
     const offset = window.innerHeight * 0.28;
-    let currentHeading = articleHeadings[0];
+    let currentIndex = 0;
 
-    for (const heading of articleHeadings) {
+    for (const [index, heading] of articleHeadings.entries()) {
       if (heading.getBoundingClientRect().top <= offset) {
-        currentHeading = heading;
+        currentIndex = index;
       } else {
         break;
       }
     }
 
-    return currentHeading?.id;
+    return currentIndex;
   };
 
   const updateActiveTocLink = () => {
-    const currentHeadingId = getCurrentHeadingId();
-    if (currentHeadingId) {
-      setActiveTocLink(currentHeadingId);
-    }
+    setActiveTocLink(getCurrentHeadingIndex());
   };
 
   if (tocLinks.length > 0 && articleHeadings.length > 0) {

--- a/apps/astro-blog/src/pages/tag/[tag]/[page]/index.astro
+++ b/apps/astro-blog/src/pages/tag/[tag]/[page]/index.astro
@@ -3,7 +3,7 @@ import type { PostMeta } from '@estrivault/content-processor';
 import BaseLayout from '$layouts/BaseLayout.astro';
 import ArchiveListing from '$components/ArchiveListing.astro';
 import { POSTS_PER_PAGE, SITE_TITLE, SITE_URL } from '$constants';
-import { getAllTags, getPosts } from '$lib/content';
+import { filterPosts, getAllPostsMeta, getPaginatedPosts } from '$lib/content';
 import { getTagRouteSegment } from '$lib/url-segments';
 
 interface Props {
@@ -37,11 +37,14 @@ function getTagCount(posts: PostMeta[], excludedTag: string): number {
 }
 
 export async function getStaticPaths() {
-  const tags = await getAllTags();
+  const allPosts = await getAllPostsMeta();
+  const tags = [...new Set(allPosts.flatMap((post) => post.tags))].sort((a, b) =>
+    a.localeCompare(b),
+  );
   const paths = [];
 
   for (const tag of tags) {
-    const tagPosts = await getPosts({ tag, perPage: POSTS_PER_PAGE });
+    const tagPosts = getPaginatedPosts(allPosts, { tag, perPage: POSTS_PER_PAGE });
 
     for (let page = 1; page <= tagPosts.totalPages; page++) {
       paths.push({
@@ -61,18 +64,14 @@ export async function getStaticPaths() {
 
 const { tag } = Astro.props as Props;
 const currentPage = Number(Astro.params.page);
-const result = await getPosts({
-  tag,
+const allPosts = await getAllPostsMeta();
+const archivePosts = filterPosts(allPosts, { tag });
+const result = getPaginatedPosts(archivePosts, {
   page: currentPage,
   perPage: POSTS_PER_PAGE,
 });
-const archivePosts = await getPosts({
-  tag,
-  page: 1,
-  perPage: Number.MAX_SAFE_INTEGER,
-});
-const topTags = getTopTags(archivePosts.posts, tag);
-const tagCount = getTagCount(archivePosts.posts, tag);
+const topTags = getTopTags(archivePosts, tag);
+const tagCount = getTagCount(archivePosts, tag);
 
 const siteBase = SITE_URL.replace(/\/$/, '');
 const pageUrl = `${siteBase}/tag/${Astro.params.tag}/${currentPage}`;

--- a/apps/astro-blog/src/pages/tag/[tag]/[page]/index.astro
+++ b/apps/astro-blog/src/pages/tag/[tag]/[page]/index.astro
@@ -1,13 +1,39 @@
 ---
+import type { PostMeta } from '@estrivault/content-processor';
 import BaseLayout from '$layouts/BaseLayout.astro';
-import Pagination from '$components/Pagination.astro';
-import PostCard from '$components/PostCard.astro';
+import ArchiveListing from '$components/ArchiveListing.astro';
 import { POSTS_PER_PAGE, SITE_TITLE, SITE_URL } from '$constants';
 import { getAllTags, getPosts } from '$lib/content';
 import { getTagRouteSegment } from '$lib/url-segments';
 
 interface Props {
   tag: string;
+}
+
+function getTopTags(posts: PostMeta[], excludedTag: string): string[] {
+  const tagCounts = new Map<string, { tag: string; count: number }>();
+
+  for (const post of posts) {
+    for (const tag of post.tags) {
+      if (tag === excludedTag) {
+        continue;
+      }
+
+      const current = tagCounts.get(tag) ?? { tag, count: 0 };
+      current.count += 1;
+      tagCounts.set(tag, current);
+    }
+  }
+
+  return [...tagCounts.values()]
+    .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
+    .slice(0, 5)
+    .map((item) => item.tag);
+}
+
+function getTagCount(posts: PostMeta[], excludedTag: string): number {
+  return new Set(posts.flatMap((post) => post.tags).filter((postTag) => postTag !== excludedTag))
+    .size;
 }
 
 export async function getStaticPaths() {
@@ -40,6 +66,13 @@ const result = await getPosts({
   page: currentPage,
   perPage: POSTS_PER_PAGE,
 });
+const archivePosts = await getPosts({
+  tag,
+  page: 1,
+  perPage: Number.MAX_SAFE_INTEGER,
+});
+const topTags = getTopTags(archivePosts.posts, tag);
+const tagCount = getTagCount(archivePosts.posts, tag);
 
 const siteBase = SITE_URL.replace(/\/$/, '');
 const pageUrl = `${siteBase}/tag/${Astro.params.tag}/${currentPage}`;
@@ -62,38 +95,28 @@ const nextUrl =
   canonical={pageUrl}
   prevUrl={prevUrl}
   nextUrl={nextUrl}
+  hideHeader
+  hideFooter
+  bodyClass="archive-editorial-page"
+  mainClass="archive-editorial-main"
 >
-  <div class="container mx-auto px-4 py-8">
-    <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold">#{tag.toUpperCase()}</h1>
-      <p class="text-gray-600">
-        全{result.total}件の記事（{result.page} / {result.totalPages}ページ）
-      </p>
-    </div>
-
-    {
-      result.posts.length > 0 ?
-        <div class="mb-8">
-          <div class="grid gap-8 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
-            {result.posts.map((post) => (
-              <PostCard post={post} />
-            ))}
-          </div>
-
-          {result.totalPages > 1 && (
-            <div class="mt-12">
-              <Pagination
-                currentPage={result.page}
-                totalPages={result.totalPages}
-                baseUrl={`/tag/${Astro.params.tag}`}
-                maxVisible={5}
-              />
-            </div>
-          )}
-        </div>
-      : <div class="rounded-lg bg-gray-50 p-8 text-center">
-          <p class="text-gray-500">このタグにはまだ記事がありません。</p>
-        </div>
-    }
-  </div>
+  <ArchiveListing
+    archiveType="TAG ARCHIVE"
+    title={`#${tag}`}
+    description={`${tag}タグが付けられた記事を、新しい順にまとめた一覧です。`}
+    posts={result.posts}
+    total={result.total}
+    page={result.page}
+    perPage={result.perPage}
+    totalPages={result.totalPages}
+    routeBase={`/tag/${Astro.params.tag}`}
+    topTags={topTags}
+    sideMeta={[
+      { label: 'TYPE', value: 'TAG' },
+      { label: 'TAG', value: tag },
+      { label: 'NOTES', value: result.total },
+      { label: 'TAGS', value: tagCount },
+    ]}
+    emptyMessage="このタグにはまだ記事がありません。"
+  />
 </BaseLayout>

--- a/apps/astro-blog/src/pages/tag/[tag]/[page]/index.astro
+++ b/apps/astro-blog/src/pages/tag/[tag]/[page]/index.astro
@@ -101,7 +101,7 @@ const nextUrl =
   mainClass="archive-editorial-main"
 >
   <ArchiveListing
-    archiveType="TAG ARCHIVE"
+    archiveType="TAG"
     title={`#${tag}`}
     description={`${tag}タグが付けられた記事を、新しい順にまとめた一覧です。`}
     posts={result.posts}

--- a/packages/content-processor/src/processor.ts
+++ b/packages/content-processor/src/processor.ts
@@ -159,6 +159,7 @@ export async function processMarkdown(
         data.coverImage as string | undefined,
         options.cloudinaryCloudName,
       ),
+      showArticleThumbnail: data.showArticleThumbnail !== false,
       draft: (data.draft as boolean) || false,
       readingTime: Math.ceil(stats.minutes),
     };
@@ -265,6 +266,7 @@ export async function extractMetadata(
         data.coverImage as string | undefined,
         options.cloudinaryCloudName,
       ),
+      showArticleThumbnail: data.showArticleThumbnail !== false,
       draft: (data.draft as boolean) || false,
       readingTime: Math.ceil(stats.minutes),
     };

--- a/packages/content-processor/src/types.ts
+++ b/packages/content-processor/src/types.ts
@@ -22,6 +22,7 @@ export interface PostMeta {
   category: string;
   tags: string[];
   coverImage?: string;
+  showArticleThumbnail?: boolean;
   draft?: boolean;
   readingTime?: number;
 }


### PR DESCRIPTION
## Summary
- Redesign the index page as an editorial-style homepage with masthead, hero, category index, latest notes, and series cards.
- Use existing navigation/category constants and keep the change scoped to the Astro index page.

## Validation
- corepack pnpm exec prettier --check apps/astro-blog/src/pages/index.astro
- git diff --check
- corepack pnpm --filter astro-blog check (fails on existing src/pages/post/[slug]/og.png.ts missing @estrivault/og-image-generator; index page errors are resolved)

## Notes
- Left the autogenerated .codex/environment file untracked and out of the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- ホームページレイアウトを記事一覧＋ページネーション形式から、編集者向けスタイルの複合セクション（マストヘッド・カテゴリインデックス・最新記事・シリーズ紹介）に変更した / サイトのコンテンツ構造をより視覚的・階層的に表現するため

- カテゴリ行を NAVIGATION_LINKS から動的に生成し、カテゴリラベル・説明文・キーを統一管理するようにした / カテゴリデータの管理を単一ソースに統一し、保守性を向上させるため

- 日付表示を日本語形式（yyyy.mm.dd）に統一するため fmtDate ヘルパーを追加した / ユーザー体験の国際化対応と表示の統一性を確保するため

- 固定の 4 つシリーズカード（EDGAR/XBRL、Stable Diffusion、Stock Analysis、Gear Reviews）を導入した / コンテンツの深掘り企画をホームページで強調し、読者の関心を引くため

- PostCard・Pagination コンポーネントを削除し、CSS グリッドレイアウトで新たなビジュアルデザインを実装した / 編集者向けの洗練されたインデックスデザインを実現するため

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/big-mon/estrivault-blog-app/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->