### PR TITLE
[codex] Improve article link visibility

### DIFF
--- a/apps/astro-blog/src/app.css
+++ b/apps/astro-blog/src/app.css
@@ -94,17 +94,27 @@ html {
 
 .article-body a:not(.heading-anchor),
 .note-body a:not(.heading-anchor) {
-  color: #111;
-  text-decoration: none;
+  color: #a83822;
+  text-decoration: underline;
   text-decoration-color: currentcolor;
+  text-decoration-thickness: 0.075em;
   text-underline-offset: 0.18em;
-  transition: color 120ms ease;
+  transition:
+    color 120ms ease,
+    text-decoration-thickness 120ms ease;
 }
 
 .article-body a:not(.heading-anchor):hover,
 .note-body a:not(.heading-anchor):hover {
   color: #d6452a;
-  text-decoration: underline;
+  text-decoration-thickness: 0.12em;
+}
+
+.article-body a:not(.heading-anchor):focus-visible,
+.note-body a:not(.heading-anchor):focus-visible {
+  border-radius: 0.15em;
+  outline: 2px solid #d6452a;
+  outline-offset: 0.18em;
 }
 
 .article-body .heading-anchor,

--- a/content/notes/2026-06-19_itsme.md
+++ b/content/notes/2026-06-19_itsme.md
@@ -9,3 +9,7 @@ tags: ['VTuber', 'Music']
 にじさんじの倉持めるとというVTuberが投稿していた[ショート動画](https://www.youtube.com/shorts/EHm6Hm2y6wc)にて、ピンと伸ばした足で地面をぺしぺし叩いている姿がなんだか頭に残って、それがきっかけで聴き始めた。
 
 後は[海外ニキが全力で踊っているショート動画](https://www.youtube.com/shorts/2U1HzFFchJk)、この2本の動画が立て続けに流れてきたからハマった。
+
+::youtube{id="EHm6Hm2y6wc"}
+
+::youtube{id="2U1HzFFchJk"}


### PR DESCRIPTION
## Summary

- Make Markdown body links visibly identifiable before hover by using the site's accent color and underline treatment.
- Strengthen hover feedback with a thicker underline.
- Add a keyboard focus outline for article and note body links.

## Why

Inline links in individual article bodies were styled like normal text until hover, making them hard to discover while reading. The root cause was `text-decoration: none` on shared Markdown body links.

## Validation

- `prettier --check apps/astro-blog/src/app.css`
- `pnpm --filter astro-blog lint`

Note: the normal `pnpm` shim failed with `mise ERROR cannot find binary path`, so validation used the existing mise-managed `pnpm.exe` directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- 記事・ノート内のインラインリンクに基本色と下線スタイルを適用した / クリック可能な要素であることを視覚的に示すため
- ホバー時に下線の厚みを増加させ、より強い視覚的フィードバックを提供した / リンク操作時のユーザー体験を向上させるため
- キーボードフォーカス時にアウトラインを表示した / キーボード操作ユーザーの操作性を確保するため
- 記事本文にYouTube動画埋め込みを2件追加した / コンテンツのエンゲージメント向上のため

<!-- end of auto-generated comment: release notes by coderabbit.ai -->