### PR TITLE
[codex] Cache generated OGP images

### DIFF
--- a/apps/astro-blog/src/pages/post/[slug]/og.png.ts
+++ b/apps/astro-blog/src/pages/post/[slug]/og.png.ts
@@ -1,7 +1,10 @@
 import type { APIRoute } from 'astro';
+import path from 'node:path';
 import { generatePostOgpPng } from '@estrivault/og-image-generator';
 import { getCategoryLabel, SITE_TITLE, SITE_URL } from '$constants';
-import { getAllPostsMeta, getPostBySlug } from '$lib/content';
+import { getAllPostsMeta } from '$lib/content';
+
+const ogpCacheDir = path.join(process.cwd(), 'node_modules', '.astro', 'og-image-cache');
 
 export async function getStaticPaths() {
   const allPosts = await getAllPostsMeta();
@@ -14,19 +17,22 @@ export const GET: APIRoute = async ({ params }) => {
     return new Response('Missing slug', { status: 400 });
   }
 
-  const post = await getPostBySlug(slug);
+  const post = (await getAllPostsMeta()).find((postMeta) => postMeta.slug === slug);
   if (!post) {
     return new Response('Not found', { status: 404 });
   }
 
-  const png = await generatePostOgpPng({
-    title: post.meta.title,
-    category: getCategoryLabel(post.meta.category || 'meta'),
-    publishedAt: post.meta.publishedAt,
-    slug: post.meta.slug,
-    siteTitle: SITE_TITLE,
-    siteUrl: SITE_URL,
-  });
+  const png = await generatePostOgpPng(
+    {
+      title: post.title,
+      category: getCategoryLabel(post.category || 'meta'),
+      publishedAt: post.publishedAt,
+      slug: post.slug,
+      siteTitle: SITE_TITLE,
+      siteUrl: SITE_URL,
+    },
+    { cacheDir: ogpCacheDir },
+  );
 
   const body = new Uint8Array(png).buffer;
 

--- a/packages/og-image-generator/src/font.ts
+++ b/packages/og-image-generator/src/font.ts
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
 import boldFontPath from '../assets/NotoSansJP-Bold.otf';
 import regularFontPath from '../assets/NotoSansJP-Regular.otf';
 
@@ -10,6 +11,7 @@ interface LoadedFont {
 }
 
 let fontPromise: Promise<LoadedFont[]> | undefined;
+let fontDigestPromise: Promise<string> | undefined;
 
 async function loadFontAsset(assetPath: string): Promise<ArrayBuffer> {
   const buffer = await readFile(new URL(assetPath, import.meta.url));
@@ -37,4 +39,18 @@ export function loadPostOgpFonts(): Promise<LoadedFont[]> {
   }
 
   return fontPromise;
+}
+
+export async function getPostOgpFontDigest(): Promise<string> {
+  fontDigestPromise ??= loadPostOgpFonts().then((fonts) => {
+    const hash = createHash('sha256');
+    for (const font of fonts) {
+      hash.update(font.name);
+      hash.update(String(font.weight));
+      hash.update(Buffer.from(font.data));
+    }
+    return hash.digest('hex');
+  });
+
+  return fontDigestPromise;
 }

--- a/packages/og-image-generator/src/index.ts
+++ b/packages/og-image-generator/src/index.ts
@@ -1,7 +1,10 @@
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import path from 'node:path';
 import { Resvg } from '@resvg/resvg-js';
 import { createElement as h } from 'react';
 import satori from 'satori';
-import { loadPostOgpFonts } from './font';
+import { getPostOgpFontDigest, loadPostOgpFonts } from './font';
 import { layoutPostOgpTitle } from './title-layout';
 
 export interface PostOgpCardData {
@@ -15,6 +18,53 @@ export interface PostOgpCardData {
 
 const IMAGE_WIDTH = 1200;
 const IMAGE_HEIGHT = 630;
+const CACHE_SCHEMA_VERSION = 'post-ogp-cache-v1';
+
+export interface PostOgpCacheOptions {
+  cacheDir?: string;
+}
+
+let templateDigestPromise: Promise<string> | undefined;
+
+function normalizePublishedAt(publishedAt: Date | string): string {
+  return publishedAt instanceof Date ? publishedAt.toISOString() : publishedAt;
+}
+
+async function readFileForDigest(relativePath: string): Promise<Buffer> {
+  return readFile(new URL(relativePath, import.meta.url));
+}
+
+async function getPostOgpTemplateDigest(): Promise<string> {
+  templateDigestPromise ??= Promise.all([
+    readFileForDigest('./index.js'),
+    readFileForDigest('./title-layout.js'),
+    readFileForDigest('./font.js'),
+    getPostOgpFontDigest(),
+  ]).then((parts) => {
+    const hash = createHash('sha256');
+    hash.update(CACHE_SCHEMA_VERSION);
+    for (const part of parts) {
+      hash.update(part);
+    }
+    return hash.digest('hex');
+  });
+
+  return templateDigestPromise;
+}
+
+export async function getPostOgpCacheKey(input: PostOgpCardData): Promise<string> {
+  const hash = createHash('sha256');
+  hash.update(
+    JSON.stringify({
+      schema: CACHE_SCHEMA_VERSION,
+      template: await getPostOgpTemplateDigest(),
+      title: input.title,
+      category: input.category || 'Other',
+      publishedAt: normalizePublishedAt(input.publishedAt),
+    }),
+  );
+  return hash.digest('hex');
+}
 
 function renderTitleLines(lines: string[], fontSize: number, lineHeight: number) {
   return lines.map((line, index) =>
@@ -36,7 +86,7 @@ function renderTitleLines(lines: string[], fontSize: number, lineHeight: number)
   );
 }
 
-export async function generatePostOgpPng(input: PostOgpCardData): Promise<Uint8Array> {
+async function renderPostOgpPng(input: PostOgpCardData): Promise<Uint8Array> {
   const titleLayout = layoutPostOgpTitle(input.title);
   const category = input.category || 'Other';
 
@@ -269,6 +319,35 @@ export async function generatePostOgpPng(input: PostOgpCardData): Promise<Uint8A
   }).render();
 
   return rendered.asPng();
+}
+
+export async function generatePostOgpPng(
+  input: PostOgpCardData,
+  options: PostOgpCacheOptions = {},
+): Promise<Uint8Array> {
+  if (!options.cacheDir) {
+    return renderPostOgpPng(input);
+  }
+
+  const cacheKey = await getPostOgpCacheKey(input);
+  const cachePath = path.join(options.cacheDir, `${cacheKey}.png`);
+
+  try {
+    return await readFile(cachePath);
+  } catch (error) {
+    if (!(error instanceof Error) || !('code' in error) || error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  const png = await renderPostOgpPng(input);
+  await mkdir(options.cacheDir, { recursive: true });
+
+  const temporaryPath = `${cachePath}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(temporaryPath, png);
+  await rename(temporaryPath, cachePath);
+
+  return png;
 }
 
 export { layoutPostOgpTitle };


### PR DESCRIPTION
## Summary

- Cache generated post OGP PNGs using a key derived from title, category, published date, template code, and font contents.
- Store the cache under Astro's `node_modules/.astro` cache area so Cloudflare Pages build caching can reuse it across builds when enabled.
- Avoid full post body processing for `og.png` generation by using post metadata directly.

## Impact

Unchanged article OGP images no longer need to be regenerated with satori/resvg on subsequent cached builds, reducing static build work as the article archive grows.

## Validation

- `tsc --build packages/og-image-generator`
- `astro build`
- repeated `astro build` confirmed cached `og.png` routes render in about 1-2ms
- `node --test test/*.test.mjs`
- `git diff --check`