### PR TITLE
[codex] Refactor content loading and post metadata normalization

### DIFF
--- a/apps/astro-blog/src/lib/content.ts
+++ b/apps/astro-blog/src/lib/content.ts
@@ -34,13 +34,21 @@ const defaultProcessorOptions: ProcessorOptions = {
   cloudinaryCloudName: import.meta.env.PUBLIC_CLOUDINARY_CLOUD_NAME ?? 'damonge',
 };
 
-interface PostMetaSource {
+interface ContentSource<TMeta extends { slug: string }> {
   filePath: string;
-  meta: PostMeta | null;
+  content: string;
+  meta: TMeta;
+  originalPath: string;
 }
 
-let allPostsMetaPromise: Promise<PostMeta[]> | undefined;
-let allNotesMetaPromise: Promise<NoteMeta[]> | undefined;
+interface ContentIndex<TMeta extends { slug: string }> {
+  sources: Array<ContentSource<TMeta>>;
+  meta: TMeta[];
+  bySlug: Map<string, ContentSource<TMeta>>;
+}
+
+let postIndexPromise: Promise<ContentIndex<PostMeta>> | undefined;
+let noteIndexPromise: Promise<ContentIndex<NoteMeta>> | undefined;
 
 function getMarkdownFiles(): Record<string, string> {
   const modules = import.meta.glob('@content/blog/**/*.{md,mdx}', {
@@ -116,18 +124,32 @@ function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function assertUniqueSlugs(posts: Array<{ filePath: string; meta: PostMeta }>): void {
+function toOriginalPath(filePath: string, contentRoot: string): string {
+  const normalizedPath = filePath.replace(/\\/g, '/');
+  const rootIndex = normalizedPath.lastIndexOf(contentRoot);
+
+  return rootIndex >= 0 ? normalizedPath.slice(rootIndex) : normalizedPath;
+}
+
+function assertUniqueSlugs<TMeta extends { slug: string }>(
+  sources: Array<{ filePath: string; meta: TMeta }>,
+  options: {
+    emptySubject: string;
+    duplicateSubject?: string;
+  },
+): void {
   const slugToPath = new Map<string, string>();
 
-  for (const { filePath, meta } of posts) {
+  for (const { filePath, meta } of sources) {
     if (!meta.slug) {
-      throw new Error(`Post slug is empty: ${filePath}`);
+      throw new Error(`${options.emptySubject} slug is empty: ${filePath}`);
     }
 
     const existingPath = slugToPath.get(meta.slug);
     if (existingPath) {
+      const duplicateSubject = options.duplicateSubject ? `${options.duplicateSubject} ` : '';
       throw new Error(
-        `Duplicate slug "${meta.slug}" detected between ${existingPath} and ${filePath}`,
+        `Duplicate ${duplicateSubject}slug "${meta.slug}" detected between ${existingPath} and ${filePath}`,
       );
     }
 
@@ -135,23 +157,44 @@ function assertUniqueSlugs(posts: Array<{ filePath: string; meta: PostMeta }>): 
   }
 }
 
-function assertUniqueNoteSlugs(notes: Array<{ filePath: string; meta: NoteMeta }>): void {
-  const slugToPath = new Map<string, string>();
+async function createContentIndex<TMeta extends { slug: string }>(options: {
+  markdownFiles: Record<string, string>;
+  contentRoot: string;
+  emptySlugSubject: string;
+  duplicateSlugSubject?: string;
+  extractMeta: (filePath: string, content: string) => TMeta | null | Promise<TMeta | null>;
+  sortMeta: (a: TMeta, b: TMeta) => number;
+}): Promise<ContentIndex<TMeta>> {
+  const sources = (
+    await Promise.all(
+      Object.entries(options.markdownFiles).map(async ([filePath, content]) => {
+        const meta = await options.extractMeta(filePath, content);
+        if (!meta) {
+          return null;
+        }
 
-  for (const { filePath, meta } of notes) {
-    if (!meta.slug) {
-      throw new Error(`Note slug is empty: ${filePath}`);
-    }
+        return {
+          filePath,
+          content,
+          meta,
+          originalPath: toOriginalPath(filePath, options.contentRoot),
+        } satisfies ContentSource<TMeta>;
+      }),
+    )
+  ).filter((source): source is ContentSource<TMeta> => source !== null);
 
-    const existingPath = slugToPath.get(meta.slug);
-    if (existingPath) {
-      throw new Error(
-        `Duplicate note slug "${meta.slug}" detected between ${existingPath} and ${filePath}`,
-      );
-    }
+  assertUniqueSlugs(sources, {
+    emptySubject: options.emptySlugSubject,
+    duplicateSubject: options.duplicateSlugSubject,
+  });
 
-    slugToPath.set(meta.slug, filePath);
-  }
+  sources.sort((a, b) => options.sortMeta(a.meta, b.meta));
+
+  return {
+    sources,
+    meta: sources.map((source) => source.meta),
+    bySlug: new Map(sources.map((source) => [source.meta.slug, source])),
+  };
 }
 
 function extractNoteMeta(filePath: string, content: string): NoteMeta | null {
@@ -216,134 +259,91 @@ async function extractFrontmatterOnly(
 export async function getAllPostsMeta(
   options: ProcessorOptions = defaultProcessorOptions,
 ): Promise<PostMeta[]> {
-  if (options === defaultProcessorOptions) {
-    allPostsMetaPromise ??= loadAllPostsMeta(options);
-    return allPostsMetaPromise;
-  }
-
-  return loadAllPostsMeta(options);
+  return (await getPostIndex(options)).meta;
 }
 
-async function loadAllPostsMeta(options: ProcessorOptions): Promise<PostMeta[]> {
-  const markdownFiles = getMarkdownFiles();
+async function getPostIndex(
+  options: ProcessorOptions = defaultProcessorOptions,
+): Promise<ContentIndex<PostMeta>> {
+  if (options === defaultProcessorOptions) {
+    postIndexPromise ??= loadPostIndex(options);
+    return postIndexPromise;
+  }
 
-  const postMetaSources = await Promise.all(
-    Object.entries(markdownFiles).map(
-      async ([filePath, content]): Promise<PostMetaSource> => ({
-        filePath,
-        meta: await extractFrontmatterOnly(filePath, content, options),
-      }),
-    ),
-  );
+  return loadPostIndex(options);
+}
 
-  const validPostSources = postMetaSources.filter(
-    (source): source is { filePath: string; meta: PostMeta } => source.meta !== null,
-  );
-
-  assertUniqueSlugs(validPostSources);
-
-  return validPostSources
-    .map((source) => source.meta)
-    .sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());
+async function loadPostIndex(options: ProcessorOptions): Promise<ContentIndex<PostMeta>> {
+  return createContentIndex({
+    markdownFiles: getMarkdownFiles(),
+    contentRoot: 'content/blog/',
+    emptySlugSubject: 'Post',
+    extractMeta: (filePath, content) => extractFrontmatterOnly(filePath, content, options),
+    sortMeta: (a, b) => b.publishedAt.getTime() - a.publishedAt.getTime(),
+  });
 }
 
 export async function getAllNotesMeta(): Promise<NoteMeta[]> {
-  allNotesMetaPromise ??= loadAllNotesMeta();
-  return allNotesMetaPromise;
+  return (await getNoteIndex()).meta;
 }
 
-async function loadAllNotesMeta(): Promise<NoteMeta[]> {
-  const markdownFiles = getNoteMarkdownFiles();
+async function getNoteIndex(): Promise<ContentIndex<NoteMeta>> {
+  noteIndexPromise ??= loadNoteIndex();
+  return noteIndexPromise;
+}
 
-  const noteMetaSources = Object.entries(markdownFiles).map(([filePath, content]) => ({
-    filePath,
-    meta: extractNoteMeta(filePath, content),
-  }));
-
-  const validNoteSources = noteMetaSources.filter(
-    (source): source is { filePath: string; meta: NoteMeta } => source.meta !== null,
-  );
-
-  assertUniqueNoteSlugs(validNoteSources);
-
-  return validNoteSources
-    .map((source) => source.meta)
-    .sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());
+async function loadNoteIndex(): Promise<ContentIndex<NoteMeta>> {
+  return createContentIndex({
+    markdownFiles: getNoteMarkdownFiles(),
+    contentRoot: 'content/notes/',
+    emptySlugSubject: 'Note',
+    duplicateSlugSubject: 'note',
+    extractMeta: extractNoteMeta,
+    sortMeta: (a, b) => b.publishedAt.getTime() - a.publishedAt.getTime(),
+  });
 }
 
 export async function getNoteBySlug(
   slug: string,
   options: ProcessorOptions = defaultProcessorOptions,
 ): Promise<NoteHTML | null> {
-  const markdownFiles = getNoteMarkdownFiles();
+  const noteIndex = await getNoteIndex();
+  const source = noteIndex.bySlug.get(slug);
 
-  for (const [filePath, content] of Object.entries(markdownFiles)) {
-    const meta = extractNoteMeta(filePath, content);
-
-    if (!meta || meta.slug !== slug) {
-      continue;
-    }
-
-    try {
-      const processed = await processMarkdown(content, options, slug);
-      return {
-        meta,
-        html: processed.html,
-        originalPath: filePath.replace(/^.*\/content\/notes\//, 'content/notes/'),
-      };
-    } catch (error) {
-      throw new Error(
-        `Failed to process note markdown file ${filePath}: ${getErrorMessage(error)}`,
-        {
-          cause: error,
-        },
-      );
-    }
+  if (!source) {
+    return null;
   }
 
-  return null;
+  return processNoteSource(source, options);
 }
 
 export async function getAllNotes(
   options: ProcessorOptions = defaultProcessorOptions,
 ): Promise<NoteHTML[]> {
-  const noteMeta = await getAllNotesMeta();
-  const markdownFiles = getNoteMarkdownFiles();
-  const slugToSource = new Map<string, { filePath: string; content: string }>();
+  const noteIndex = await getNoteIndex();
 
-  for (const [filePath, content] of Object.entries(markdownFiles)) {
-    const meta = extractNoteMeta(filePath, content);
-    if (meta) {
-      slugToSource.set(meta.slug, { filePath, content });
-    }
+  return Promise.all(noteIndex.sources.map((source) => processNoteSource(source, options)));
+}
+
+async function processNoteSource(
+  source: ContentSource<NoteMeta>,
+  options: ProcessorOptions,
+): Promise<NoteHTML> {
+  try {
+    const processed = await processMarkdown(source.content, options, source.meta.slug);
+    return {
+      meta: source.meta,
+      html: processed.html,
+      originalPath: source.originalPath,
+    };
+  } catch (error) {
+    throw new Error(
+      `Failed to process note markdown file ${source.filePath}: ${getErrorMessage(error)}`,
+      {
+        cause: error,
+      },
+    );
   }
-
-  const notes: Array<NoteHTML | null> = await Promise.all(
-    noteMeta.map(async (note) => {
-      const source = slugToSource.get(note.slug);
-      if (!source) {
-        return null;
-      }
-
-      try {
-        const processed = await processMarkdown(source.content, options, note.slug);
-        return {
-          meta: note,
-          html: processed.html,
-          originalPath: source.filePath.replace(/^.*\/content\/notes\//, 'content/notes/'),
-        } satisfies NoteHTML;
-      } catch (error) {
-        throw new Error(
-          `Failed to process note markdown file ${source.filePath}: ${getErrorMessage(error)}`,
-          {
-            cause: error,
-          },
-        );
-      }
-    }),
-  );
-
-  return notes.filter((note): note is NoteHTML => note !== null);
 }
 
 export function getRelatedNotes(current: NoteMeta, notes: NoteMeta[], limit = 3): NoteMeta[] {
@@ -436,36 +436,25 @@ export async function getPostBySlug(
   slug: string,
   options: ProcessorOptions = defaultProcessorOptions,
 ): Promise<PostHTML | null> {
-  const markdownFiles = getMarkdownFiles();
+  const postIndex = await getPostIndex(options);
+  const source = postIndex.bySlug.get(slug);
 
-  for (const [filePath, content] of Object.entries(markdownFiles)) {
-    const generatedSlug = generateSlugFromPath(filePath);
-    let meta: PostMeta;
-
-    try {
-      meta = await extractMetadata(content, options, generatedSlug);
-    } catch (error) {
-      throw new Error(`Invalid markdown file ${filePath}: ${getErrorMessage(error)}`, {
-        cause: error,
-      });
-    }
-
-    if (meta.slug !== slug || meta.draft) {
-      continue;
-    }
-
-    try {
-      const post = await processMarkdown(content, options, slug);
-      post.originalPath = filePath.replace(/^.*\/content\/blog\//, 'content/blog/');
-      return post;
-    } catch (error) {
-      throw new Error(`Failed to process markdown file ${filePath}: ${getErrorMessage(error)}`, {
-        cause: error,
-      });
-    }
+  if (!source) {
+    return null;
   }
 
-  return null;
+  try {
+    const post = await processMarkdown(source.content, options, source.meta.slug);
+    post.originalPath = source.originalPath;
+    return post;
+  } catch (error) {
+    throw new Error(
+      `Failed to process markdown file ${source.filePath}: ${getErrorMessage(error)}`,
+      {
+        cause: error,
+      },
+    );
+  }
 }
 
 export async function getAllCategories(): Promise<string[]> {

--- a/packages/content-processor/src/processor.ts
+++ b/packages/content-processor/src/processor.ts
@@ -52,6 +52,85 @@ function resolveCoverImage(coverImage?: string, cloudinaryCloudName: string = ''
   return buildUrl(cloudinaryCloudName, publicId, { w: 1200, quality: 85 });
 }
 
+function normalizeDateField(
+  value: unknown,
+  invalidFallback: unknown,
+  invalidMessage: string,
+): unknown {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  let dateValue = value;
+  if (dateValue.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/)) {
+    dateValue = dateValue + '.000Z';
+  } else if (dateValue.match(/^\d{4}-\d{2}-\d{2}$/)) {
+    dateValue = dateValue + 'T00:00:00.000Z';
+  }
+
+  if (isNaN(Date.parse(dateValue))) {
+    console.warn(invalidMessage);
+    return invalidFallback;
+  }
+
+  return dateValue;
+}
+
+function normalizePostMeta(
+  data: Record<string, unknown>,
+  markdown: string,
+  options: ProcessorOptions = {},
+  slug?: string,
+): PostMeta {
+  if (!data.title) {
+    throw new FrontMatterError('Front-matterにtitleが含まれていません');
+  }
+
+  const stats = readingTime(markdown, { wordsPerMinute: 600 });
+  const tags =
+    Array.isArray(data.tags) ?
+      data.tags
+        .filter((tag): tag is string => typeof tag === 'string')
+        .map((tag) => tag.trim())
+        .filter((tag) => tag.length > 0)
+    : [];
+
+  const publishedAtValue =
+    data.publishedAt ?
+      normalizeDateField(
+        data.publishedAt,
+        new Date().toISOString(),
+        `Invalid publishedAt format: ${data.publishedAt}, using current date`,
+      )
+    : new Date().toISOString();
+  const publishedAt = new Date(publishedAtValue as string);
+
+  const updatedAtSource = data.updatedAt || publishedAtValue;
+  const updatedAtValue = normalizeDateField(
+    updatedAtSource,
+    publishedAtValue,
+    `Invalid updatedAt format: ${data.updatedAt}, using publishedAt`,
+  );
+  const updatedAt = new Date(updatedAtValue as string);
+
+  return {
+    slug: (data.slug as string) || slug || '',
+    title: data.title as string,
+    description: (data.description as string) || '',
+    publishedAt,
+    updatedAt,
+    category: (data.category as string) || '',
+    tags,
+    coverImage: resolveCoverImage(
+      data.coverImage as string | undefined,
+      options.cloudinaryCloudName,
+    ),
+    showArticleThumbnail: data.showArticleThumbnail !== false,
+    draft: (data.draft as boolean) || false,
+    readingTime: Math.ceil(stats.minutes),
+  };
+}
+
 /**
  * Markdownコンテンツ（フロントマター付き）を解析し、HTML・メタデータ・見出し情報・各種埋め込み検出結果を返します。
  *
@@ -70,14 +149,7 @@ export async function processMarkdown(
   try {
     // フロントマターの解析
     const { data, content: markdown } = parseFrontmatter(content);
-
-    // 必須フィールドの検証
-    if (!data.title) {
-      throw new FrontMatterError('Front-matterにtitleが含まれていません');
-    }
-
-    // 読了時間の計算
-    const stats = readingTime(markdown, { wordsPerMinute: 600 });
+    const meta = normalizePostMeta(data, markdown, options, slug);
 
     // マークダウンをパースしてコードブロックを自動検出
     const parseProcessor = unified().use(remarkParse).use(remarkDirective).use(remarkGfm);
@@ -98,71 +170,6 @@ export async function processMarkdown(
     // 見出し情報を取得（heading-extractorプラグインで抽出されたもの）
     const headings: HeadingInfo[] =
       ((result.data as Record<string, unknown>)?.headings as HeadingInfo[]) || [];
-
-    // タグを検証して正規化
-    const tags =
-      Array.isArray(data.tags) ?
-        data.tags
-          .filter((tag): tag is string => typeof tag === 'string')
-          .map((tag) => tag.trim())
-          .filter((tag) => tag.length > 0)
-      : [];
-
-    // 日付の正規化とDate型への変換
-    let publishedAtStr = data.publishedAt as string | undefined;
-    if (publishedAtStr) {
-      if (typeof publishedAtStr === 'string') {
-        // "2022-03-24T17:42:00" のような形式を "2022-03-24T17:42:00.000Z" に修正
-        if (publishedAtStr.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/)) {
-          publishedAtStr = publishedAtStr + '.000Z';
-        }
-        // "2022-03-24" のような形式を "2022-03-24T00:00:00.000Z" に修正
-        else if (publishedAtStr.match(/^\d{4}-\d{2}-\d{2}$/)) {
-          publishedAtStr = publishedAtStr + 'T00:00:00.000Z';
-        }
-        // 無効な日付の場合は現在日時を使用
-        if (isNaN(Date.parse(publishedAtStr))) {
-          console.warn(`Invalid publishedAt format: ${data.publishedAt}, using current date`);
-          publishedAtStr = new Date().toISOString();
-        }
-      }
-    } else {
-      publishedAtStr = new Date().toISOString();
-    }
-    const publishedAt = new Date(publishedAtStr as string);
-
-    let updatedAtStr = (data.updatedAt as string | undefined) || publishedAtStr;
-    if (updatedAtStr && typeof updatedAtStr === 'string') {
-      // 同様にupdatedAtも正規化
-      if (updatedAtStr.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/)) {
-        updatedAtStr = updatedAtStr + '.000Z';
-      } else if (updatedAtStr.match(/^\d{4}-\d{2}-\d{2}$/)) {
-        updatedAtStr = updatedAtStr + 'T00:00:00.000Z';
-      }
-      if (isNaN(Date.parse(updatedAtStr))) {
-        console.warn(`Invalid updatedAt format: ${data.updatedAt}, using publishedAt`);
-        updatedAtStr = publishedAtStr;
-      }
-    }
-    const updatedAt = new Date(updatedAtStr as string);
-
-    // メタデータの構築
-    const meta: PostMeta = {
-      slug: (data.slug as string) || slug || '',
-      title: data.title as string,
-      description: (data.description as string) || '',
-      publishedAt,
-      updatedAt,
-      category: (data.category as string) || '',
-      tags,
-      coverImage: resolveCoverImage(
-        data.coverImage as string | undefined,
-        options.cloudinaryCloudName,
-      ),
-      showArticleThumbnail: data.showArticleThumbnail !== false,
-      draft: (data.draft as boolean) || false,
-      readingTime: Math.ceil(stats.minutes),
-    };
 
     return {
       meta,
@@ -198,80 +205,7 @@ export async function extractMetadata(
     // フロントマターの解析
     const { data, content: markdown } = parseFrontmatter(content);
 
-    // 必須フィールドの検証
-    if (!data.title) {
-      throw new FrontMatterError('Front-matterにtitleが含まれていません');
-    }
-
-    // 読了時間の計算
-    const stats = readingTime(markdown, { wordsPerMinute: 600 });
-
-    // タグを検証して正規化
-    const tags =
-      Array.isArray(data.tags) ?
-        data.tags
-          .filter((tag): tag is string => typeof tag === 'string')
-          .map((tag) => tag.trim())
-          .filter((tag) => tag.length > 0)
-      : [];
-
-    // 日付の正規化とDate型への変換
-    let publishedAtStr = data.publishedAt as string | undefined;
-    if (publishedAtStr) {
-      if (typeof publishedAtStr === 'string') {
-        // "2022-03-24T17:42:00" のような形式を "2022-03-24T17:42:00.000Z" に修正
-        if (publishedAtStr.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/)) {
-          publishedAtStr = publishedAtStr + '.000Z';
-        }
-        // "2022-03-24" のような形式を "2022-03-24T00:00:00.000Z" に修正
-        else if (publishedAtStr.match(/^\d{4}-\d{2}-\d{2}$/)) {
-          publishedAtStr = publishedAtStr + 'T00:00:00.000Z';
-        }
-        // 無効な日付の場合は現在日時を使用
-        if (isNaN(Date.parse(publishedAtStr))) {
-          console.warn(`Invalid publishedAt format: ${data.publishedAt}, using current date`);
-          publishedAtStr = new Date().toISOString();
-        }
-      }
-    } else {
-      publishedAtStr = new Date().toISOString();
-    }
-    const publishedAt = new Date(publishedAtStr as string);
-
-    let updatedAtStr = (data.updatedAt as string | undefined) || publishedAtStr;
-    if (updatedAtStr && typeof updatedAtStr === 'string') {
-      // 同様にupdatedAtも正規化
-      if (updatedAtStr.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/)) {
-        updatedAtStr = updatedAtStr + '.000Z';
-      } else if (updatedAtStr.match(/^\d{4}-\d{2}-\d{2}$/)) {
-        updatedAtStr = updatedAtStr + 'T00:00:00.000Z';
-      }
-      if (isNaN(Date.parse(updatedAtStr))) {
-        console.warn(`Invalid updatedAt format: ${data.updatedAt}, using publishedAt`);
-        updatedAtStr = publishedAtStr;
-      }
-    }
-    const updatedAt = new Date(updatedAtStr as string);
-
-    // メタデータの構築
-    const meta: PostMeta = {
-      slug: (data.slug as string) || slug || '',
-      title: data.title as string,
-      description: (data.description as string) || '',
-      publishedAt,
-      updatedAt,
-      category: (data.category as string) || '',
-      tags,
-      coverImage: resolveCoverImage(
-        data.coverImage as string | undefined,
-        options.cloudinaryCloudName,
-      ),
-      showArticleThumbnail: data.showArticleThumbnail !== false,
-      draft: (data.draft as boolean) || false,
-      readingTime: Math.ceil(stats.minutes),
-    };
-
-    return meta;
+    return normalizePostMeta(data, markdown, options, slug);
   } catch (error) {
     if (error instanceof FrontMatterError || error instanceof MarkdownParseError) {
       throw error;


### PR DESCRIPTION
## Summary

- Add a shared content index/source layer for posts and notes in `apps/astro-blog/src/lib/content.ts`.
- Reuse the indexed `slug -> source` map for `getPostBySlug()` and `getNoteBySlug()` instead of scanning all Markdown files again.
- Reuse note index sources when rendering all notes, keeping pagination/filter helpers separate from source loading.
- Centralize post metadata normalization in `packages/content-processor/src/processor.ts` so `processMarkdown()` and `extractMetadata()` share the same date, tag, cover image, draft, and reading-time handling.

## Impact

This keeps existing URLs and rendering behavior intact while reducing repeated source work and keeping post metadata interpretation consistent between list metadata and detail rendering.

Closes #201
Closes #202

## Validation

- `pnpm type-check`
- `pnpm --filter astro-blog build`
- `pnpm --filter @estrivault/content-processor build`
- `git diff --find-renames -- content/blog`