### PR TITLE
[codex] Clarify trusted Markdown pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,6 +230,8 @@ The `@estrivault/content-processor` uses a unified pipeline (`packages/content-p
 
 Article and note Markdown should use the same `processMarkdown()` pipeline. If rendered Markdown differs between posts and notes, first check the consuming component/CSS before changing the processor.
 
+Blog and note bodies are trusted, repository-authored Markdown. `rehypeRaw` is intentionally enabled so raw HTML and custom embeds survive processing; Astro renders the processed output with `set:html`. Do not remove `rehypeRaw` or add sanitization unless the content trust model changes.
+
 Shared Markdown body presentation belongs in `apps/astro-blog/src/app.css` and should target both `.article-body` and `.note-body`. Avoid keeping article-only body styles inside `apps/astro-blog/src/pages/post/[slug]/index.astro` when the same Markdown constructs can appear in notes.
 
 ### Astro Routing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,7 +205,7 @@ pnpm --filter @estrivault/cloudinary-utils dev  # Watch mode for development
 **Content Processing:**
 
 - unified, remark-parse, remark-directive, remark-gfm for Markdown parsing
-- rehype-raw, rehype-sanitize, rehype-stringify for HTML processing
+- rehype-raw, rehype-stringify for HTML processing
 - gray-matter for frontmatter parsing
 - reading-time for estimated reading time calculation
 
@@ -231,6 +231,8 @@ The `@estrivault/content-processor` uses a unified pipeline (`packages/content-p
 Article and note Markdown should use the same `processMarkdown()` pipeline. If rendered Markdown differs between posts and notes, first check the consuming component/CSS before changing the processor.
 
 Blog and note bodies are trusted, repository-authored Markdown. `rehypeRaw` is intentionally enabled so raw HTML and custom embeds survive processing; Astro renders the processed output with `set:html`. Do not remove `rehypeRaw` or add sanitization unless the content trust model changes.
+
+The package currently does not run `rehype-sanitize` and `ProcessorOptions` should not expose a sanitize schema option unless sanitization is added to the pipeline with tests. Keep this trust-boundary rationale in `AGENTS.md`; keep README package docs short and human-scannable.
 
 Shared Markdown body presentation belongs in `apps/astro-blog/src/app.css` and should target both `.article-body` and `.note-body`. Avoid keeping article-only body styles inside `apps/astro-blog/src/pages/post/[slug]/index.astro` when the same Markdown constructs can appear in notes.
 

--- a/packages/content-processor/README.md
+++ b/packages/content-processor/README.md
@@ -1,181 +1,47 @@
 # @estrivault/content-processor
 
-Markdownファイルを処理してHTMLに変換するコアパッケージです。unified/remark/rehype パイプラインを使用し、YouTube、Twitter、GitHub、Amazonのカスタム埋め込み機能を提供します。
+`estrivault-blog-app` の Markdown コンテンツを HTML に変換するワークスペース内パッケージです。
 
-## Trust Boundary
+ブログ記事とノートの本文処理を担い、frontmatter、カスタム埋め込み、画像・リンク変換、見出し抽出、読了時間の算出をまとめて扱います。このパッケージはリポジトリ管理下の Markdown を前提にしています。実装方針や trust boundary の詳細はルートの `AGENTS.md` を参照してください。
 
-This package is used for repository-authored Markdown under this blog's content directories. It does not process external user-generated Markdown.
+## 主な役割
 
-Raw HTML is intentionally enabled with `remarkRehype({ allowDangerousHtml: true })` and `rehypeRaw` so authored Markdown and custom embed plugins can produce the HTML needed by the Astro app. The Astro app renders that processed HTML with `set:html` because the content has already passed through this trusted Markdown pipeline.
+- Markdown + frontmatter を解析する
+- YouTube、Twitter、GitHub、Amazon の埋め込み記法を HTML に変換する
+- Cloudinary 連携で画像URLを最適化する
+- 見出し情報、読了時間、記事メタデータを抽出する
+- Astro アプリが描画できる HTML を生成する
 
-`ProcessorOptions.sanitizeSchema` was removed because the pipeline does not run `rehype-sanitize`. If this package ever needs to process untrusted Markdown, add `rehype-sanitize` explicitly to the pipeline and expose a tested schema option at the same time.
+## 主なAPI
 
-## 特徴
+- `processMarkdown(markdown, options)`:
+  Markdown本文をHTML、メタデータ、見出し情報に変換します。
 
-- **統合パイプライン**: unified/remark/rehype エコシステムを使用
-- **カスタム埋め込み**: YouTube、Twitter、GitHub、Amazonディレクティブのサポート
-- **画像最適化**: Cloudinary連携で自動画像変換
-- **フロントマター処理**: gray-matterでメタデータを抽出
-- **見出し抽出**: 見出し情報とアンカーリンクの自動生成
-- **読み取り時間算出**: reading-timeで推定読み取り時間を計算
-- **リンク変換**: 内部・外部リンクの自動変換
-- **型安全**: TypeScriptで書かれた型安全なAPI
+- `extractMetadata(markdown)`:
+  frontmatter と本文から記事メタデータだけを抽出します。
 
-## インストール
+- `parseFrontmatter(markdown)`:
+  frontmatter と本文を分離します。
 
-```bash
-pnpm add @estrivault/content-processor
-```
+- `createPipeline(options, enableSyntaxHighlight)`:
+  unified/remark/rehype の変換パイプラインを直接作成します。
 
-## 基本的な使い方
+- `normalizeForSlug(value)` / `normalizeForTagFilter(value)`:
+  ルーティングやタグ絞り込み用に文字列を正規化します。
 
-### Markdownの処理
-
-```typescript
-import { processMarkdown, extractMetadata } from '@estrivault/content-processor';
-
-// Markdownコンテンツの完全処理（HTML + メタデータ）
-const result = await processMarkdown(markdownContent, {
-  cloudinaryCloudName: 'your-cloud-name',
-});
-
-console.log(result.meta.title); // タイトル
-console.log(result.meta.readingTime); // 読み取り時間
-console.log(result.html); // 変換されたHTML
-console.log(result.headings); // 見出し情報
-
-// メタデータのみ抽出
-const meta = await extractMetadata(markdownContent);
-console.log(meta.tags); // タグ配列
-console.log(meta.category); // カテゴリ
-```
-
-### フロントマターの処理
-
-```typescript
-import { parseFrontmatter } from '@estrivault/content-processor';
-
-// フロントマターの解析
-const { data, content } = parseFrontmatter(markdownWithFrontmatter);
-console.log(data.title); // フロントマターのタイトル
-console.log(content); // Markdownコンテンツ
-```
-
-### パイプラインの直接使用
-
-```typescript
-import { createPipeline } from '@estrivault/content-processor';
-
-// カスタムオプションでパイプラインを作成
-const pipeline = createPipeline({
-  cloudinaryCloudName: 'your-cloud-name',
-  // その他のオプション
-});
-
-// Markdownを直接処理
-const result = await pipeline.process(markdownContent);
-console.log(String(result)); // 変換されたHTML
-```
-
-### ユーティリティ関数
-
-```typescript
-import { normalizeForSlug, normalizeForTagFilter } from '@estrivault/content-processor';
-
-// URLスラッグの正規化
-const slug = normalizeForSlug('日本語のタイトル');
-
-// タグフィルター用の正規化
-const normalizedTag = normalizeForTagFilter('タグ名');
-```
-
-## サポートしている埋め込み
-
-### YouTube
+## 対応している埋め込み
 
 ```markdown
 ::youtube[dQw4w9WgXcQ]
-```
-
-### Twitter
-
-```markdown
 ::twitter[https://twitter.com/user/status/123456789]
-```
-
-### GitHub
-
-```markdown
 ::github[https://github.com/user/repo]
-```
-
-### Amazon
-
-```markdown
 ::amazon[B08N5WRWNW]
-```
-
-## アーキテクチャ
-
-### パイプライン構成
-
-1. **remark-parse**: Markdownのパーシング
-2. **remark-directive**: カスタムディレクティブの処理
-3. **remark-gfm**: GitHub Flavored Markdownのサポート
-4. **カスタムプラグイン**: 埋め込み変換・変換処理
-5. **remark-rehype**: MarkdownからHTMLへの変換
-6. **rehype-raw**: HTMLのローデータ処理
-7. **rehype-stringify**: HTMLの文字列化
-
-### ファイル構成
-
-```
-src/
-├── index.ts              # メインエクスポート
-├── processor.ts          # コア処理機能
-├── pipeline.ts           # 統合パイプライン
-├── types.ts              # 型定義
-├── errors.ts             # エラークラス
-├── plugins/
-│   ├── embeds/           # 埋め込みプラグイン
-│   │   ├── youtube-embed.ts
-│   │   ├── twitter-embed.ts
-│   │   ├── github-embed.ts
-│   │   └── amazon-embed.ts
-│   └── transforms/       # 変換プラグイン
-│       ├── image-transform.ts
-│       ├── link-transform.ts
-│       ├── heading-anchor.ts
-│       └── heading-extractor.ts
-└── utils/
-    └── normalize.ts      # 文字列正規化
 ```
 
 ## 開発
 
-### ビルド
+リポジトリルートから実行します。
 
 ```bash
-pnpm build
+pnpm --filter @estrivault/content-processor build
 ```
-
-### 開発時の監視
-
-```bash
-pnpm dev
-```
-
-## 主な依存関係
-
-- **unified**: テキスト処理パイプライン
-- **remark-parse**: Markdownパーサー
-- **remark-directive**: カスタムディレクティブサポート
-- **remark-gfm**: GitHub Flavored Markdownサポート
-- **rehype-raw**: HTML処理
-- **gray-matter**: フロントマターパーサー
-- **reading-time**: 読み取り時間算出
-- **@estrivault/cloudinary-utils**: 画像最適化
-
-## ライセンス
-
-MIT

--- a/packages/content-processor/README.md
+++ b/packages/content-processor/README.md
@@ -2,6 +2,14 @@
 
 Markdownファイルを処理してHTMLに変換するコアパッケージです。unified/remark/rehype パイプラインを使用し、YouTube、Twitter、GitHub、Amazonのカスタム埋め込み機能を提供します。
 
+## Trust Boundary
+
+This package is used for repository-authored Markdown under this blog's content directories. It does not process external user-generated Markdown.
+
+Raw HTML is intentionally enabled with `remarkRehype({ allowDangerousHtml: true })` and `rehypeRaw` so authored Markdown and custom embed plugins can produce the HTML needed by the Astro app. The Astro app renders that processed HTML with `set:html` because the content has already passed through this trusted Markdown pipeline.
+
+`ProcessorOptions.sanitizeSchema` was removed because the pipeline does not run `rehype-sanitize`. If this package ever needs to process untrusted Markdown, add `rehype-sanitize` explicitly to the pipeline and expose a tested schema option at the same time.
+
 ## 特徴
 
 - **統合パイプライン**: unified/remark/rehype エコシステムを使用
@@ -117,8 +125,7 @@ const normalizedTag = normalizeForTagFilter('タグ名');
 4. **カスタムプラグイン**: 埋め込み変換・変換処理
 5. **remark-rehype**: MarkdownからHTMLへの変換
 6. **rehype-raw**: HTMLのローデータ処理
-7. **rehype-sanitize**: HTMLのサニタイゼーション
-8. **rehype-stringify**: HTMLの文字列化
+7. **rehype-stringify**: HTMLの文字列化
 
 ### ファイル構成
 
@@ -165,7 +172,6 @@ pnpm dev
 - **remark-directive**: カスタムディレクティブサポート
 - **remark-gfm**: GitHub Flavored Markdownサポート
 - **rehype-raw**: HTML処理
-- **rehype-sanitize**: HTMLサニタイゼーション
 - **gray-matter**: フロントマターパーサー
 - **reading-time**: 読み取り時間算出
 - **@estrivault/cloudinary-utils**: 画像最適化

--- a/packages/content-processor/package.json
+++ b/packages/content-processor/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "@estrivault/cloudinary-utils": "workspace:^",
     "gray-matter": "^4.0.3",
-    "hast-util-sanitize": "^5.0.2",
     "reading-time": "^1.5.0",
     "rehype-pretty-code": "^0.14.3",
     "rehype-raw": "^7.0.0",

--- a/packages/content-processor/src/pipeline.ts
+++ b/packages/content-processor/src/pipeline.ts
@@ -50,6 +50,8 @@ function createBasePipeline(
 
     // HTML 変換
     .use(remarkRehype, { allowDangerousHtml: true })
+    // Blog and note bodies are trusted, repository-authored Markdown.
+    // Raw HTML supports custom embeds; Astro renders the processed output with set:html.
     .use(rehypeRaw);
 
   // シンタックスハイライトを条件で追加（Cloudflare Workers対応）

--- a/packages/content-processor/src/pipeline.ts
+++ b/packages/content-processor/src/pipeline.ts
@@ -50,8 +50,6 @@ function createBasePipeline(
 
     // HTML 変換
     .use(remarkRehype, { allowDangerousHtml: true })
-    // Blog and note bodies are trusted, repository-authored Markdown.
-    // Raw HTML supports custom embeds; Astro renders the processed output with set:html.
     .use(rehypeRaw);
 
   // シンタックスハイライトを条件で追加（Cloudflare Workers対応）

--- a/packages/content-processor/src/types.ts
+++ b/packages/content-processor/src/types.ts
@@ -9,7 +9,6 @@ export interface ProcessorOptions {
   embeds?: EmbedOptions;
   cloudinaryCloudName?: string;
   imageBase?: string;
-  sanitizeSchema?: import('hast-util-sanitize').Schema;
 }
 
 /** 投稿のメタ情報 */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,9 +112,6 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
-      hast-util-sanitize:
-        specifier: ^5.0.2
-        version: 5.0.2
       reading-time:
         specifier: ^1.5.0
         version: 1.5.0
@@ -2563,9 +2560,6 @@ packages:
 
   hast-util-raw@9.1.0:
     resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
-
-  hast-util-sanitize@5.0.2:
-    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
 
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
@@ -7276,12 +7270,6 @@ snapshots:
       vfile: 6.0.3
       web-namespaces: 2.0.1
       zwitch: 2.0.4
-
-  hast-util-sanitize@5.0.2:
-    dependencies:
-      '@types/hast': 3.0.4
-      '@ungap/structured-clone': 1.3.1
-      unist-util-position: 5.0.0
 
   hast-util-to-html@9.0.5:
     dependencies:


### PR DESCRIPTION
## Summary

- Document the content-processor trust boundary for repository-authored Markdown
- Explain why raw HTML is enabled with `rehypeRaw` and rendered through Astro `set:html`
- Remove the unused `ProcessorOptions.sanitizeSchema` option and the unused `hast-util-sanitize` dependency
- Update the README pipeline/dependency notes so they match the implementation

## Validation

- `pnpm type-check`
- `pnpm install --lockfile-only --frozen-lockfile --ignore-scripts`

Closes #199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- `ProcessorOptions` から `sanitizeSchema` フィールドと `hast-util-sanitize` 依存関係を削除 / 未使用で曖昧な機能を排除し、実装の意図を明確にするため

- AGENTS.md にブログコンテンツは信頼済みコンテンツであり、`rehypeRaw` で生HTMLを意図的に保持する設計を明記 / 実装の信頼境界を明示するため

- AGENTS.md に「今後は信頼モデルが変わらない限り `rehypeRaw` を削除や sanitization 追加をしない」ポリシーを追記 / 将来の変更判断の指針を明確にするため

- content-processor README を長文から日本語の要点中心へ簡潔化（+22/-150行） / パッケージドキュメントの構成を実装と一致させるため

<!-- end of auto-generated comment: release notes by coderabbit.ai -->