### PR TITLE
[codex] Add table exclusion classes

### DIFF
--- a/packages/content-processor/src/pipeline.ts
+++ b/packages/content-processor/src/pipeline.ts
@@ -10,6 +10,7 @@ import { rehypeImageTransform } from './plugins/transforms/image-transform';
 import { rehypeLinkTransform } from './plugins/transforms/link-transform';
 import { rehypeHeadingAnchor } from './plugins/transforms/heading-anchor';
 import { rehypeHeadingExtractor } from './plugins/transforms/heading-extractor';
+import { rehypeTableClass } from './plugins/transforms/table-class';
 import { remarkYoutubeEmbed } from './plugins/embeds/youtube-embed';
 import { remarkTwitterEmbed } from './plugins/embeds/twitter-embed';
 import { remarkCommonLinkEmbed } from './plugins/embeds/common-link-embed';
@@ -70,6 +71,9 @@ function createBasePipeline(
 
       // リンク変換
       .use(rehypeLinkTransform)
+
+      // tableタグに広告・アノテーション除外用クラスを追加
+      .use(rehypeTableClass)
 
       // 見出しアンカー追加
       .use(rehypeHeadingAnchor)

--- a/packages/content-processor/src/plugins/transforms/table-class.ts
+++ b/packages/content-processor/src/plugins/transforms/table-class.ts
@@ -1,0 +1,35 @@
+import { visit } from 'unist-util-visit';
+import type { Plugin, Transformer } from 'unified';
+import type { Element, Root } from 'hast';
+
+const TABLE_CLASS_NAMES = ['adsense-exclude-area', 'google-anno-skip'];
+
+/**
+ * tableタグに広告・アノテーション除外用のクラスを付与するrehypeプラグイン
+ */
+export const rehypeTableClass: Plugin<[], Root, Root> = () => {
+  const transformer: Transformer<Root, Root> = (tree: Root) => {
+    visit(tree, 'element', (node: Element) => {
+      if (node.tagName !== 'table') {
+        return undefined;
+      }
+
+      const existingClassName = node.properties?.className;
+      const classNames =
+        Array.isArray(existingClassName) ? existingClassName.map(String)
+        : typeof existingClassName === 'string' ? existingClassName.split(/\s+/).filter(Boolean)
+        : [];
+
+      node.properties = {
+        ...node.properties,
+        className: [...new Set([...classNames, ...TABLE_CLASS_NAMES])],
+      };
+
+      return undefined;
+    });
+
+    return tree;
+  };
+
+  return transformer;
+};


### PR DESCRIPTION
## What changed

Adds a rehype transform that attaches `adsense-exclude-area google-anno-skip` to generated Markdown table elements.

## Why

Tables generated from Markdown should be excluded from AdSense and Google annotation handling.

## Validation

- `corepack pnpm --filter @estrivault/content-processor run build:types`
- `corepack pnpm --filter @estrivault/content-processor run build:bundle`
- `prettier --check packages/content-processor/src/pipeline.ts packages/content-processor/src/plugins/transforms/table-class.ts`
- Verified a Markdown table renders as `<table class="adsense-exclude-area google-anno-skip">...`.
- Confirmed `content/blog` has no diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Markdown→HTML変換パイプラインに`rehypeTableClass`プラグインを追加し、生成されたtable要素に`adsense-exclude-area`と`google-anno-skip`クラスを自動付与するようにした / AdSenseとGoogle Annotationからテーブルを除外するため

- 新規プラグイン内で既存のclass属性（文字列・配列・その他形式）と新規クラスを安全にマージし、重複なく統合するロジックを実装した / 既存スタイルとの競合を防ぎながら確実にクラスを適用するため

- パイプライン内では見出しアンカー処理など他の変換の前にテーブルクラス処理を実行するように配置した / すべてのMarkdownテーブルに確実に除外クラスが付与されるようにするため

<!-- end of auto-generated comment: release notes by coderabbit.ai -->