### PR TITLE
[codex] Share redirect URL normalization

### DIFF
--- a/apps/astro-blog/scripts/generate-redirects.mjs
+++ b/apps/astro-blog/scripts/generate-redirects.mjs
@@ -1,12 +1,13 @@
 import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractMetadata } from '@estrivault/content-processor';
+import { getSlugFromMarkdownPath } from '../src/lib/url-segments.mjs';
 
 const POSTS_PER_PAGE = 12;
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const appRoot = path.resolve(__dirname, '..');
 const contentRoot = path.resolve(appRoot, '../../content/blog');
-const notesContentRoot = path.resolve(appRoot, '../../content/notes');
 const outputPath = path.resolve(appRoot, 'public/_redirects');
 
 async function getMarkdownFiles(directory) {
@@ -26,157 +27,25 @@ async function getMarkdownFiles(directory) {
   return files.flat();
 }
 
-function generateSlugFromPath(filePath) {
-  return path.basename(filePath).replace(/\.(md|mdx)$/, '');
-}
-
-function normalizeFullWidthAscii(value) {
-  return value.replace(/[\uFF10-\uFF19\uFF21-\uFF3A\uFF41-\uFF5A]/g, (char) =>
-    String.fromCharCode(char.charCodeAt(0) - 0xfee0),
-  );
-}
-
-function normalizeForTagFilter(value) {
-  return normalizeFullWidthAscii(value).trim().toLowerCase().replace(/\s+/g, ' ');
-}
-
-function normalizeForSlug(value) {
-  return normalizeFullWidthAscii(value)
-    .trim()
-    .toLowerCase()
-    .replace(/[\s_]+/g, '-')
-    .replace(/[^a-z0-9-]/g, '')
-    .replace(/-+/g, '-')
-    .replace(/^-+|-+$/g, '');
-}
-
-function getTagRouteSegment(tag) {
-  const cleaned = tag.trim();
-  if (!cleaned) {
-    throw new Error('Tag route segment cannot be generated from an empty tag.');
-  }
-
-  const normalizedSlug = normalizeForSlug(cleaned);
-  if (normalizedSlug) {
-    return normalizedSlug;
-  }
-
-  const normalizedTagSegment = normalizeForTagFilter(cleaned)
-    .replace(/[\s/\\?#]+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-+|-+$/g, '');
-
-  if (!normalizedTagSegment) {
-    throw new Error(`Tag route segment cannot be generated from tag: ${tag}`);
-  }
-
-  return normalizedTagSegment;
-}
-
-function readScalar(frontmatter, field) {
-  const match = frontmatter.match(new RegExp(`^${field}:\\s*(.+)$`, 'm'));
-  if (!match) {
-    return undefined;
-  }
-
-  return match[1].trim().replace(/^['"]|['"]$/g, '');
-}
-
-function readTags(frontmatter) {
-  const rawTags = readScalar(frontmatter, 'tags');
-  if (!rawTags) {
-    return [];
-  }
-
-  if (!rawTags.startsWith('[') || !rawTags.endsWith(']')) {
-    return rawTags
-      .split(',')
-      .map((tag) => tag.trim().replace(/^['"]|['"]$/g, ''))
-      .filter(Boolean);
-  }
-
-  const tags = [];
-  const pattern = /'([^']*)'|"([^"]*)"|([^,[\]\s][^,\]]*)/g;
-  let match;
-
-  while ((match = pattern.exec(rawTags.slice(1, -1)))) {
-    tags.push((match[1] ?? match[2] ?? match[3]).trim());
-  }
-
-  return tags.filter(Boolean);
-}
-
-function extractRedirectMeta(content, filePath) {
-  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  if (!match) {
-    throw new Error(`Frontmatter block is missing: ${filePath}`);
-  }
-
-  const frontmatter = match[1];
-  const draft = readScalar(frontmatter, 'draft') === 'true';
-
-  return {
-    slug: readScalar(frontmatter, 'slug') ?? generateSlugFromPath(filePath),
-    category: readScalar(frontmatter, 'category') ?? '',
-    tags: readTags(frontmatter),
-    draft,
-  };
-}
-
-function increment(map, key) {
-  map.set(key, (map.get(key) ?? 0) + 1);
-}
-
 function getTotalPages(count) {
   return Math.ceil(count / POSTS_PER_PAGE);
 }
 
-function getArchiveRedirects(basePath, totalPages) {
-  const lines = [
-    `${basePath}/1 ${basePath}/ 301`,
-    `${basePath}/1/ ${basePath}/ 301`,
-    `${basePath} ${basePath}/ 301`,
-  ];
+async function isPublishedPost(content, filePath) {
+  const slug = getSlugFromMarkdownPath(filePath);
+  const meta = await extractMetadata(content, undefined, slug);
 
-  for (let page = 2; page <= totalPages; page++) {
-    lines.push(`${basePath}/${page} ${basePath}/${page}/ 301`);
-  }
-
-  return lines;
+  return meta.draft !== true;
 }
 
 const files = await getMarkdownFiles(contentRoot);
-const noteFiles = await getMarkdownFiles(notesContentRoot);
-const posts = [];
-const notes = [];
-const categoryCounts = new Map();
-const tagCounts = new Map();
+let postCount = 0;
 
 for (const filePath of files) {
   const content = await readFile(filePath, 'utf8');
-  const meta = extractRedirectMeta(content, filePath);
-
-  if (meta.draft) {
-    continue;
+  if (await isPublishedPost(content, filePath)) {
+    postCount += 1;
   }
-
-  posts.push(meta);
-  increment(categoryCounts, meta.category.toLowerCase());
-
-  for (const tag of meta.tags) {
-    increment(tagCounts, getTagRouteSegment(tag));
-  }
-}
-
-for (const filePath of noteFiles) {
-  const content = await readFile(filePath, 'utf8');
-  const meta = extractRedirectMeta(content, filePath);
-
-  if (meta.draft) {
-    continue;
-  }
-
-  notes.push(meta);
 }
 
 const lines = [
@@ -187,40 +56,32 @@ const lines = [
   '/1/ / 301',
 ];
 
-for (let page = 2; page <= getTotalPages(posts.length); page++) {
+for (let page = 2; page <= getTotalPages(postCount); page++) {
   lines.push(`/${page} /${page}/ 301`);
 }
 
 lines.push('', '# Archive pages are collection resources and keep a trailing slash.');
-lines.push('/notes /notes/ 301');
-
-for (const [category, count] of [...categoryCounts.entries()].sort(([a], [b]) =>
-  a.localeCompare(b),
-)) {
-  lines.push(...getArchiveRedirects(`/category/${category}`, getTotalPages(count)));
-}
-
-for (const [tag, count] of [...tagCounts.entries()].sort(([a], [b]) => a.localeCompare(b))) {
-  lines.push(...getArchiveRedirects(`/tag/${tag}`, getTotalPages(count)));
-}
+lines.push(
+  '/notes /notes/ 301',
+  '/category/:category/1 /category/:category/ 301',
+  '/category/:category/1/ /category/:category/ 301',
+  '/category/:category /category/:category/ 301',
+  '/category/:category/:page /category/:category/:page/ 301',
+  '/tag/:tag/1 /tag/:tag/ 301',
+  '/tag/:tag/1/ /tag/:tag/ 301',
+  '/tag/:tag /tag/:tag/ 301',
+  '/tag/:tag/:page /tag/:tag/:page/ 301',
+);
 
 lines.push('', '# Article pages are document resources and omit a trailing slash.');
 lines.push(
-  '# Cloudflare serves generated post index.html files at trailing-slash URLs by default.',
-  '# Proxy canonical post URLs to those files so the browser URL stays slashless.',
+  '# Cloudflare serves generated document index.html files at trailing-slash URLs by default.',
+  '# Proxy canonical document URLs to those files so the browser URL stays slashless.',
+  '/post/:slug /post/:slug/ 200',
+  '/post/:slug/ /post/:slug 301',
+  '/notes/:slug /notes/:slug/ 200',
+  '/notes/:slug/ /notes/:slug 301',
 );
-
-for (const post of posts.sort((a, b) => a.slug.localeCompare(b.slug))) {
-  const encodedSlug = encodeURIComponent(post.slug);
-  lines.push(`/post/${encodedSlug} /post/${encodedSlug}/ 200`);
-  lines.push(`/post/${encodedSlug}/ /post/${encodedSlug} 301`);
-}
-
-for (const note of notes.sort((a, b) => a.slug.localeCompare(b.slug))) {
-  const encodedSlug = encodeURIComponent(note.slug);
-  lines.push(`/notes/${encodedSlug} /notes/${encodedSlug}/ 200`);
-  lines.push(`/notes/${encodedSlug}/ /notes/${encodedSlug} 301`);
-}
 
 await mkdir(path.dirname(outputPath), { recursive: true });
 await writeFile(outputPath, `${lines.join('\n')}\n`, 'utf8');

--- a/apps/astro-blog/scripts/generate-redirects.mjs
+++ b/apps/astro-blog/scripts/generate-redirects.mjs
@@ -35,7 +35,7 @@ async function isPublishedPost(content, filePath) {
   const slug = getSlugFromMarkdownPath(filePath);
   const meta = await extractMetadata(content, undefined, slug);
 
-  return meta.draft !== true;
+  return !meta.draft;
 }
 
 const files = await getMarkdownFiles(contentRoot);

--- a/apps/astro-blog/src/lib/content.ts
+++ b/apps/astro-blog/src/lib/content.ts
@@ -7,6 +7,7 @@ import {
   type PostMeta,
   type ProcessorOptions,
 } from '@estrivault/content-processor';
+import { getSlugFromMarkdownPath } from './url-segments';
 
 export interface PaginatedPosts {
   posts: PostMeta[];
@@ -68,16 +69,6 @@ function getNoteMarkdownFiles(): Record<string, string> {
   });
 
   return modules as Record<string, string>;
-}
-
-function generateSlugFromPath(filePath: string): string {
-  const pathParts = filePath.split('/');
-  const filename = pathParts[pathParts.length - 1];
-  if (!filename) {
-    return '';
-  }
-
-  return filename.replace(/\.(md|mdx)$/, '');
 }
 
 function stripMarkdown(value: string): string {
@@ -213,7 +204,7 @@ function extractNoteMeta(filePath: string, content: string): NoteMeta | null {
   const publishedAt = normalizeDate(data.publishedAt, filePath);
 
   const meta: NoteMeta = {
-    slug: (data.slug as string) || generateSlugFromPath(filePath),
+    slug: (data.slug as string) || getSlugFromMarkdownPath(filePath),
     title: data.title as string,
     excerpt: createExcerpt(markdown, 150),
     publishedAt,
@@ -241,7 +232,7 @@ async function extractFrontmatterOnly(
       }
     }
 
-    const slug = generateSlugFromPath(filePath);
+    const slug = getSlugFromMarkdownPath(filePath);
     const meta = await extractMetadata(content, options, slug);
 
     if (meta.draft) {

--- a/apps/astro-blog/src/lib/url-segments.mjs
+++ b/apps/astro-blog/src/lib/url-segments.mjs
@@ -1,0 +1,91 @@
+import { normalizeForSlug, normalizeForTagFilter } from '@estrivault/content-processor';
+
+/**
+ * @param {string} tag
+ * @returns {string}
+ */
+export function getTagRouteSegment(tag) {
+  const cleaned = tag.trim();
+  if (!cleaned) {
+    throw new Error('Tag route segment cannot be generated from an empty tag.');
+  }
+
+  const normalizedSlug = normalizeForSlug(cleaned);
+  if (normalizedSlug) {
+    return normalizedSlug;
+  }
+
+  const normalizedTagSegment = normalizeForTagFilter(cleaned)
+    .replace(/[\s/\\?#]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  if (!normalizedTagSegment) {
+    throw new Error(`Tag route segment cannot be generated from tag: ${tag}`);
+  }
+
+  return normalizedTagSegment;
+}
+
+/**
+ * @param {string} category
+ * @returns {string}
+ */
+export function getCategoryRouteSegment(category) {
+  const routeSegment = category.toLowerCase();
+  if (!routeSegment.trim()) {
+    throw new Error('Category route segment cannot be generated from an empty category.');
+  }
+
+  return routeSegment;
+}
+
+/**
+ * @param {string} segment
+ * @returns {string}
+ */
+export function encodeRouteSegment(segment) {
+  return encodeURIComponent(segment);
+}
+
+/**
+ * @param {string} filePath
+ * @returns {string}
+ */
+export function getSlugFromMarkdownPath(filePath) {
+  const filename = filePath.split(/[\\/]/).pop();
+  if (!filename) {
+    return '';
+  }
+
+  return filename.replace(/\.(md|mdx)$/, '');
+}
+
+/**
+ * @param {string} routeBase
+ * @param {number} page
+ * @returns {string}
+ */
+export function getArchivePagePath(routeBase, page) {
+  if (!Number.isInteger(page) || page < 1) {
+    throw new Error(`Archive page must be a positive integer: ${page}`);
+  }
+
+  const normalizedBase = routeBase === '/' ? '' : routeBase.replace(/\/+$/g, '');
+
+  if (page === 1) {
+    return `${normalizedBase}/`;
+  }
+
+  return `${normalizedBase}/${page}/`;
+}
+
+/**
+ * @param {string} siteBase
+ * @param {string} routeBase
+ * @param {number} page
+ * @returns {string}
+ */
+export function getArchivePageUrl(siteBase, routeBase, page) {
+  return `${siteBase.replace(/\/$/, '')}${getArchivePagePath(routeBase, page)}`;
+}

--- a/apps/astro-blog/src/lib/url-segments.ts
+++ b/apps/astro-blog/src/lib/url-segments.ts
@@ -1,46 +1,8 @@
-import { normalizeForSlug, normalizeForTagFilter } from '@estrivault/content-processor';
-
-export function getTagRouteSegment(tag: string): string {
-  const cleaned = tag.trim();
-  if (!cleaned) {
-    throw new Error('Tag route segment cannot be generated from an empty tag.');
-  }
-
-  const normalizedSlug = normalizeForSlug(cleaned);
-  if (normalizedSlug) {
-    return normalizedSlug;
-  }
-
-  const normalizedTagSegment = normalizeForTagFilter(cleaned)
-    .replace(/[\s/\\?#]+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-+|-+$/g, '');
-
-  if (!normalizedTagSegment) {
-    throw new Error(`Tag route segment cannot be generated from tag: ${tag}`);
-  }
-
-  return normalizedTagSegment;
-}
-
-export function encodeRouteSegment(segment: string): string {
-  return encodeURIComponent(segment);
-}
-
-export function getArchivePagePath(routeBase: string, page: number): string {
-  if (!Number.isInteger(page) || page < 1) {
-    throw new Error(`Archive page must be a positive integer: ${page}`);
-  }
-
-  const normalizedBase = routeBase === '/' ? '' : routeBase.replace(/\/+$/g, '');
-
-  if (page === 1) {
-    return `${normalizedBase}/`;
-  }
-
-  return `${normalizedBase}/${page}/`;
-}
-
-export function getArchivePageUrl(siteBase: string, routeBase: string, page: number): string {
-  return `${siteBase.replace(/\/$/, '')}${getArchivePagePath(routeBase, page)}`;
-}
+export {
+  encodeRouteSegment,
+  getArchivePagePath,
+  getArchivePageUrl,
+  getCategoryRouteSegment,
+  getSlugFromMarkdownPath,
+  getTagRouteSegment,
+} from './url-segments.mjs';

--- a/apps/astro-blog/src/pages/category/[category]/[...page].astro
+++ b/apps/astro-blog/src/pages/category/[category]/[...page].astro
@@ -4,7 +4,7 @@ import BaseLayout from '$layouts/BaseLayout.astro';
 import ArchiveListing from '$components/ArchiveListing.astro';
 import { getCategoryMeta, POSTS_PER_PAGE, SITE_TITLE, SITE_URL } from '$constants';
 import { filterPosts, getAllPostsMeta, getPaginatedPosts } from '$lib/content';
-import { getArchivePageUrl } from '$lib/url-segments';
+import { getArchivePageUrl, getCategoryRouteSegment } from '$lib/url-segments';
 
 interface Props {
   category: string;
@@ -44,7 +44,7 @@ export async function getStaticPaths() {
     for (let page = 1; page <= categoryPosts.totalPages; page++) {
       paths.push({
         params: {
-          category: category.toLowerCase(),
+          category: getCategoryRouteSegment(category),
           page: page === 1 ? undefined : String(page),
         },
         props: {

--- a/apps/astro-blog/src/pages/sitemap.xml.ts
+++ b/apps/astro-blog/src/pages/sitemap.xml.ts
@@ -8,13 +8,14 @@ import {
   getAllTags,
   getPosts,
 } from '$lib/content';
-import { encodeRouteSegment, getArchivePageUrl, getTagRouteSegment } from '$lib/url-segments';
+import {
+  encodeRouteSegment,
+  getArchivePageUrl,
+  getCategoryRouteSegment,
+  getTagRouteSegment,
+} from '$lib/url-segments';
 
 export const prerender = true;
-
-function encodeSegment(segment: string): string {
-  return encodeURIComponent(segment.toLowerCase());
-}
 
 function xmlEscape(value: string): string {
   return value
@@ -45,7 +46,7 @@ export const GET: APIRoute = async () => {
 
   for (const category of categories) {
     const categoryPosts = await getPosts({ category, perPage: POSTS_PER_PAGE });
-    const encodedCategory = encodeSegment(category);
+    const encodedCategory = encodeRouteSegment(getCategoryRouteSegment(category));
 
     for (let page = 1; page <= categoryPosts.totalPages; page++) {
       categoryUrls.push(`<url>


### PR DESCRIPTION
## Summary

Closes #203.

- Move URL segment helpers into a shared JS module so Astro code and the redirect generator use the same tag/category/slug normalization.
- Replace the hand-written redirect frontmatter parsing with `@estrivault/content-processor` metadata extraction, which uses `gray-matter` internally.
- Collapse generated `_redirects` rules from per-post/per-tag/per-category enumeration into placeholder-based canonical rules.

## Redirect behavior

The generated `_redirects` file now has 34 lines instead of 720. This is an intentional behavior change: category and tag archive trailing-slash redirects are preserved with placeholder rules, while post/note document proxy and trailing-slash redirects are generalized by slug.

This means generic rules may match non-existent slugs too; those should still resolve to 404 when the backing asset is absent.

## Validation

- `pnpm --filter astro-blog run generate:redirects`
- `pnpm type-check`
- `git diff --check`
- `git diff --find-renames -- content/blog`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **URL正規化ロジックの共有化**: アプリケーションのスラッグ生成・タグ/カテゴリ正規化処理を、`url-segments.mjs` の共通ヘルパーに統一し、リダイレクト生成スクリプトで同じロジックを再利用できるようにした（コード重複の排除と保守性向上）

- **リダイレクト定義の簡略化**: `_redirects` ファイルを個別スラッグ列挙型から、プレースホルダベースの宣言型ルール（`:category`、`:tag`、`:slug` など）に変更し、720行から34行に削減した（保守性向上・可読性改善）

- **Frontmatter解析の置き換え**: カスタムフロントマター解析をメタデータ抽出用の標準ヘルパーに統一し、記事・メモのスラッグ生成を共通の `getSlugFromMarkdownPath` で一元化した（実装の統一・冗長性排除）

- **アーカイブページング**: リダイレクト生成時に公開済み記事数に基づいてアーカイブのページ数を動的に計算し、固定的な個別ルールではなく計算ベースのプレースホルダルールで対応するようにした（スケーラビリティ向上・自動化）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->